### PR TITLE
Added proper license link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Our expedition is just beginning. Key milestones for the Guild include:
 
 ## ⚖️ License
 
-This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the [License](License) file.
+This project is currently under discussion for its open-source license. We intend to use a widely recognized open-source license (e.g., **MIT License**). Please check back for updates in the [License](License.md) file.
 
 ---
 


### PR DESCRIPTION
🔖 Pull Request for Issue https://github.com/LarytheLord/Adventurers-Guild/issues/53
👤 Username: @vinitjain2005

🛠️ Changes Made:
✅ Updated the license link in the README.md file to correctly point to ./LICENSE.md.

🔗 Ensures proper redirection to the license file when users click the link.

🎯 Purpose:
This PR fixes the incorrect markdown link to the license file, improving navigation and making licensing information easily accessible.

Screenshot
<img width="1396" height="149" alt="Screenshot 2025-08-07 181932" src="https://github.com/user-attachments/assets/04632761-90fb-4a6b-8fe1-4021282b8966" />
