### PR TITLE
Added clickable MIT License link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Our expedition is just beginning. Key milestones for the Guild include:
 
 ## ⚖️ License
 
-This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the `LICENSE` file.
+This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the [License](License) file.
 
 ---
 


### PR DESCRIPTION
🔄 Pull Request: Add Clickable License Link to README
📄 Description:
This PR updates the README.md by adding a direct clickable link to the LICENSE file in the license section.

🛠️ Changes Made:

Added hyperlink to the MIT License reference in the README.

📌 Motivation:
To improve accessibility and navigation by allowing users to directly view the license file from the README.

✅ Checklist:

 README updated

 No environment variables affected

 No breaking changes introduced

🔗 Related Issue:
Fixes #24

<img width="1408" height="472" alt="Screenshot 2025-08-02 072520" src="https://github.com/user-attachments/assets/6b4b4b06-6657-4ee8-98b5-b54be06df0ce" />
