### PR TITLE
Fix: Updated license link to point to LICENSE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Our expedition is just beginning. Key milestones for the Guild include:
 
 ## ⚖️ License
 
-This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the [License](License) file.
+This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the [License](./LICENSE.md) file.
 
 ---
 


### PR DESCRIPTION
🔖 Pull Request for Issue #53 
👤 Username: @vinitjain2005

🛠️ Changes Made:
✅ Updated the license link in the README.md file to correctly point to ./LICENSE.md.

🔗 Ensures proper redirection to the license file when users click the link.

🎯 Purpose:
This PR fixes the incorrect markdown link to the license file, improving navigation and making licensing information easily accessible.

Screenshot
<img width="1398" height="164" alt="Screenshot 2025-08-06 202637" src="https://github.com/user-attachments/assets/3b74f0a8-689c-4141-b556-d3a20b641265" />
