### PR TITLE
Fix quest detail crash + ship role-specific dashboards and rankings

### DIFF
--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -51,6 +51,11 @@ export async function GET(request: NextRequest) {
             email: true,
           },
         },
+        _count: {
+          select: {
+            assignments: true,
+          },
+        },
       },
       skip: parseInt(offset),
       take: parseInt(limit),

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -1,46 +1,204 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { UserRank } from '@prisma/client';
 import { prisma } from '@/lib/db';
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get('userId');
+type RankingsMode = 'adventurer' | 'company';
+type SortOrder = 'asc' | 'desc';
+type AdventurerSort = 'xp' | 'level' | 'skillPoints';
+type CompanySort = 'totalSpent' | 'questsPosted' | 'completedQuests' | 'activeQuests';
 
-  if (!userId) {
-    return NextResponse.json({ success: false, error: 'User ID required' }, { status: 400 });
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+function parseLimit(rawLimit: string | null): number {
+  if (!rawLimit) return DEFAULT_LIMIT;
+  const parsed = Number.parseInt(rawLimit, 10);
+  if (Number.isNaN(parsed)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(parsed, 1), MAX_LIMIT);
+}
+
+function parseOrder(rawOrder: string | null): SortOrder {
+  return rawOrder === 'asc' ? 'asc' : 'desc';
+}
+
+function parseMode(rawMode: string | null): RankingsMode {
+  return rawMode === 'company' ? 'company' : 'adventurer';
+}
+
+function parseAdventurerSort(rawSort: string | null): AdventurerSort {
+  if (rawSort === 'level' || rawSort === 'skillPoints') return rawSort;
+  return 'xp';
+}
+
+function parseCompanySort(rawSort: string | null): CompanySort {
+  if (
+    rawSort === 'questsPosted' ||
+    rawSort === 'completedQuests' ||
+    rawSort === 'activeQuests'
+  ) {
+    return rawSort;
   }
+  return 'totalSpent';
+}
 
+function normalizeRank(rawRank: string | null): UserRank | null {
+  if (!rawRank) return null;
+  const rank = rawRank.toUpperCase();
+  return ['F', 'E', 'D', 'C', 'B', 'A', 'S'].includes(rank) ? (rank as UserRank) : null;
+}
+
+export async function GET(request: NextRequest) {
   try {
-    // Get total count of adventurers
-    const totalUsers = await prisma.user.count({
-      where: { role: 'adventurer' }
-    });
+    const { searchParams } = new URL(request.url);
+    const mode = parseMode(searchParams.get('mode'));
+    const order = parseOrder(searchParams.get('order'));
+    const limit = parseLimit(searchParams.get('limit'));
 
-    // Get user's XP
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { xp: true }
-    });
+    if (mode === 'company') {
+      const sort = parseCompanySort(searchParams.get('sort'));
+      const companies = await prisma.user.findMany({
+        where: { role: 'company' },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          createdAt: true,
+          isVerified: true,
+          companyProfile: {
+            select: {
+              companyName: true,
+              industry: true,
+              size: true,
+              isVerified: true,
+              questsPosted: true,
+              totalSpent: true,
+            },
+          },
+          quests: {
+            select: { status: true },
+          },
+        },
+      });
 
-    if (!user) {
-      return NextResponse.json({ success: false, error: 'User not found' }, { status: 404 });
+      const ranked = companies
+        .map((company) => {
+          const totalSpent = Number(company.companyProfile?.totalSpent ?? 0);
+          const questsPosted = company.companyProfile?.questsPosted ?? company.quests.length;
+          const completedQuests = company.quests.filter((quest) => quest.status === 'completed').length;
+          const activeQuests = company.quests.filter((quest) =>
+            ['available', 'in_progress', 'review'].includes(quest.status)
+          ).length;
+
+          return {
+            id: company.id,
+            name: company.name || company.companyProfile?.companyName || company.email,
+            email: company.email,
+            companyName: company.companyProfile?.companyName || company.name || company.email,
+            industry: company.companyProfile?.industry || null,
+            size: company.companyProfile?.size || null,
+            isVerified: company.isVerified || company.companyProfile?.isVerified || false,
+            totalSpent,
+            questsPosted,
+            completedQuests,
+            activeQuests,
+            createdAt: company.createdAt,
+          };
+        })
+        .sort((a, b) => {
+          const direction = order === 'asc' ? 1 : -1;
+          const delta = (a[sort] - b[sort]) * direction;
+          if (delta !== 0) return delta;
+          return a.createdAt.getTime() - b.createdAt.getTime();
+        })
+        .slice(0, limit)
+        .map((company, index) => ({
+          ...company,
+          position: index + 1,
+        }));
+
+      return NextResponse.json({
+        success: true,
+        mode,
+        sort,
+        order,
+        total: companies.length,
+        rankings: ranked,
+      });
     }
 
-    // Count users with more XP
-    const betterUsersCount = await prisma.user.count({
-      where: {
-        role: 'adventurer',
-        xp: { gt: user.xp }
-      }
+    const sort = parseAdventurerSort(searchParams.get('sort'));
+    const rank = normalizeRank(searchParams.get('rank'));
+    const where = {
+      role: 'adventurer' as const,
+      ...(rank ? { rank } : {}),
+    };
+
+    const adventurers = await prisma.user.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        rank: true,
+        xp: true,
+        level: true,
+        skillPoints: true,
+        createdAt: true,
+        adventurerProfile: {
+          select: {
+            specialization: true,
+            totalQuestsCompleted: true,
+            questCompletionRate: true,
+          },
+        },
+      },
+      orderBy: {
+        [sort]: order,
+      },
+      take: limit,
     });
+
+    const rankings = adventurers.map((user, index) => ({
+      id: user.id,
+      name: user.name || user.email,
+      email: user.email,
+      rank: user.rank,
+      xp: user.xp,
+      level: user.level,
+      skillPoints: user.skillPoints,
+      position: index + 1,
+      adventurerProfiles: user.adventurerProfile
+        ? {
+            specialization: user.adventurerProfile.specialization || undefined,
+            totalQuestsCompleted: user.adventurerProfile.totalQuestsCompleted,
+            questCompletionRate: Number(user.adventurerProfile.questCompletionRate),
+          }
+        : undefined,
+      adventurer_profiles: user.adventurerProfile
+        ? {
+            specialization: user.adventurerProfile.specialization || undefined,
+            totalQuestsCompleted: user.adventurerProfile.totalQuestsCompleted,
+            questCompletionRate: Number(user.adventurerProfile.questCompletionRate),
+          }
+        : undefined,
+    }));
+
+    const total = await prisma.user.count({ where });
 
     return NextResponse.json({
       success: true,
-      rank: {
-        position: betterUsersCount + 1,
-        totalUsers
-      }
+      mode,
+      sort,
+      order,
+      rank,
+      total,
+      rankings,
     });
   } catch (error) {
-    return NextResponse.json({ success: false, error: 'Failed to fetch user rank' }, { status: 500 });
+    console.error('Error fetching rankings:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch rankings' },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/rankings/user/route.ts
+++ b/app/api/rankings/user/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+
+type RankingsMode = 'adventurer' | 'company';
+type SortOrder = 'asc' | 'desc';
+type AdventurerSort = 'xp' | 'level' | 'skillPoints';
+type CompanySort = 'totalSpent' | 'questsPosted' | 'completedQuests' | 'activeQuests';
+
+function parseMode(rawMode: string | null): RankingsMode | null {
+  if (rawMode === 'adventurer' || rawMode === 'company') return rawMode;
+  return null;
+}
+
+function parseOrder(rawOrder: string | null): SortOrder {
+  return rawOrder === 'asc' ? 'asc' : 'desc';
+}
+
+function parseAdventurerSort(rawSort: string | null): AdventurerSort {
+  if (rawSort === 'level' || rawSort === 'skillPoints') return rawSort;
+  return 'xp';
+}
+
+function parseCompanySort(rawSort: string | null): CompanySort {
+  if (
+    rawSort === 'questsPosted' ||
+    rawSort === 'completedQuests' ||
+    rawSort === 'activeQuests'
+  ) {
+    return rawSort;
+  }
+  return 'totalSpent';
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    const { searchParams } = new URL(request.url);
+
+    const requestedUserId = searchParams.get('userId');
+    const userId = requestedUserId || session?.user?.id;
+
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'User ID required' },
+        { status: 400 }
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        role: true,
+        xp: true,
+        level: true,
+        skillPoints: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: 'User not found' },
+        { status: 404 }
+      );
+    }
+
+    const requestedMode = parseMode(searchParams.get('mode'));
+    const mode: RankingsMode =
+      requestedMode || (user.role === 'company' ? 'company' : 'adventurer');
+    const order = parseOrder(searchParams.get('order'));
+
+    if (mode === 'company') {
+      const sort = parseCompanySort(searchParams.get('sort'));
+      const companies = await prisma.user.findMany({
+        where: { role: 'company' },
+        select: {
+          id: true,
+          createdAt: true,
+          companyProfile: {
+            select: {
+              totalSpent: true,
+              questsPosted: true,
+            },
+          },
+          quests: {
+            select: { status: true },
+          },
+        },
+      });
+
+      const ranked = companies
+        .map((company) => {
+          const totalSpent = Number(company.companyProfile?.totalSpent ?? 0);
+          const questsPosted = company.companyProfile?.questsPosted ?? company.quests.length;
+          const completedQuests = company.quests.filter((quest) => quest.status === 'completed').length;
+          const activeQuests = company.quests.filter((quest) =>
+            ['available', 'in_progress', 'review'].includes(quest.status)
+          ).length;
+
+          return {
+            id: company.id,
+            totalSpent,
+            questsPosted,
+            completedQuests,
+            activeQuests,
+            createdAt: company.createdAt,
+          };
+        })
+        .sort((a, b) => {
+          const direction = order === 'asc' ? 1 : -1;
+          const delta = (a[sort] - b[sort]) * direction;
+          if (delta !== 0) return delta;
+          return a.createdAt.getTime() - b.createdAt.getTime();
+        });
+
+      const position = ranked.findIndex((entry) => entry.id === userId) + 1;
+      if (position === 0) {
+        return NextResponse.json(
+          { success: false, error: 'User is not ranked in company mode' },
+          { status: 404 }
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        rank: {
+          mode,
+          sort,
+          order,
+          position,
+          totalUsers: ranked.length,
+        },
+      });
+    }
+
+    const sort = parseAdventurerSort(searchParams.get('sort'));
+    const comparator = order === 'asc' ? 'lt' : 'gt';
+    const scoreValue = user[sort];
+
+    const totalUsers = await prisma.user.count({
+      where: { role: 'adventurer' },
+    });
+
+    const betterUsersCount = await prisma.user.count({
+      where: {
+        role: 'adventurer',
+        [sort]: { [comparator]: scoreValue },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      rank: {
+        mode,
+        sort,
+        order,
+        position: betterUsersCount + 1,
+        totalUsers,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching user ranking:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch user ranking' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/company/page.tsx
+++ b/app/dashboard/company/page.tsx
@@ -1,258 +1,450 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/db';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Trophy, Target, Users, TrendingUp, Plus, Coins } from 'lucide-react';
+import {
+  ArrowRight,
+  Briefcase,
+  CheckCircle2,
+  Coins,
+  Clock3,
+  Rocket,
+  Sparkles,
+  Target,
+  Trophy,
+  Users,
+} from 'lucide-react';
 import Link from 'next/link';
 
-interface Quest {
-  id: string;
-  title: string;
-  description: string;
-  difficulty: string;
-  xpReward: number;
-  skillPointsReward: number;
-  monetaryReward?: number;
-  status: string;
-  applicants: number;
+const ACTIVE_ASSIGNMENT_STATUSES = ['assigned', 'started', 'in_progress', 'submitted', 'review'] as const;
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'available':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-300';
+    case 'in_progress':
+      return 'bg-sky-100 text-sky-700 border-sky-300';
+    case 'review':
+      return 'bg-amber-100 text-amber-700 border-amber-300';
+    case 'completed':
+      return 'bg-violet-100 text-violet-700 border-violet-300';
+    case 'cancelled':
+      return 'bg-rose-100 text-rose-700 border-rose-300';
+    default:
+      return 'bg-slate-100 text-slate-700 border-slate-300';
+  }
 }
 
-export default function CompanyDashboard() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
-  const [quests, setQuests] = useState<Quest[]>([]);
-  const [loading, setLoading] = useState(true);
+export default async function CompanyDashboardPage() {
+  const session = await getServerSession(authOptions);
 
-  useEffect(() => {
-    // Check if user is authenticated and has company role
-    if (status === 'unauthenticated') {
-      router.push('/login');
-      return;
-    }
-    
-    if (status === 'authenticated' && session?.user?.role !== 'company') {
-      // Redirect non-companies to their appropriate dashboard
-      if (session.user.role === 'admin') {
-        router.push('/admin');
-      } else {
-        router.push('/dashboard');
-      }
-      return;
-    }
-
-    // Fetch company quests from real API
-    const fetchQuests = async () => {
-      try {
-        const res = await fetch('/api/company/quests');
-        if (res.ok) {
-          const data = await res.json();
-          const mapped = (data.quests || []).map((q: Record<string, unknown>) => ({
-            id: q.id,
-            title: q.title,
-            description: q.description,
-            difficulty: q.difficulty || 'D',
-            xpReward: q.xpReward || 0,
-            skillPointsReward: q.skillPointsReward || 0,
-            monetaryReward: q.monetaryReward,
-            status: q.status,
-            applicants: 0, // Assignment count not in this query
-          }));
-          setQuests(mapped);
-        }
-      } catch (error) {
-        console.error('Error fetching quests:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (status === 'authenticated') {
-      fetchQuests();
-    }
-  }, [status, session, router]);
-
-  if (status === 'loading' || loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
-      </div>
-    );
+  if (!session?.user) {
+    redirect('/login');
   }
 
-  // Calculate company stats from real data
+  if (session.user.role === 'adventurer') {
+    redirect('/dashboard');
+  }
+
+  if (session.user.role === 'admin') {
+    redirect('/admin');
+  }
+
+  const companyId = session.user.id;
+
+  const [company, quests, assignments, companySpendBoard] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: companyId },
+      select: {
+        name: true,
+        email: true,
+        companyProfile: {
+          select: {
+            companyName: true,
+            industry: true,
+            size: true,
+            isVerified: true,
+            questsPosted: true,
+            totalSpent: true,
+          },
+        },
+      },
+    }),
+    prisma.quest.findMany({
+      where: { companyId },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        difficulty: true,
+        deadline: true,
+        xpReward: true,
+        monetaryReward: true,
+        createdAt: true,
+        _count: {
+          select: {
+            assignments: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    }),
+    prisma.questAssignment.findMany({
+      where: {
+        quest: { companyId },
+      },
+      select: {
+        status: true,
+        userId: true,
+        quest: {
+          select: {
+            id: true,
+            title: true,
+            xpReward: true,
+          },
+        },
+        user: {
+          select: {
+            name: true,
+            email: true,
+            rank: true,
+            adventurerProfile: {
+              select: {
+                specialization: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { assignedAt: 'desc' },
+      take: 120,
+    }),
+    prisma.user.findMany({
+      where: { role: 'company' },
+      select: {
+        id: true,
+        companyProfile: { select: { totalSpent: true } },
+      },
+    }),
+  ]);
+
   const totalQuests = quests.length;
-  const activeQuests = quests.filter(q => q.status === 'available' || q.status === 'in_progress').length;
-  const completedQuests = quests.filter(q => q.status === 'completed').length;
-  const totalSpent = quests.reduce((sum, quest) => sum + (quest.monetaryReward || 0), 0);
+  const openQuests = quests.filter((quest) => quest.status === 'available').length;
+  const inProgressQuests = quests.filter((quest) => ['in_progress', 'review'].includes(quest.status)).length;
+  const completedQuests = quests.filter((quest) => quest.status === 'completed').length;
+
+  const activeCollaborators = new Set(
+    assignments
+      .filter((assignment) => ACTIVE_ASSIGNMENT_STATUSES.includes(assignment.status as (typeof ACTIVE_ASSIGNMENT_STATUSES)[number]))
+      .map((assignment) => assignment.userId)
+  ).size;
+
+  const pendingReviews = assignments.filter((assignment) => ['submitted', 'review'].includes(assignment.status)).length;
+
+  const totalSpent = Number(
+    company?.companyProfile?.totalSpent ??
+      quests.filter((quest) => quest.status === 'completed').reduce((acc, quest) => acc + Number(quest.monetaryReward || 0), 0)
+  );
+
+  const leaderboard = companySpendBoard
+    .map((entry) => ({
+      id: entry.id,
+      totalSpent: Number(entry.companyProfile?.totalSpent ?? 0),
+    }))
+    .sort((a, b) => b.totalSpent - a.totalSpent);
+
+  const companyPosition = leaderboard.findIndex((entry) => entry.id === companyId) + 1;
+
+  const topAdventurers = Object.values(
+    assignments.reduce<Record<string, {
+      id: string;
+      name: string;
+      rank: string;
+      specialization: string;
+      completed: number;
+      active: number;
+      deliveredXp: number;
+    }>>((acc, assignment) => {
+      if (!assignment.user || !assignment.userId) return acc;
+
+      if (!acc[assignment.userId]) {
+        acc[assignment.userId] = {
+          id: assignment.userId,
+          name: assignment.user.name || assignment.user.email,
+          rank: assignment.user.rank,
+          specialization: assignment.user.adventurerProfile?.specialization || 'Adventurer',
+          completed: 0,
+          active: 0,
+          deliveredXp: 0,
+        };
+      }
+
+      if (assignment.status === 'completed') {
+        acc[assignment.userId].completed += 1;
+        acc[assignment.userId].deliveredXp += assignment.quest.xpReward;
+      }
+
+      if (ACTIVE_ASSIGNMENT_STATUSES.includes(assignment.status as (typeof ACTIVE_ASSIGNMENT_STATUSES)[number])) {
+        acc[assignment.userId].active += 1;
+      }
+
+      return acc;
+    }, {})
+  )
+    .sort((a, b) => {
+      if (b.completed !== a.completed) return b.completed - a.completed;
+      return b.deliveredXp - a.deliveredXp;
+    })
+    .slice(0, 5);
+
   const completionRate = totalQuests > 0 ? Math.round((completedQuests / totalQuests) * 100) : 0;
+  const pipelineHealth = totalQuests > 0 ? Math.round(((openQuests + inProgressQuests) / totalQuests) * 100) : 0;
+
+  const urgentQuests = quests
+    .filter((quest) => {
+      if (!quest.deadline) return false;
+      if (quest.status === 'completed' || quest.status === 'cancelled') return false;
+      const msLeft = new Date(quest.deadline).getTime() - Date.now();
+      return msLeft <= 1000 * 60 * 60 * 24 * 14;
+    })
+    .slice(0, 4);
 
   return (
-    <div className="container mx-auto py-6 space-y-6">
-      {/* Welcome Section */}
-      <div>
-        <h1 className="text-3xl font-bold">Company Dashboard</h1>
-        <p className="text-muted-foreground mt-1">
-          Manage your quests and connect with adventurers
-        </p>
-      </div>
-
-      {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total Quests</CardTitle>
-            <Target className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{totalQuests}</div>
-            <p className="text-xs text-muted-foreground">+{totalQuests} this month</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Quests</CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{activeQuests}</div>
-            <p className="text-xs text-muted-foreground">Currently running</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Completed Quests</CardTitle>
-            <Trophy className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{completedQuests}</div>
-            <p className="text-xs text-muted-foreground">Successfully delivered</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total Investment</CardTitle>
-            <Coins className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">${totalSpent.toFixed(2)}</div>
-            <p className="text-xs text-muted-foreground">On platform</p>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Quick Actions */}
-      <div className="flex flex-wrap gap-4">
-        <Button asChild>
-          <Link href="/dashboard/company/create-quest">
-            <Plus className="w-4 h-4 mr-2" />
-            Create New Quest
-          </Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/dashboard/company/analytics">View Analytics</Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/dashboard/company/profile">Company Profile</Link>
-        </Button>
-      </div>
-
-      {/* Recent Quests */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
+    <div className="guild-page">
+      <section className="guild-hero">
+        <div className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <Badge className="rounded-full border border-sky-300 bg-sky-100 text-sky-700">
+              Company Operations Deck
+            </Badge>
             <div>
-              <CardTitle>Recent Quests</CardTitle>
-              <CardDescription>Your latest posted quests</CardDescription>
+              <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">
+                {company?.companyProfile?.companyName || company?.name || 'Company'} control center
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-600 sm:text-base">
+                Track delivery quality, manage adventurer talent, and maintain quest momentum from one place.
+              </p>
             </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="guild-chip">{company?.companyProfile?.industry || 'Technology'}</span>
+              <span className="guild-chip">{company?.companyProfile?.size || 'startup'} size</span>
+              <span className="guild-chip">
+                {company?.companyProfile?.isVerified ? 'Verified company' : 'Verification pending'}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid w-full max-w-md grid-cols-2 gap-3">
+            <Button className="col-span-2" asChild>
+              <Link href="/dashboard/company/create-quest">
+                <Rocket className="h-4 w-4" />
+                Launch New Quest
+              </Link>
+            </Button>
             <Button variant="outline" asChild>
-              <Link href="/dashboard/company/quests">View All</Link>
+              <Link href="/dashboard/company/quests">Manage Quests</Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/dashboard/company/analytics">Analytics</Link>
             </Button>
           </div>
-        </CardHeader>
-        <CardContent>
-          {quests.length === 0 ? (
-            <div className="text-center py-8">
-              <Target className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-              <h3 className="text-lg font-medium">No quests yet</h3>
-              <p className="text-muted-foreground">Create your first quest to get started</p>
-              <Button className="mt-4" asChild>
-                <Link href="/dashboard/company/create-quest">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create Quest
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Quest Portfolio</p>
+            <Briefcase className="h-4 w-4 text-sky-600" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{totalQuests}</p>
+          <p className="mt-1 text-xs text-slate-500">{openQuests} open, {inProgressQuests} in delivery</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active Adventurers</p>
+            <Users className="h-4 w-4 text-violet-600" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{activeCollaborators}</p>
+          <p className="mt-1 text-xs text-slate-500">{pendingReviews} submissions need review</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Delivery Success</p>
+            <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{completionRate}%</p>
+          <p className="mt-1 text-xs text-slate-500">{completedQuests} completed quests</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Guild Spend Rank</p>
+            <Trophy className="h-4 w-4 text-amber-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">#{companyPosition || '-'}</p>
+          <p className="mt-1 text-xs text-slate-500">${totalSpent.toLocaleString()} total platform spend</p>
+        </article>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <Card className="guild-panel xl:col-span-2">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Quest Delivery Board</CardTitle>
+              <CardDescription>Latest quests and execution status</CardDescription>
+            </div>
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/dashboard/company/quests">View all quests</Link>
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {quests.length === 0 ? (
+              <div className="rounded-xl border-2 border-dashed border-slate-300 p-10 text-center text-sm text-slate-500">
+                No quests posted yet. Launch your first quest to start recruiting adventurers.
+              </div>
+            ) : (
+              quests.slice(0, 6).map((quest) => (
+                <Link
+                  key={quest.id}
+                  href={`/dashboard/company/quests/${quest.id}`}
+                  className="guild-list-item flex items-start justify-between gap-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-semibold text-slate-900">{quest.title}</p>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                      <span>{quest.difficulty}-Rank</span>
+                      <span>{quest._count.assignments} applicant(s)</span>
+                      <span>{quest.xpReward} XP</span>
+                      {quest.deadline && <span>Due {new Date(quest.deadline).toLocaleDateString()}</span>}
+                    </div>
+                  </div>
+                  <Badge variant="outline" className={statusBadgeClass(quest.status)}>
+                    {quest.status.replace('_', ' ')}
+                  </Badge>
+                </Link>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="guild-panel">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-violet-500" />
+              Top Adventurers
+            </CardTitle>
+            <CardDescription>Best performers on your quests</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {topAdventurers.length === 0 ? (
+              <p className="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+                Adventurer ranking appears once assignments start.
+              </p>
+            ) : (
+              topAdventurers.map((adventurer, index) => (
+                <div key={adventurer.id} className="rounded-xl border border-slate-200 bg-white p-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-slate-900">#{index + 1} {adventurer.name}</p>
+                    <Badge variant="outline">{adventurer.rank}</Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-slate-500">{adventurer.specialization}</p>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-600">
+                    <span>{adventurer.completed} completed</span>
+                    <span>{adventurer.active} active</span>
+                    <span>{adventurer.deliveredXp} XP delivered</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <Card className="guild-panel">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Target className="h-5 w-5 text-emerald-500" />
+              Pipeline Signals
+            </CardTitle>
+            <CardDescription>Health indicators for ongoing quest delivery</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="text-slate-600">Delivery completion</span>
+                <span className="font-semibold text-slate-900">{completionRate}%</span>
+              </div>
+              <Progress value={completionRate} className="h-2.5" />
+            </div>
+            <div>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="text-slate-600">Pipeline activity</span>
+                <span className="font-semibold text-slate-900">{pipelineHealth}%</span>
+              </div>
+              <Progress value={pipelineHealth} className="h-2.5" />
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+              {pendingReviews > 0
+                ? `${pendingReviews} submission(s) are waiting for company review.`
+                : 'No pending reviews. Quest pipeline is clear.'}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="guild-panel">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Clock3 className="h-5 w-5 text-rose-500" />
+              Urgent Quest Deadlines
+            </CardTitle>
+            <CardDescription>Quests due within the next 14 days</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {urgentQuests.length === 0 ? (
+              <p className="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+                No urgent deadlines right now.
+              </p>
+            ) : (
+              urgentQuests.map((quest) => (
+                <Link
+                  key={quest.id}
+                  href={`/dashboard/company/quests/${quest.id}`}
+                  className="guild-list-item flex items-center justify-between"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-slate-900">{quest.title}</p>
+                    <p className="text-xs text-slate-500">{new Date(quest.deadline as Date).toLocaleDateString()}</p>
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-slate-400" />
+                </Link>
+              ))
+            )}
+            <div className="grid grid-cols-2 gap-2 pt-1">
+              <Button variant="outline" asChild>
+                <Link href="/dashboard/company/profile">
+                  <Coins className="h-4 w-4" />
+                  Company Profile
+                </Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href="/dashboard/company/payments">
+                  <Rocket className="h-4 w-4" />
+                  Payments
                 </Link>
               </Button>
             </div>
-          ) : (
-            <div className="space-y-4">
-              {quests.slice(0, 3).map((quest) => (
-                <div 
-                  key={quest.id} 
-                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent transition-colors"
-                >
-                  <div className="flex-1">
-                    <h4 className="font-medium">{quest.title}</h4>
-                    <p className="text-sm text-muted-foreground truncate max-w-md">
-                      {quest.description}
-                    </p>
-                    <div className="flex items-center gap-2 mt-2">
-                      <Badge variant="outline">{quest.difficulty}-Rank</Badge>
-                      <Badge variant="outline">{quest.status}</Badge>
-                      <span className="text-sm text-muted-foreground">
-                        {quest.applicants} applicant{quest.applicants !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="font-medium">{quest.xpReward} XP</div>
-                    <div className="text-sm text-muted-foreground">
-                      {quest.skillPointsReward} SP
-                    </div>
-                    {quest.monetaryReward && (
-                      <div className="text-sm font-medium text-primary">
-                        ${quest.monetaryReward}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Upcoming Features */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Platform Analytics</CardTitle>
-          <CardDescription>Insights about your quest performance</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div>
-              <div className="flex justify-between mb-1">
-                <span className="text-sm font-medium">Completion Rate</span>
-                <span className="text-sm font-medium">{completionRate}%</span>
-              </div>
-              <Progress value={completionRate} className="h-2" />
-            </div>
-            <div>
-              <div className="flex justify-between mb-1">
-                <span className="text-sm font-medium">Active vs Total</span>
-                <span className="text-sm font-medium">{activeQuests} / {totalQuests}</span>
-              </div>
-              <Progress value={totalQuests > 0 ? Math.round((activeQuests / totalQuests) * 100) : 0} className="h-2" />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/app/dashboard/company/quests/page.tsx
+++ b/app/dashboard/company/quests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -8,7 +8,18 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle, Target, Zap, Users, Clock, Search, ExternalLink, Plus } from 'lucide-react';
+import {
+  AlertCircle,
+  ArrowRight,
+  Briefcase,
+  Clock,
+  Plus,
+  Search,
+  Sparkles,
+  Target,
+  Users,
+  Zap,
+} from 'lucide-react';
 import Link from 'next/link';
 
 interface Quest {
@@ -28,10 +39,26 @@ interface Quest {
   companyId: string;
   createdAt: string;
   deadline?: string;
-  users: {
-    name: string;
-    email: string;
+  _count?: {
+    assignments?: number;
   };
+}
+
+function statusClass(status: string) {
+  switch (status) {
+    case 'available':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-300';
+    case 'in_progress':
+      return 'bg-sky-100 text-sky-700 border-sky-300';
+    case 'review':
+      return 'bg-amber-100 text-amber-700 border-amber-300';
+    case 'completed':
+      return 'bg-violet-100 text-violet-700 border-violet-300';
+    case 'cancelled':
+      return 'bg-rose-100 text-rose-700 border-rose-300';
+    default:
+      return 'bg-slate-100 text-slate-700 border-slate-300';
+  }
 }
 
 export default function CompanyQuestsPage() {
@@ -49,7 +76,6 @@ export default function CompanyQuestsPage() {
     }
 
     if (status === 'authenticated' && session?.user?.role !== 'company' && session.user.role !== 'admin') {
-      // Only companies and admins can access this page
       router.push('/dashboard');
       return;
     }
@@ -59,8 +85,7 @@ export default function CompanyQuestsPage() {
         setLoading(true);
         setError(null);
 
-        // Fetch quests for the current company
-        const response = await fetch('/api/company/quests');
+        const response = await fetch('/api/company/quests?limit=80');
         const data = await response.json();
 
         if (!data.success) {
@@ -68,7 +93,7 @@ export default function CompanyQuestsPage() {
           return;
         }
 
-        setQuests(data.quests || data.quest);
+        setQuests(data.quests || []);
       } catch (err) {
         console.error('Error fetching company quests:', err);
         setError('An error occurred while fetching quests');
@@ -82,24 +107,30 @@ export default function CompanyQuestsPage() {
     }
   }, [status, session, router]);
 
-  const filteredQuests = quests.filter(quest =>
-    quest.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.questCategory.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.status.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredQuests = useMemo(
+    () =>
+      quests.filter((quest) =>
+        [quest.title, quest.description, quest.questCategory, quest.status]
+          .join(' ')
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())
+      ),
+    [quests, searchTerm]
   );
 
   if (status === 'loading' || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+      <div className="guild-page">
+        <div className="guild-panel flex min-h-[320px] items-center justify-center">
+          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-primary" />
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="container mx-auto py-6">
+      <div className="guild-page">
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{error}</AlertDescription>
@@ -108,126 +139,157 @@ export default function CompanyQuestsPage() {
     );
   }
 
-  return (
-    <div className="container mx-auto py-6 max-w-6xl">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold">Your Quests</h1>
-        <p className="text-muted-foreground mt-1">
-          Manage and track the quests you&apos;ve posted for adventurers
-        </p>
-      </div>
+  const activeQuests = filteredQuests.filter((quest) => ['available', 'in_progress', 'review'].includes(quest.status)).length;
+  const completedQuests = filteredQuests.filter((quest) => quest.status === 'completed').length;
 
-      <div className="mb-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-            <Input
-              placeholder="Search quests by title, category, or status..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10"
-            />
+  return (
+    <div className="guild-page">
+      <section className="guild-hero">
+        <div className="relative z-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="rounded-full border border-sky-300 bg-sky-100 text-sky-700">
+              Company Quest Operations
+            </Badge>
+            <h1 className="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Your Quests</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600 sm:text-base">
+              Manage every quest lifecycle from posting to completion.
+            </p>
           </div>
-          <div className="flex gap-2">
-            <Button onClick={() => router.push('/dashboard/company')}>
-              ← Back to Dashboard
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" asChild>
+              <Link href="/dashboard/company">
+                Back to Dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
             </Button>
-            <Button onClick={() => router.push('/dashboard/company/create-quest')}>
-              <Plus className="w-4 h-4 mr-2" />
-              Create Quest
+            <Button asChild>
+              <Link href="/dashboard/company/create-quest">
+                <Plus className="h-4 w-4" />
+                Create Quest
+              </Link>
             </Button>
           </div>
         </div>
-      </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className="guild-kpi sm:col-span-2 xl:col-span-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total Quests</p>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{filteredQuests.length}</p>
+          <p className="mt-1 text-xs text-slate-500">In your current workspace</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active</p>
+            <Target className="h-4 w-4 text-emerald-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{activeQuests}</p>
+          <p className="mt-1 text-xs text-slate-500">Open, in progress, or review</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Completed</p>
+            <Sparkles className="h-4 w-4 text-violet-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{completedQuests}</p>
+          <p className="mt-1 text-xs text-slate-500">Delivered successfully</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recruitment Focus</p>
+            <Briefcase className="h-4 w-4 text-sky-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">
+            {filteredQuests.filter((quest) => (quest._count?.assignments ?? 0) === 0).length}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Quests needing applicants</p>
+        </article>
+      </section>
+
+      <section className="guild-panel p-4 sm:p-5">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="Search by title, category, or status"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </section>
 
       {filteredQuests.length === 0 ? (
-        <div className="text-center py-12">
-          <Target className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
-          <h3 className="text-xl font-medium mb-2">No quests yet</h3>
-          <p className="text-muted-foreground mb-4">
-            You haven&apos;t posted any quests yet. Create your first quest to get started.
-          </p>
-          <Button onClick={() => router.push('/dashboard/company/create-quest')}>
-            <Plus className="w-4 h-4 mr-2" />
-            Create Your First Quest
+        <section className="guild-panel p-12 text-center">
+          <Target className="mx-auto mb-4 h-14 w-14 text-slate-400" />
+          <h3 className="text-xl font-semibold text-slate-900">No quests found</h3>
+          <p className="mt-2 text-sm text-slate-500">Create your first quest to start attracting adventurers.</p>
+          <Button className="mt-4" asChild>
+            <Link href="/dashboard/company/create-quest">
+              <Plus className="h-4 w-4" />
+              Create Quest
+            </Link>
           </Button>
-        </div>
+        </section>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredQuests.map((quest) => (
-            <Card key={quest.id} className="flex flex-col h-full">
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div>
-                    <CardTitle className="text-xl">{quest.title}</CardTitle>
+            <Card key={quest.id} className="guild-panel border-slate-200/80">
+              <CardHeader className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <CardTitle className="line-clamp-2 text-lg">{quest.title}</CardTitle>
                     <CardDescription>
                       Created on {new Date(quest.createdAt).toLocaleDateString()}
                     </CardDescription>
                   </div>
-                  <Badge className={`
-                    ${quest.status === 'available' ? 'bg-green-500' : 
-                      quest.status === 'in_progress' ? 'bg-yellow-500' : 
-                      quest.status === 'completed' ? 'bg-blue-500' : 
-                      quest.status === 'draft' ? 'bg-gray-500' : 
-                      quest.status === 'cancelled' ? 'bg-red-500' : 
-                      'bg-gray-500'}
-                  `}>
-                    {quest.status.charAt(0).toUpperCase() + quest.status.slice(1)}
+                  <Badge variant="outline" className={statusClass(quest.status)}>
+                    {quest.status.replace('_', ' ')}
                   </Badge>
                 </div>
-                <div className="flex flex-wrap gap-2 mt-2">
-                  <Badge variant="secondary">{quest.questCategory}</Badge>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary" className="capitalize">{quest.questCategory}</Badge>
                   <Badge variant="outline">{quest.difficulty}-Rank</Badge>
                 </div>
               </CardHeader>
-              <CardContent className="flex flex-col flex-grow">
-                <p className="text-muted-foreground mb-4 line-clamp-2">
-                  {quest.description}
-                </p>
-                
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div className="flex items-center">
-                    <Zap className="w-4 h-4 mr-2 text-yellow-500" />
-                    <span className="text-sm">{quest.xpReward} XP</span>
+              <CardContent>
+                <p className="line-clamp-2 text-sm text-slate-600">{quest.description}</p>
+
+                <div className="mt-4 grid grid-cols-2 gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs">
+                  <div className="flex items-center gap-1 text-slate-700">
+                    <Zap className="h-3.5 w-3.5 text-amber-500" />
+                    {quest.xpReward} XP
                   </div>
-                  <div className="flex items-center">
-                    <Target className="w-4 h-4 mr-2 text-blue-500" />
-                    <span className="text-sm">{quest.skillPointsReward} SP</span>
-                  </div>
+                  <div className="text-slate-700">{quest.skillPointsReward} SP</div>
+                  {(quest._count?.assignments ?? 0) > 0 && (
+                    <div className="col-span-2 flex items-center gap-1 text-slate-600">
+                      <Users className="h-3.5 w-3.5" />
+                      {quest._count?.assignments} applicant(s)
+                    </div>
+                  )}
                   {quest.monetaryReward && (
-                    <div className="flex items-center col-span-2">
-                      <span className="text-sm font-medium">${quest.monetaryReward}</span>
+                    <div className="col-span-2 font-semibold text-emerald-600">
+                      ${Number(quest.monetaryReward)} budget
                     </div>
                   )}
                 </div>
-                
-                <div className="mb-4">
-                  <p className="text-xs text-muted-foreground mb-1">Applicants</p>
-                  <div className="flex items-center">
-                    <Users className="w-4 h-4 mr-2 text-green-500" />
-                    <span className="text-sm">0/{quest.maxParticipants || 1}</span>
-                  </div>
-                </div>
-                
+
                 {quest.deadline && (
-                  <div className="flex items-center text-sm text-muted-foreground mb-4">
-                    <Clock className="w-4 h-4 mr-2" />
-                    <span>Due: {new Date(quest.deadline).toLocaleDateString()}</span>
+                  <div className="mt-4 flex items-center gap-1 text-xs text-slate-500">
+                    <Clock className="h-3.5 w-3.5" />
+                    Due {new Date(quest.deadline).toLocaleDateString()}
                   </div>
                 )}
-                
-                <div className="mt-auto">
-                  <Link href={`/dashboard/company/quests/${quest.id}`} className="w-full">
-                    <Button variant="outline" className="w-full">
-                      View Details
-                      <ExternalLink className="w-4 h-4 ml-2" />
-                    </Button>
+
+                <Button className="mt-4 w-full" variant="outline" asChild>
+                  <Link href={`/dashboard/company/quests/${quest.id}`}>
+                    View Details
+                    <ArrowRight className="h-4 w-4" />
                   </Link>
-                </div>
+                </Button>
               </CardContent>
             </Card>
           ))}
-        </div>
+        </section>
       )}
     </div>
   );

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -16,22 +17,27 @@ import {
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import NotificationBell from '@/components/NotificationBell';
 import {
+  BarChart3,
+  Briefcase,
+  Building2,
+  Compass,
   Home,
-  Target,
-  Users,
-  Trophy,
-  Settings,
+  LineChart,
   LogOut,
   Menu,
-  X,
-  Briefcase,
-  Zap,
   Plus,
-  BarChart3,
-  Building2,
+  Settings,
+  ShieldCheck,
+  Sword,
+  Target,
+  Trophy,
+  Users,
+  X,
+  Zap,
 } from 'lucide-react';
 import Link from 'next/link';
 import { signOut } from 'next-auth/react';
+import { cn } from '@/lib/utils';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -40,6 +46,7 @@ interface DashboardLayoutProps {
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Redirect to login if not authenticated
@@ -71,11 +78,13 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     .toUpperCase() || 'U';
 
   const isCompany = user?.role === 'company';
+  const isAdmin = user?.role === 'admin';
+  const profileHref = isCompany ? '/dashboard/company/profile' : '/dashboard/profile';
 
   const adventurerNav = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
     { name: 'Quests', href: '/dashboard/quests', icon: Target },
-    { name: 'My Quests', href: '/dashboard/my-quests', icon: Briefcase },
+    { name: 'My Pipeline', href: '/dashboard/my-quests', icon: Briefcase },
     { name: 'Skill Tree', href: '/dashboard/skill-tree', icon: Zap },
     { name: 'Teams', href: '/dashboard/teams', icon: Users },
     { name: 'Leaderboard', href: '/dashboard/leaderboard', icon: Trophy },
@@ -85,14 +94,23 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     { name: 'Dashboard', href: '/dashboard/company', icon: Home },
     { name: 'My Quests', href: '/dashboard/company/quests', icon: Target },
     { name: 'Create Quest', href: '/dashboard/company/create-quest', icon: Plus },
+    { name: 'Rankings', href: '/dashboard/leaderboard', icon: Trophy },
     { name: 'Analytics', href: '/dashboard/company/analytics', icon: BarChart3 },
     { name: 'Company Profile', href: '/dashboard/company/profile', icon: Building2 },
   ];
 
   const navigation = isCompany ? companyNav : adventurerNav;
+  const roleTitle = isCompany ? 'Company Command' : 'Adventurer Hub';
+  const roleSubtitle = isCompany
+    ? 'Manage delivery and talent pipeline'
+    : 'Track progression and claim new quests';
+  const roleIcon = isCompany ? Briefcase : Sword;
+  const RoleIcon = roleIcon;
+
+  const isActive = (href: string) => pathname === href || pathname?.startsWith(`${href}/`);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen guild-shell">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -103,24 +121,42 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
       {/* Sidebar */}
       <aside
-        className={`fixed top-0 left-0 z-50 h-full w-64 bg-card border-r transform transition-transform duration-200 ease-in-out lg:translate-x-0 ${
+        className={`fixed top-0 left-0 z-50 h-full w-72 border-r border-slate-800 bg-slate-950 text-slate-100 transform transition-transform duration-200 ease-in-out lg:translate-x-0 ${
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         <div className="flex flex-col h-full">
           {/* Logo */}
-          <div className="flex items-center justify-between p-4 border-b">
-            <Link href="/dashboard" className="flex items-center space-x-2">
-              <span className="text-xl font-bold">Adventurers Guild</span>
+          <div className="flex items-center justify-between p-4 border-b border-slate-800">
+            <Link
+              href={isCompany ? '/dashboard/company' : '/dashboard'}
+              className="flex items-center space-x-2"
+            >
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-bold text-black">
+                AG
+              </span>
+              <span className="text-sm font-semibold tracking-wide text-slate-200">
+                Adventurers Guild
+              </span>
             </Link>
             <Button
               variant="ghost"
               size="icon"
-              className="lg:hidden"
+              className="lg:hidden text-slate-200 hover:bg-slate-800"
               onClick={() => setSidebarOpen(false)}
             >
               <X className="h-5 w-5" />
             </Button>
+          </div>
+
+          <div className="px-4 pt-4">
+            <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
+              <div className="flex items-center gap-2 text-orange-300">
+                <RoleIcon className="h-4 w-4" />
+                <p className="text-xs font-semibold uppercase tracking-[0.2em]">{roleTitle}</p>
+              </div>
+              <p className="mt-2 text-xs text-slate-400">{roleSubtitle}</p>
+            </div>
           </div>
 
           {/* Navigation */}
@@ -129,25 +165,45 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               <Link
                 key={item.name}
                 href={item.href}
-                className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-accent transition-colors"
+                className={cn(
+                  'flex items-center space-x-3 rounded-lg px-3 py-2 text-sm transition-colors',
+                  isActive(item.href)
+                    ? 'bg-gradient-to-r from-orange-500/25 to-amber-400/20 text-white border border-orange-400/40'
+                    : 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
+                )}
                 onClick={() => setSidebarOpen(false)}
               >
                 <item.icon className="h-5 w-5" />
                 <span>{item.name}</span>
               </Link>
             ))}
+            {isAdmin && (
+              <Link
+                href="/admin"
+                className={cn(
+                  'mt-2 flex items-center space-x-3 rounded-lg px-3 py-2 text-sm transition-colors',
+                  pathname === '/admin'
+                    ? 'bg-gradient-to-r from-violet-500/30 to-indigo-500/20 text-white border border-violet-400/50'
+                    : 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
+                )}
+                onClick={() => setSidebarOpen(false)}
+              >
+                <ShieldCheck className="h-5 w-5" />
+                <span>Admin Console</span>
+              </Link>
+            )}
           </nav>
 
           {/* User section */}
-          <div className="p-4 border-t">
-            <div className="flex items-center space-x-3">
+          <div className="p-4 border-t border-slate-800">
+            <div className="flex items-center space-x-3 rounded-xl border border-slate-800 bg-slate-900/70 p-3">
               <Avatar>
                 <AvatarImage src={user?.image || undefined} />
-                <AvatarFallback>{userInitials}</AvatarFallback>
+                <AvatarFallback className="bg-slate-800 text-slate-100">{userInitials}</AvatarFallback>
               </Avatar>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">{user?.name}</p>
-                <p className="text-xs text-muted-foreground truncate">
+                <p className="text-sm font-medium truncate text-slate-100">{user?.name}</p>
+                <p className="text-xs text-slate-400 truncate">
                   {user?.email}
                 </p>
               </div>
@@ -157,10 +213,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </aside>
 
       {/* Main content */}
-      <div className="lg:pl-64">
+      <div className="lg:pl-72">
         {/* Top bar */}
-        <header className="sticky top-0 z-30 bg-background border-b">
-          <div className="flex items-center justify-between px-4 py-3">
+        <header className="sticky top-0 z-30 border-b border-slate-200/70 bg-white/80 backdrop-blur-lg">
+          <div className="flex items-center justify-between px-4 py-3 lg:px-8">
             <Button
               variant="ghost"
               size="icon"
@@ -170,7 +226,13 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               <Menu className="h-5 w-5" />
             </Button>
 
-            <div className="flex-1" />
+            <div className="hidden lg:flex items-center gap-2 text-sm text-slate-500">
+              <Compass className="h-4 w-4" />
+              <span>
+                {isCompany ? 'Company Dashboard' : 'Adventurer Dashboard'}
+              </span>
+              <LineChart className="h-4 w-4 text-orange-500" />
+            </div>
 
             <div className="flex items-center space-x-2">
               <NotificationBell userId={session?.user?.id || ''} />
@@ -189,14 +251,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                   <DropdownMenuLabel>My Account</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
-                    <Link href="/dashboard/profile">
+                    <Link href={profileHref}>
                       <Settings className="mr-2 h-4 w-4" />
                       Profile Settings
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => signOut({ callbackUrl: '/' })}
+                    onClick={() => signOut({ callbackUrl: '/home' })}
                     className="text-destructive"
                   >
                     <LogOut className="mr-2 h-4 w-4" />
@@ -209,7 +271,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         </header>
 
         {/* Page content */}
-        <main className="p-4 lg:p-6">{children}</main>
+        <main className="px-4 pb-8 pt-6 lg:px-8">{children}</main>
       </div>
     </div>
   );

--- a/app/dashboard/leaderboard/page.tsx
+++ b/app/dashboard/leaderboard/page.tsx
@@ -1,20 +1,27 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import Link from 'next/link';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Trophy, Medal, Award, Zap } from 'lucide-react';
+  ArrowUpRight,
+  Award,
+  Building2,
+  Medal,
+  Sparkles,
+  Trophy,
+  Users,
+  Zap,
+} from 'lucide-react';
 
-interface RankedUser {
+type Mode = 'adventurer' | 'company';
+
+type AdventurerRankRow = {
   id: string;
   name: string;
   rank: string;
@@ -26,7 +33,19 @@ interface RankedUser {
     specialization?: string;
     totalQuestsCompleted?: number;
   };
-}
+};
+
+type CompanyRankRow = {
+  id: string;
+  name: string;
+  companyName: string;
+  totalSpent: number;
+  questsPosted: number;
+  completedQuests: number;
+  activeQuests: number;
+  position: number;
+  isVerified: boolean;
+};
 
 const RANK_COLORS: Record<string, string> = {
   S: 'bg-amber-100 text-amber-700 border-amber-300',
@@ -39,148 +58,323 @@ const RANK_COLORS: Record<string, string> = {
 };
 
 export default function LeaderboardPage() {
-  const { data: session } = useSession();
-  const [users, setUsers] = useState<RankedUser[]>([]);
+  const { data: session, status } = useSession();
+  const defaultMode: Mode = session?.user?.role === 'company' ? 'company' : 'adventurer';
+
+  const [mode, setMode] = useState<Mode>(defaultMode);
+  const [adventurerSort, setAdventurerSort] = useState<'xp' | 'level' | 'skillPoints'>('xp');
+  const [companySort, setCompanySort] = useState<'totalSpent' | 'questsPosted' | 'completedQuests' | 'activeQuests'>('totalSpent');
   const [loading, setLoading] = useState(true);
-  const [sortBy, setSortBy] = useState('xp');
+  const [userPosition, setUserPosition] = useState<{ position: number; totalUsers: number } | null>(null);
+  const [adventurers, setAdventurers] = useState<AdventurerRankRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRankRow[]>([]);
 
   useEffect(() => {
-    const fetchRankings = async () => {
+    if (status === 'authenticated') {
+      setMode(session?.user?.role === 'company' ? 'company' : 'adventurer');
+    }
+  }, [status, session?.user?.role]);
+
+  const activeSort = mode === 'adventurer' ? adventurerSort : companySort;
+
+  useEffect(() => {
+    const loadRankings = async () => {
+      if (status !== 'authenticated') return;
+
       try {
-        const res = await fetch(`/api/rankings?sort=${sortBy}&order=desc&limit=50`);
-        if (res.ok) {
-          const data = await res.json();
-          setUsers(data.rankings || []);
+        setLoading(true);
+
+        const [rankingRes, userRankRes] = await Promise.all([
+          fetch(`/api/rankings?mode=${mode}&sort=${activeSort}&order=desc&limit=50`),
+          fetch(`/api/rankings/user?mode=${mode}&sort=${activeSort}&order=desc`),
+        ]);
+
+        const rankingData = await rankingRes.json();
+        const userRankData = await userRankRes.json();
+
+        if (mode === 'adventurer') {
+          setAdventurers(rankingData.rankings || []);
+        } else {
+          setCompanies(rankingData.rankings || []);
         }
+
+        setUserPosition(userRankData.rank || null);
       } catch (error) {
-        console.error('Error fetching rankings:', error);
+        console.error('Failed to load leaderboard:', error);
+        if (mode === 'adventurer') setAdventurers([]);
+        else setCompanies([]);
+        setUserPosition(null);
       } finally {
         setLoading(false);
       }
     };
-    fetchRankings();
-  }, [sortBy]);
 
-  const getPositionIcon = (pos: number) => {
-    if (pos === 1) return <Trophy className="w-5 h-5 text-amber-500" />;
-    if (pos === 2) return <Medal className="w-5 h-5 text-slate-400" />;
-    if (pos === 3) return <Award className="w-5 h-5 text-amber-700" />;
-    return <span className="w-5 text-center text-sm font-medium text-muted-foreground">{pos}</span>;
+    loadRankings();
+  }, [mode, activeSort, status]);
+
+  const topThree = useMemo(() => {
+    if (mode === 'adventurer') {
+      if (adventurers.length < 3) return [];
+      return [adventurers[1], adventurers[0], adventurers[2]].filter(Boolean);
+    }
+
+    if (companies.length < 3) return [];
+    return [companies[1], companies[0], companies[2]].filter(Boolean);
+  }, [mode, adventurers, companies]);
+
+  const getPositionIcon = (position: number) => {
+    if (position === 1) return <Trophy className="h-5 w-5 text-amber-500" />;
+    if (position === 2) return <Medal className="h-5 w-5 text-slate-400" />;
+    if (position === 3) return <Award className="h-5 w-5 text-amber-700" />;
+    return <span className="text-sm font-semibold text-slate-500">{position}</span>;
   };
 
-  if (loading) {
+  if (status === 'loading' || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
+      <div className="guild-page">
+        <div className="guild-panel flex min-h-[320px] items-center justify-center">
+          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-primary" />
+        </div>
       </div>
     );
   }
 
-  return (
-    <div className="container mx-auto py-6 max-w-3xl">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-3xl font-bold">Leaderboard</h1>
-          <p className="text-muted-foreground mt-1">Top adventurers ranked by performance</p>
-        </div>
-        <Select value={sortBy} onValueChange={setSortBy}>
-          <SelectTrigger className="w-[160px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="xp">Sort by XP</SelectItem>
-            <SelectItem value="level">Sort by Level</SelectItem>
-            <SelectItem value="skillPoints">Sort by Skill Points</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+  const activeRows = mode === 'adventurer' ? adventurers : companies;
 
-      {/* Top 3 podium */}
-      {users.length >= 3 && (
-        <div className="grid grid-cols-3 gap-4 mb-8">
-          {[users[1], users[0], users[2]].map((user, idx) => {
-            const isFirst = idx === 1;
+  return (
+    <div className="guild-page">
+      <section className="guild-hero">
+        <div className="relative z-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="rounded-full border border-violet-300 bg-violet-100 text-violet-700">
+              Guild Rankings
+            </Badge>
+            <h1 className="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">
+              {mode === 'adventurer' ? 'Adventurer Leaderboard' : 'Company Impact Leaderboard'}
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600 sm:text-base">
+              {mode === 'adventurer'
+                ? 'See who is climbing from F-Rank to S-Rank the fastest.'
+                : 'Track which companies are creating the strongest quest ecosystems.'}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Select value={mode} onValueChange={(value) => setMode(value as Mode)}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Select board" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="adventurer">Adventurer Board</SelectItem>
+                <SelectItem value="company">Company Board</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {mode === 'adventurer' ? (
+              <Select value={adventurerSort} onValueChange={(value) => setAdventurerSort(value as typeof adventurerSort)}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="xp">Sort by XP</SelectItem>
+                  <SelectItem value="level">Sort by Level</SelectItem>
+                  <SelectItem value="skillPoints">Sort by Skill Points</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : (
+              <Select value={companySort} onValueChange={(value) => setCompanySort(value as typeof companySort)}>
+                <SelectTrigger className="w-[220px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="totalSpent">Sort by Total Spend</SelectItem>
+                  <SelectItem value="completedQuests">Sort by Completed Quests</SelectItem>
+                  <SelectItem value="questsPosted">Sort by Quests Posted</SelectItem>
+                  <SelectItem value="activeQuests">Sort by Active Quests</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className="guild-kpi sm:col-span-2 xl:col-span-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Your Position</p>
+          <p className="mt-2 text-2xl font-bold text-slate-900">
+            #{userPosition?.position ?? '-'}
+            <span className="ml-1 text-sm font-medium text-slate-500">/ {userPosition?.totalUsers ?? '-'}</span>
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Current standing on selected board</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Board Type</p>
+            {mode === 'adventurer' ? <Users className="h-4 w-4 text-sky-500" /> : <Building2 className="h-4 w-4 text-violet-500" />}
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900 capitalize">{mode}</p>
+          <p className="mt-1 text-xs text-slate-500">{activeRows.length} visible entries</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Current Sort</p>
+            <ArrowUpRight className="h-4 w-4 text-amber-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{activeSort}</p>
+          <p className="mt-1 text-xs text-slate-500">Descending order</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Season Highlight</p>
+            <Sparkles className="h-4 w-4 text-emerald-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">Top 3</p>
+          <p className="mt-1 text-xs text-slate-500">Podium updates in real time</p>
+        </article>
+      </section>
+
+      {topThree.length > 0 && (
+        <section className="grid gap-4 md:grid-cols-3">
+          {topThree.map((row, idx) => {
+            const isCenter = idx === 1;
+            const name = mode === 'adventurer' ? (row as AdventurerRankRow).name : (row as CompanyRankRow).companyName;
+            const position = row.position;
+
             return (
-              <Card key={user.id} className={`text-center ${isFirst ? 'border-amber-300 bg-amber-50/50 -mt-4' : ''}`}>
-                <CardContent className="pt-6 pb-4">
-                  <div className="flex justify-center mb-2">
-                    {getPositionIcon(user.position)}
-                  </div>
-                  <Avatar className={`mx-auto mb-2 ${isFirst ? 'h-16 w-16' : 'h-12 w-12'}`}>
-                    <AvatarFallback className="text-lg font-bold">
-                      {user.name?.charAt(0) || '?'}
-                    </AvatarFallback>
+              <Card
+                key={`${mode}-${row.id}`}
+                className={`guild-panel text-center ${isCenter ? 'border-amber-300 bg-amber-50/70 -mt-1 md:-mt-3' : ''}`}
+              >
+                <CardContent className="pt-6">
+                  <div className="mb-2 flex justify-center">{getPositionIcon(position)}</div>
+                  <Avatar className={`mx-auto ${isCenter ? 'h-14 w-14' : 'h-12 w-12'}`}>
+                    <AvatarFallback className="text-lg font-bold">{name?.charAt(0) || '?'}</AvatarFallback>
                   </Avatar>
-                  <p className="font-semibold text-sm truncate">{user.name}</p>
-                  <Badge className={`mt-1 ${RANK_COLORS[user.rank] || ''}`} variant="outline">
-                    {user.rank}-Rank
-                  </Badge>
-                  <div className="mt-2 flex items-center justify-center gap-1 text-sm">
-                    <Zap className="w-3.5 h-3.5 text-amber-500" />
-                    <span className="font-medium">{user.xp.toLocaleString()} XP</span>
-                  </div>
+                  <p className="mt-2 truncate text-sm font-semibold text-slate-900">{name}</p>
+
+                  {mode === 'adventurer' ? (
+                    <>
+                      <Badge variant="outline" className={`mt-2 ${RANK_COLORS[(row as AdventurerRankRow).rank] || ''}`}>
+                        {(row as AdventurerRankRow).rank}-Rank
+                      </Badge>
+                      <p className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-slate-700">
+                        <Zap className="h-3.5 w-3.5 text-amber-500" />
+                        {(row as AdventurerRankRow).xp.toLocaleString()} XP
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <Badge variant="outline" className="mt-2 bg-sky-100 text-sky-700 border-sky-300">
+                        {(row as CompanyRankRow).isVerified ? 'Verified' : 'Unverified'}
+                      </Badge>
+                      <p className="mt-2 text-sm font-semibold text-slate-700">
+                        ${(row as CompanyRankRow).totalSpent.toLocaleString()} invested
+                      </p>
+                    </>
+                  )}
                 </CardContent>
               </Card>
             );
           })}
-        </div>
+        </section>
       )}
 
-      {/* Full rankings table */}
-      <Card>
+      <Card className="guild-panel">
         <CardHeader>
-          <CardTitle>All Rankings</CardTitle>
+          <CardTitle>{mode === 'adventurer' ? 'Full Adventurer Rankings' : 'Full Company Rankings'}</CardTitle>
+          <CardDescription>
+            {mode === 'adventurer'
+              ? 'Leaderboard by adventurer performance and progression'
+              : 'Leaderboard by company spend and quest operations'}
+          </CardDescription>
         </CardHeader>
         <CardContent className="p-0">
-          {users.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              No adventurers ranked yet.
-            </div>
+          {activeRows.length === 0 ? (
+            <div className="p-10 text-center text-sm text-slate-500">No ranking data available yet.</div>
           ) : (
             <div className="divide-y">
-              {users.map(user => {
-                const isCurrentUser = session?.user?.id === user.id;
-                const profile = Array.isArray(user.adventurer_profiles)
-                  ? user.adventurer_profiles[0]
-                  : user.adventurer_profiles;
+              {mode === 'adventurer'
+                ? adventurers.map((user) => {
+                    const isCurrentUser = session?.user?.id === user.id;
+                    const profile = user.adventurer_profiles;
 
-                return (
-                  <div
-                    key={user.id}
-                    className={`flex items-center gap-4 px-6 py-3.5 ${isCurrentUser ? 'bg-indigo-50/50' : 'hover:bg-slate-50'}`}
-                  >
-                    <div className="w-8 flex justify-center shrink-0">
-                      {getPositionIcon(user.position)}
-                    </div>
-                    <Avatar className="h-9 w-9 shrink-0">
-                      <AvatarFallback className="text-sm font-semibold">
-                        {user.name?.charAt(0) || '?'}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium text-sm truncate">
-                        {user.name}
-                        {isCurrentUser && <span className="text-xs text-muted-foreground ml-2">(You)</span>}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {profile?.specialization || 'Adventurer'} · Level {user.level}
-                        {profile?.totalQuestsCompleted ? ` · ${profile.totalQuestsCompleted} quests` : ''}
-                      </p>
-                    </div>
-                    <Badge className={`shrink-0 ${RANK_COLORS[user.rank] || ''}`} variant="outline">
-                      {user.rank}
-                    </Badge>
-                    <div className="text-right shrink-0 w-24">
-                      <p className="text-sm font-semibold">{user.xp.toLocaleString()} XP</p>
-                      <p className="text-xs text-muted-foreground">{user.skillPoints} SP</p>
-                    </div>
-                  </div>
-                );
-              })}
+                    return (
+                      <div
+                        key={user.id}
+                        className={`flex items-center gap-4 px-5 py-3.5 ${isCurrentUser ? 'bg-indigo-50/70' : 'hover:bg-slate-50'}`}
+                      >
+                        <div className="w-8 shrink-0 text-center">{getPositionIcon(user.position)}</div>
+                        <Avatar className="h-9 w-9 shrink-0">
+                          <AvatarFallback>{user.name?.charAt(0) || '?'}</AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-semibold text-slate-900">
+                            {user.name}
+                            {isCurrentUser && <span className="ml-2 text-xs font-medium text-slate-500">(You)</span>}
+                          </p>
+                          <p className="text-xs text-slate-500">
+                            {profile?.specialization || 'Adventurer'} · Level {user.level}
+                            {profile?.totalQuestsCompleted ? ` · ${profile.totalQuestsCompleted} quests` : ''}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className={RANK_COLORS[user.rank] || ''}>
+                          {user.rank}
+                        </Badge>
+                        <div className="w-24 shrink-0 text-right">
+                          <p className="text-sm font-semibold text-slate-900">{user.xp.toLocaleString()} XP</p>
+                          <p className="text-xs text-slate-500">{user.skillPoints} SP</p>
+                        </div>
+                      </div>
+                    );
+                  })
+                : companies.map((company) => {
+                    const isCurrentUser = session?.user?.id === company.id;
+                    return (
+                      <div
+                        key={company.id}
+                        className={`flex items-center gap-4 px-5 py-3.5 ${isCurrentUser ? 'bg-indigo-50/70' : 'hover:bg-slate-50'}`}
+                      >
+                        <div className="w-8 shrink-0 text-center">{getPositionIcon(company.position)}</div>
+                        <Avatar className="h-9 w-9 shrink-0">
+                          <AvatarFallback>{company.companyName?.charAt(0) || '?'}</AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-semibold text-slate-900">
+                            {company.companyName}
+                            {isCurrentUser && <span className="ml-2 text-xs font-medium text-slate-500">(You)</span>}
+                          </p>
+                          <p className="text-xs text-slate-500">
+                            {company.completedQuests} completed · {company.activeQuests} active · {company.questsPosted} posted
+                          </p>
+                        </div>
+                        <Badge
+                          variant="outline"
+                          className={company.isVerified ? 'bg-emerald-100 text-emerald-700 border-emerald-300' : ''}
+                        >
+                          {company.isVerified ? 'Verified' : 'Pending'}
+                        </Badge>
+                        <div className="w-28 shrink-0 text-right">
+                          <p className="text-sm font-semibold text-slate-900">${company.totalSpent.toLocaleString()}</p>
+                          <p className="text-xs text-slate-500">total spend</p>
+                        </div>
+                      </div>
+                    );
+                  })}
             </div>
           )}
         </CardContent>
       </Card>
+
+      <div className="flex justify-end">
+        <Button asChild>
+          <Link href={mode === 'adventurer' ? '/dashboard/quests' : '/dashboard/company/create-quest'}>
+            {mode === 'adventurer' ? 'Find Next Quest' : 'Launch New Quest'}
+          </Link>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/my-quests/page.tsx
+++ b/app/dashboard/my-quests/page.tsx
@@ -16,6 +16,10 @@ export default async function MyQuestsPage() {
     redirect("/login");
   }
 
+  if (session.user.role === 'company') {
+    redirect('/dashboard/company');
+  }
+
   // Fetch user's assignments
   const assignments = await prisma.questAssignment.findMany({
     where: {
@@ -48,7 +52,7 @@ export default async function MyQuestsPage() {
               <h3 className="text-lg font-semibold mb-2">No quests found</h3>
               <p className="text-muted-foreground mb-4">You haven&apos;t accepted any quests yet.</p>
               <Button asChild>
-                <Link href="/quests">Find Quests</Link>
+                <Link href="/dashboard/quests">Find Quests</Link>
               </Button>
             </CardContent>
           </Card>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,202 +1,380 @@
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { prisma } from "@/lib/db";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Trophy, Target, TrendingUp, Zap, Clock } from "lucide-react";
-import Link from "next/link";
-import { RankBadge } from "@/components/ui/rank-badge";
-import type { Rank } from "@/components/ui/rank-badge";
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/db';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import {
+  ArrowRight,
+  Clock,
+  Flame,
+  Sparkles,
+  Target,
+  Trophy,
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
+import Link from 'next/link';
+import { RankBadge } from '@/components/ui/rank-badge';
+import type { Rank } from '@/components/ui/rank-badge';
+import { RANK_THRESHOLDS } from '@/lib/ranks';
 
-const XP_THRESHOLDS: Record<string, { next: string; required: number }> = {
-  F: { next: "E", required: 500 },
-  E: { next: "D", required: 1500 },
-  D: { next: "C", required: 3500 },
-  C: { next: "B", required: 7500 },
-  B: { next: "A", required: 15000 },
-  A: { next: "S", required: 30000 },
-  S: { next: "S", required: 30000 },
-};
+const RANK_ORDER: Rank[] = ['F', 'E', 'D', 'C', 'B', 'A', 'S'];
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
 
-  const userId = session?.user?.id;
+  if (!session?.user) {
+    redirect('/login');
+  }
 
-  const [user, activeAssignments] = await Promise.all([
-    userId
-      ? prisma.user.findUnique({
-          where: { id: userId },
-          select: { xp: true, rank: true, skillPoints: true, name: true },
-        })
-      : null,
-    userId
-      ? prisma.questAssignment.findMany({
-          where: {
-            userId,
-            status: { in: ["assigned", "started", "in_progress"] },
+  if (session.user.role === 'company') {
+    redirect('/dashboard/company');
+  }
+
+  if (session.user.role === 'admin') {
+    redirect('/admin');
+  }
+
+  const userId = session.user.id;
+
+  const [user, activeAssignments, availableQuests] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        xp: true,
+        rank: true,
+        level: true,
+        skillPoints: true,
+        name: true,
+        adventurerProfile: {
+          select: {
+            specialization: true,
+            totalQuestsCompleted: true,
+            questCompletionRate: true,
+            currentStreak: true,
           },
-          include: {
-            quest: {
-              select: { id: true, title: true, xpReward: true, monetaryReward: true, deadline: true },
-            },
+        },
+      },
+    }),
+    prisma.questAssignment.findMany({
+      where: {
+        userId,
+        status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'review'] },
+      },
+      include: {
+        quest: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            xpReward: true,
+            skillPointsReward: true,
+            monetaryReward: true,
+            deadline: true,
+            company: { select: { name: true } },
           },
-          orderBy: { assignedAt: "desc" },
-          take: 5,
-        })
-      : [],
+        },
+      },
+      orderBy: { assignedAt: 'desc' },
+      take: 5,
+    }),
+    prisma.quest.findMany({
+      where: { status: 'available' },
+      select: {
+        id: true,
+        title: true,
+        difficulty: true,
+        questCategory: true,
+        xpReward: true,
+        skillPointsReward: true,
+        monetaryReward: true,
+        requiredSkills: true,
+        requiredRank: true,
+        company: { select: { name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 24,
+    }),
   ]);
 
-  const completedCount = userId
-    ? await prisma.questAssignment.count({ where: { userId, status: "completed" } })
-    : 0;
+  const [completedCount, reviewCount, totalAdventurers] = await Promise.all([
+    prisma.questAssignment.count({ where: { userId, status: 'completed' } }),
+    prisma.questAssignment.count({ where: { userId, status: { in: ['submitted', 'review'] } } }),
+    prisma.user.count({ where: { role: 'adventurer' } }),
+  ]);
 
   const xp = user?.xp ?? 0;
-  const rank = (user?.rank ?? "F") as Rank;
-  const threshold = XP_THRESHOLDS[rank];
-  const xpToNext = Math.max(0, threshold.required - xp);
+  const rank = (user?.rank ?? 'F') as Rank;
+  const level = user?.level ?? 1;
+  const rankIndex = RANK_ORDER.indexOf(rank);
+  const currentThreshold = RANK_THRESHOLDS[rankIndex]?.threshold ?? 0;
+  const nextEntry = RANK_THRESHOLDS[rankIndex + 1];
+  const xpToNext = nextEntry ? Math.max(0, nextEntry.threshold - xp) : 0;
+  const progress =
+    nextEntry && nextEntry.threshold > currentThreshold
+      ? Math.max(0, Math.min(100, ((xp - currentThreshold) / (nextEntry.threshold - currentThreshold)) * 100))
+      : 100;
+  const specialization = user?.adventurerProfile?.specialization || 'Generalist';
+
+  const leaderboardPosition =
+    (await prisma.user.count({ where: { role: 'adventurer', xp: { gt: xp } } })) + 1;
+
+  const rankValue = (candidate: string | null | undefined) => {
+    if (!candidate) return 0;
+    const idx = RANK_ORDER.indexOf(candidate as Rank);
+    return idx >= 0 ? idx : 0;
+  };
+
+  const recommendedQuests = availableQuests
+    .filter((quest) => {
+      const requirement = quest.requiredRank ?? quest.difficulty;
+      return rankValue(requirement) <= rankValue(rank);
+    })
+    .slice(0, 4);
 
   return (
-    <div className="container py-8">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-bold">Dashboard</h1>
-          <p className="text-muted-foreground">
-            Welcome back, {session?.user?.name ?? "Adventurer"}.
-          </p>
-        </div>
-        <Button asChild>
-          <Link href="/dashboard/quests">Find New Quests</Link>
-        </Button>
-      </div>
-
-      {/* Stats Overview */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total XP</CardTitle>
-            <Zap className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{xp.toLocaleString()}</div>
-            <p className="text-xs text-muted-foreground">
-              {rank === "S" ? "Max rank reached" : `${xpToNext.toLocaleString()} XP to ${threshold.next}-Rank`}
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Quests</CardTitle>
-            <Target className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{activeAssignments.length}</div>
-            <p className="text-xs text-muted-foreground">Currently in progress</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Completed</CardTitle>
-            <Trophy className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{completedCount}</div>
-            <p className="text-xs text-muted-foreground">Quests finished</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Current Rank</CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-2">
-              <RankBadge rank={rank} size="sm" />
-              <span className="text-2xl font-bold">{rank}-Rank</span>
+    <div className="guild-page">
+      <section className="guild-hero">
+        <div className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <Badge className="rounded-full border border-orange-300 bg-orange-100 text-orange-700">
+              Adventurer Command Center
+            </Badge>
+            <div>
+              <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">
+                Welcome back, {user?.name || session.user.name || 'Adventurer'}.
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-600 sm:text-base">
+                You are {leaderboardPosition} of {totalAdventurers} on the guild board. Keep momentum,
+                ship quests, and lock in your next rank.
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground mt-1">
-              {user?.skillPoints ?? 0} skill points
-            </p>
-          </CardContent>
-        </Card>
-      </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="guild-chip">{specialization}</span>
+              <span className="guild-chip">Level {level}</span>
+              <span className="guild-chip">{user?.adventurerProfile?.currentStreak ?? 0} day streak</span>
+            </div>
+          </div>
 
-      {/* Active Quests */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
-        <Card className="col-span-4">
+          <div className="flex w-full max-w-md flex-col gap-3 rounded-2xl border border-slate-200 bg-white/90 p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <RankBadge rank={rank} size="sm" />
+                <p className="text-sm font-semibold text-slate-700">{rank}-Rank progression</p>
+              </div>
+              <p className="text-sm font-semibold text-slate-900">{xp.toLocaleString()} XP</p>
+            </div>
+            <Progress value={progress} className="h-2.5" />
+            <p className="text-xs text-slate-600">
+              {nextEntry
+                ? `${xpToNext.toLocaleString()} XP to ${nextEntry.rank}-Rank`
+                : 'You reached S-Rank. Maintain your lead.'}
+            </p>
+            <div className="flex gap-2 pt-1">
+              <Button className="flex-1" asChild>
+                <Link href="/dashboard/quests">
+                  Discover Quests
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button variant="outline" className="flex-1" asChild>
+                <Link href="/dashboard/leaderboard">View Leaderboard</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className="guild-kpi">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Current Rank</p>
+          <div className="mt-2 flex items-center gap-2">
+            <RankBadge rank={rank} size="sm" />
+            <p className="text-xl font-bold text-slate-900">{rank}-Rank</p>
+          </div>
+          <p className="mt-2 text-xs text-slate-500">{user?.skillPoints ?? 0} skill points available</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">XP Total</p>
+            <Zap className="h-4 w-4 text-amber-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{xp.toLocaleString()}</p>
+          <p className="mt-1 text-xs text-slate-500">
+            {nextEntry ? `${xpToNext.toLocaleString()} XP to ${nextEntry.rank}` : 'Top tier achieved'}
+          </p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active Pipeline</p>
+            <Target className="h-4 w-4 text-sky-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{activeAssignments.length}</p>
+          <p className="mt-1 text-xs text-slate-500">{reviewCount} waiting for review</p>
+        </article>
+
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Completed Quests</p>
+            <Trophy className="h-4 w-4 text-emerald-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{completedCount}</p>
+          <p className="mt-1 flex items-center gap-1 text-xs text-slate-500">
+            <Flame className="h-3.5 w-3.5 text-orange-500" />
+            {user?.adventurerProfile?.questCompletionRate?.toString() ?? '0.00'}% completion rate
+          </p>
+        </article>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <Card className="guild-panel xl:col-span-2">
           <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Active Quests</CardTitle>
+            <div>
+              <CardTitle>Current Quest Pipeline</CardTitle>
+              <CardDescription>Assignments already in your queue</CardDescription>
+            </div>
             <Button variant="ghost" size="sm" asChild>
               <Link href="/dashboard/my-quests">View all</Link>
             </Button>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-3">
             {activeAssignments.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-[200px] text-muted-foreground border-2 border-dashed rounded-lg gap-3">
+              <div className="flex h-[200px] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-slate-300 text-slate-500">
                 <p>No active quests yet.</p>
                 <Button size="sm" asChild>
                   <Link href="/dashboard/quests">Browse Quest Board</Link>
                 </Button>
               </div>
             ) : (
-              <div className="space-y-3">
-                {activeAssignments.map((a) => (
-                  <Link
-                    key={a.id}
-                    href={`/dashboard/quests/${a.quest.id}`}
-                    className="flex items-center justify-between p-3 rounded-lg border hover:bg-accent transition-colors"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium truncate">{a.quest.title}</p>
-                      <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
-                        <span className="flex items-center gap-1">
-                          <Zap className="h-3 w-3" />{a.quest.xpReward} XP
+              activeAssignments.map((assignment) => (
+                <Link
+                  key={assignment.id}
+                  href={`/dashboard/quests/${assignment.quest.id}`}
+                  className="guild-list-item flex items-start justify-between gap-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-semibold text-slate-900">{assignment.quest.title}</p>
+                    <p className="mt-0.5 text-xs text-slate-500">
+                      {assignment.quest.company?.name || 'Unknown Company'}
+                    </p>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                      <span className="flex items-center gap-1">
+                        <Zap className="h-3 w-3 text-amber-500" />
+                        {assignment.quest.xpReward} XP
+                      </span>
+                      <span>{assignment.quest.skillPointsReward} SP</span>
+                      {assignment.quest.monetaryReward && (
+                        <span className="font-medium text-emerald-600">
+                          ${Number(assignment.quest.monetaryReward)}
                         </span>
-                        {a.quest.monetaryReward && (
-                          <span>${Number(a.quest.monetaryReward)}</span>
-                        )}
-                        {a.quest.deadline && (
-                          <span className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {new Date(a.quest.deadline).toLocaleDateString()}
-                          </span>
-                        )}
-                      </div>
+                      )}
+                      {assignment.quest.deadline && (
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {new Date(assignment.quest.deadline).toLocaleDateString()}
+                        </span>
+                      )}
                     </div>
-                    <Badge variant="secondary" className="ml-3 capitalize shrink-0">
-                      {a.status.replace("_", " ")}
-                    </Badge>
-                  </Link>
-                ))}
-              </div>
+                  </div>
+                  <Badge variant="secondary" className="shrink-0 capitalize">
+                    {assignment.status.replace('_', ' ')}
+                  </Badge>
+                </Link>
+              ))
             )}
           </CardContent>
         </Card>
 
-        <Card className="col-span-3">
+        <Card className="guild-panel">
           <CardHeader>
-            <CardTitle>Quick Links</CardTitle>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5 text-orange-500" />
+              Ranking Snapshot
+            </CardTitle>
+            <CardDescription>Your standing in the guild right now</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-2">
-            <Button variant="outline" className="w-full justify-start" asChild>
-              <Link href="/dashboard/quests">Quest Board</Link>
-            </Button>
-            <Button variant="outline" className="w-full justify-start" asChild>
-              <Link href="/dashboard/my-quests">My Quests</Link>
-            </Button>
-            <Button variant="outline" className="w-full justify-start" asChild>
-              <Link href="/dashboard/leaderboard">Leaderboard</Link>
-            </Button>
-            <Button variant="outline" className="w-full justify-start" asChild>
-              <Link href="/dashboard/profile">Profile</Link>
+          <CardContent className="space-y-4">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Guild Position</p>
+              <p className="mt-1 text-2xl font-bold text-slate-900">
+                #{leaderboardPosition}
+                <span className="ml-1 text-sm font-medium text-slate-500">/ {totalAdventurers}</span>
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Career Focus</p>
+              <p className="mt-1 text-sm font-semibold text-slate-800">{specialization}</p>
+              <p className="mt-2 text-xs text-slate-500">
+                {user?.adventurerProfile?.totalQuestsCompleted ?? completedCount} total quests completed
+              </p>
+            </div>
+            <Button variant="outline" className="w-full justify-between" asChild>
+              <Link href="/dashboard/leaderboard">
+                Open Full Leaderboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
             </Button>
           </CardContent>
         </Card>
-      </div>
+      </section>
+
+      <section className="guild-panel">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-sky-500" />
+              Recommended Quests For You
+            </CardTitle>
+            <CardDescription>Matches based on your current rank and progression</CardDescription>
+          </div>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/dashboard/quests">Open Quest Board</Link>
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {recommendedQuests.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-slate-300 p-8 text-center text-sm text-slate-500">
+              No matching quests yet. Check back soon for new opportunities.
+            </div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              {recommendedQuests.map((quest) => (
+                <Link
+                  key={quest.id}
+                  href={`/dashboard/quests/${quest.id}`}
+                  className="rounded-xl border border-slate-200 bg-white p-4 transition-all hover:-translate-y-0.5 hover:shadow-md"
+                >
+                  <div className="flex items-center justify-between">
+                    <Badge variant="outline">{quest.difficulty}-Rank</Badge>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      {quest.questCategory}
+                    </span>
+                  </div>
+                  <h3 className="mt-3 line-clamp-2 text-sm font-semibold text-slate-900">{quest.title}</h3>
+                  <p className="mt-1 text-xs text-slate-500">{quest.company?.name || 'Unknown Company'}</p>
+                  <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                    <span>{quest.xpReward} XP</span>
+                    <span>{quest.skillPointsReward} SP</span>
+                    {quest.monetaryReward && (
+                      <span className="font-semibold text-emerald-600">${Number(quest.monetaryReward)}</span>
+                    )}
+                  </div>
+                  {quest.requiredSkills.length > 0 && (
+                    <p className="mt-2 line-clamp-1 text-xs text-slate-500">
+                      {quest.requiredSkills.slice(0, 3).join(' · ')}
+                    </p>
+                  )}
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </section>
     </div>
   );
 }

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -32,7 +32,7 @@ interface Quest {
   companyId: string;
   createdAt: string;
   deadline?: string;
-  users: {
+  company?: {
     name: string;
     email: string;
   };
@@ -88,7 +88,12 @@ export default function QuestDetailPage() {
           return;
         }
 
-        setQuest(questData.quests[0] || questData.quest);
+        const normalizedQuest = questData.quest ?? questData.quests?.[0] ?? null;
+        if (!normalizedQuest) {
+          setError('Quest details not found');
+          return;
+        }
+        setQuest(normalizedQuest);
 
         // Fetch user's assignment for this quest
         if (session?.user?.id) {
@@ -239,7 +244,7 @@ export default function QuestDetailPage() {
                 <Badge variant="outline">{quest.difficulty}-Rank</Badge>
               </div>
               <CardDescription>
-                Posted by {quest.users?.name || 'Unknown Company'}
+                Posted by {quest.company?.name || 'Unknown Company'}
               </CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/app/dashboard/quests/page.tsx
+++ b/app/dashboard/quests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -8,7 +8,16 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle, Target, Zap, Users, Clock, Search, ExternalLink } from 'lucide-react';
+import {
+  AlertCircle,
+  ArrowRight,
+  Clock,
+  Search,
+  Sparkles,
+  Target,
+  Trophy,
+  Zap,
+} from 'lucide-react';
 import Link from 'next/link';
 
 interface Quest {
@@ -28,7 +37,7 @@ interface Quest {
   companyId: string;
   createdAt: string;
   deadline?: string;
-  users: {
+  company?: {
     name: string;
     email: string;
   };
@@ -49,7 +58,6 @@ export default function QuestsPage() {
     }
 
     if (status === 'authenticated' && session?.user?.role === 'company') {
-      // Companies shouldn't access this page
       router.push('/dashboard/company');
       return;
     }
@@ -59,7 +67,7 @@ export default function QuestsPage() {
         setLoading(true);
         setError(null);
 
-        const response = await fetch('/api/quests?status=available');
+        const response = await fetch('/api/quests?status=available&limit=60');
         const data = await response.json();
 
         if (!data.success) {
@@ -67,7 +75,7 @@ export default function QuestsPage() {
           return;
         }
 
-        setQuests(data.quests || data.quest);
+        setQuests(data.quests || []);
       } catch (err) {
         console.error('Error fetching quests:', err);
         setError('An error occurred while fetching quests');
@@ -81,24 +89,36 @@ export default function QuestsPage() {
     }
   }, [status, session, router]);
 
-  const filteredQuests = quests.filter(quest =>
-    quest.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.questCategory.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    quest.requiredSkills.some(skill => skill.toLowerCase().includes(searchTerm.toLowerCase()))
+  const filteredQuests = useMemo(
+    () =>
+      quests.filter((quest) =>
+        [
+          quest.title,
+          quest.description,
+          quest.questCategory,
+          ...(quest.requiredSkills || []),
+          quest.company?.name || '',
+        ]
+          .join(' ')
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())
+      ),
+    [quests, searchTerm]
   );
 
   if (status === 'loading' || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+      <div className="guild-page">
+        <div className="guild-panel flex min-h-[320px] items-center justify-center">
+          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-primary" />
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="container mx-auto py-6">
+      <div className="guild-page">
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{error}</AlertDescription>
@@ -107,120 +127,150 @@ export default function QuestsPage() {
     );
   }
 
-  return (
-    <div className="container mx-auto py-6 max-w-6xl">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold">Available Quests</h1>
-        <p className="text-muted-foreground mt-1">
-          Browse and accept quests to earn XP, skill points, and real-world experience
-        </p>
-      </div>
+  const highRewardCount = filteredQuests.filter((quest) => quest.xpReward >= 1500).length;
 
-      <div className="mb-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-            <Input
-              placeholder="Search quests by title, category, or required skills..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10"
-            />
+  return (
+    <div className="guild-page">
+      <section className="guild-hero">
+        <div className="relative z-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="rounded-full border border-emerald-300 bg-emerald-100 text-emerald-700">
+              Quest Marketplace
+            </Badge>
+            <h1 className="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Available Quests</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600 sm:text-base">
+              Browse live company projects, match your rank, and choose your next challenge.
+            </p>
           </div>
-          <Button onClick={() => router.push('/dashboard')}>
-            ← Back to Dashboard
+          <Button variant="outline" asChild>
+            <Link href="/dashboard">
+              Back to Dashboard
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </Button>
         </div>
-      </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className="guild-kpi sm:col-span-2 xl:col-span-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Open Quests</p>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{filteredQuests.length}</p>
+          <p className="mt-1 text-xs text-slate-500">Matching your current search</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">High XP Quests</p>
+            <Zap className="h-4 w-4 text-amber-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">{highRewardCount}</p>
+          <p className="mt-1 text-xs text-slate-500">1500 XP and above</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Newly Posted</p>
+            <Sparkles className="h-4 w-4 text-violet-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">
+            {filteredQuests.filter((quest) => Date.now() - new Date(quest.createdAt).getTime() <= 1000 * 60 * 60 * 24 * 7).length}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Posted in last 7 days</p>
+        </article>
+        <article className="guild-kpi">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Quest Types</p>
+            <Trophy className="h-4 w-4 text-sky-500" />
+          </div>
+          <p className="mt-2 text-2xl font-bold text-slate-900">
+            {new Set(filteredQuests.map((quest) => quest.questType)).size}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Distinct categories</p>
+        </article>
+      </section>
+
+      <section className="guild-panel p-4 sm:p-5">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="Search by title, category, skills, or company"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </section>
 
       {filteredQuests.length === 0 ? (
-        <div className="text-center py-12">
-          <Target className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
-          <h3 className="text-xl font-medium mb-2">No quests available</h3>
-          <p className="text-muted-foreground mb-4">
-            Check back later for new quests or filter your search
-          </p>
-          <Button onClick={() => setSearchTerm('')}>
-            Clear Search
-          </Button>
-        </div>
+        <section className="guild-panel p-12 text-center">
+          <Target className="mx-auto mb-4 h-14 w-14 text-slate-400" />
+          <h3 className="text-xl font-semibold text-slate-900">No quests found</h3>
+          <p className="mt-2 text-sm text-slate-500">Try adjusting your filters or search terms.</p>
+          <Button className="mt-4" onClick={() => setSearchTerm('')}>Clear Search</Button>
+        </section>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredQuests.map((quest) => (
-            <Card key={quest.id} className="flex flex-col h-full">
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div>
-                    <CardTitle className="text-xl">{quest.title}</CardTitle>
-                    <CardDescription>
-                      Posted by {quest.users?.name || 'Unknown Company'}
+            <Card key={quest.id} className="guild-panel border-slate-200/80">
+              <CardHeader className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <CardTitle className="line-clamp-2 text-lg">{quest.title}</CardTitle>
+                    <CardDescription className="mt-1 truncate">
+                      Posted by {quest.company?.name || 'Unknown Company'}
                     </CardDescription>
                   </div>
                   <Badge variant="outline">{quest.difficulty}-Rank</Badge>
                 </div>
-                <div className="flex flex-wrap gap-2 mt-2">
-                  <Badge variant="secondary">{quest.questCategory}</Badge>
-                  <Badge variant="outline">{quest.questType}</Badge>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary" className="capitalize">{quest.questCategory}</Badge>
+                  <Badge variant="outline" className="capitalize">{quest.questType.replace('_', ' ')}</Badge>
                 </div>
               </CardHeader>
-              <CardContent className="flex flex-col flex-grow">
-                <p className="text-muted-foreground mb-4 line-clamp-2">
-                  {quest.description}
-                </p>
-                
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div className="flex items-center">
-                    <Zap className="w-4 h-4 mr-2 text-yellow-500" />
-                    <span className="text-sm">{quest.xpReward} XP</span>
+              <CardContent>
+                <p className="line-clamp-2 text-sm text-slate-600">{quest.description}</p>
+
+                <div className="mt-4 grid grid-cols-2 gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs">
+                  <div className="flex items-center gap-1 text-slate-700">
+                    <Zap className="h-3.5 w-3.5 text-amber-500" />
+                    {quest.xpReward} XP
                   </div>
-                  <div className="flex items-center">
-                    <Target className="w-4 h-4 mr-2 text-blue-500" />
-                    <span className="text-sm">{quest.skillPointsReward} SP</span>
-                  </div>
+                  <div className="text-slate-700">{quest.skillPointsReward} SP</div>
                   {quest.monetaryReward && (
-                    <div className="flex items-center col-span-2">
-                      <span className="text-sm font-medium">${quest.monetaryReward}</span>
+                    <div className="col-span-2 font-semibold text-emerald-600">
+                      ${Number(quest.monetaryReward)} reward
                     </div>
                   )}
                 </div>
-                
-                {quest.requiredSkills && quest.requiredSkills.length > 0 && (
-                  <div className="mb-4">
-                    <p className="text-xs text-muted-foreground mb-1">Required Skills</p>
-                    <div className="flex flex-wrap gap-1">
-                      {quest.requiredSkills.slice(0, 3).map((skill, index) => (
-                        <Badge key={index} variant="outline" className="text-xs">
-                          {skill}
-                        </Badge>
-                      ))}
-                      {quest.requiredSkills.length > 3 && (
-                        <Badge variant="outline" className="text-xs">
-                          +{quest.requiredSkills.length - 3} more
-                        </Badge>
-                      )}
-                    </div>
+
+                {quest.requiredSkills?.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-1.5">
+                    {quest.requiredSkills.slice(0, 3).map((skill) => (
+                      <Badge key={`${quest.id}-${skill}`} variant="outline" className="text-[11px]">
+                        {skill}
+                      </Badge>
+                    ))}
+                    {quest.requiredSkills.length > 3 && (
+                      <Badge variant="outline" className="text-[11px]">+{quest.requiredSkills.length - 3}</Badge>
+                    )}
                   </div>
                 )}
-                
+
                 {quest.deadline && (
-                  <div className="flex items-center text-sm text-muted-foreground mb-4">
-                    <Clock className="w-4 h-4 mr-2" />
-                    <span>Due: {new Date(quest.deadline).toLocaleDateString()}</span>
+                  <div className="mt-4 flex items-center gap-1 text-xs text-slate-500">
+                    <Clock className="h-3.5 w-3.5" />
+                    Due {new Date(quest.deadline).toLocaleDateString()}
                   </div>
                 )}
-                
-                <div className="mt-auto">
-                  <Link href={`/dashboard/quests/${quest.id}`} className="w-full">
-                    <Button className="w-full">
-                      View Quest Details
-                      <ExternalLink className="w-4 h-4 ml-2" />
-                    </Button>
+
+                <Button className="mt-4 w-full" asChild>
+                  <Link href={`/dashboard/quests/${quest.id}`}>
+                    View Quest Details
+                    <ArrowRight className="h-4 w-4" />
                   </Link>
-                </div>
+                </Button>
               </CardContent>
             </Card>
           ))}
-        </div>
+        </section>
       )}
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -90,6 +90,63 @@
   .section-alt {
     @apply bg-slate-50/60;
   }
+
+  .guild-page {
+    @apply mx-auto w-full max-w-7xl space-y-6;
+  }
+
+  .guild-hero {
+    @apply relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-[0_20px_40px_-30px_rgba(15,23,42,0.45)] sm:p-8;
+  }
+
+  .guild-panel {
+    @apply rounded-2xl border border-slate-200/80 bg-white/95 shadow-[0_20px_40px_-34px_rgba(15,23,42,0.55)];
+  }
+
+  .guild-kpi {
+    @apply rounded-xl border border-slate-200/80 bg-white p-4 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.7)];
+  }
+
+  .guild-chip {
+    @apply inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600;
+  }
+
+  .guild-list-item {
+    @apply rounded-xl border border-slate-200/80 bg-white/90 p-3 transition-colors hover:bg-slate-50;
+  }
+}
+
+.guild-shell {
+  position: relative;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(251, 146, 60, 0.18), transparent 34%),
+    radial-gradient(circle at 90% 0%, rgba(14, 165, 233, 0.14), transparent 28%),
+    linear-gradient(180deg, #f8fafc 0%, #f8fafc 42%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
+.guild-hero::before {
+  content: "";
+  position: absolute;
+  right: -90px;
+  top: -110px;
+  width: 260px;
+  height: 260px;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.2) 0%, rgba(249, 115, 22, 0) 72%);
+  pointer-events: none;
+}
+
+.guild-hero::after {
+  content: "";
+  position: absolute;
+  left: -80px;
+  bottom: -120px;
+  width: 240px;
+  height: 240px;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.14) 0%, rgba(59, 130, 246, 0) 72%);
+  pointer-events: none;
 }
 
 /* Scrollbar */

--- a/components/PaymentProcessor.tsx
+++ b/components/PaymentProcessor.tsx
@@ -54,16 +54,19 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
 
         const response = await fetch(`/api/quests/${questId}`);
         const data = await response.json();
+        const questData = data.quest ?? data.quests?.[0];
 
-        if (!data.success || !data.quests?.[0]) {
+        if (!data.success || !questData) {
           setError(data.error || 'Failed to fetch quest');
           return;
         }
-
-        const questData = data.quests[0];
         
         // Verify user has permission to pay for this quest
-        if (session?.user?.role !== 'admin' && questData.company_id !== session?.user?.id) {
+        if (
+          session?.user?.role !== 'admin' &&
+          questData.companyId !== session?.user?.id &&
+          questData.company_id !== session?.user?.id
+        ) {
           setError('Unauthorized to make payment for this quest');
           return;
         }

--- a/lib/rank-utils.ts
+++ b/lib/rank-utils.ts
@@ -1,5 +1,14 @@
-export async function fetchRankings(params: { sort?: string; order?: string; limit?: string; rank?: string }) {
+export async function fetchRankings(params: {
+  mode?: 'adventurer' | 'company';
+  sort?: string;
+  order?: string;
+  limit?: string;
+  rank?: string;
+}) {
   const searchParams = new URLSearchParams();
+  if (params.mode) searchParams.append('mode', params.mode);
+  if (params.sort) searchParams.append('sort', params.sort);
+  if (params.order) searchParams.append('order', params.order);
   if (params.limit) searchParams.append('limit', params.limit);
   if (params.rank) searchParams.append('rank', params.rank);
   
@@ -8,8 +17,16 @@ export async function fetchRankings(params: { sort?: string; order?: string; lim
   return data.rankings || [];
 }
 
-export async function getUserRank(userId: string) {
-  const res = await fetch(`/api/rankings/user?userId=${userId}`);
+export async function getUserRank(
+  userId: string,
+  params?: { mode?: 'adventurer' | 'company'; sort?: string; order?: string }
+) {
+  const searchParams = new URLSearchParams({ userId });
+  if (params?.mode) searchParams.append('mode', params.mode);
+  if (params?.sort) searchParams.append('sort', params.sort);
+  if (params?.order) searchParams.append('order', params.order);
+
+  const res = await fetch(`/api/rankings/user?${searchParams.toString()}`);
   const data = await res.json();
   return data.rank || null;
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Adventurers Guild",
+  "short_name": "Adventurers",
+  "description": "Take on real coding quests from companies, earn rewards, and rank up from F to S.",
+  "start_url": "/home",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#f97316",
+  "icons": [
+    {
+      "src": "/pwa/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/pwa/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/pwa/icon-192x192.svg
+++ b/public/pwa/icon-192x192.svg
@@ -1,0 +1,12 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="20" y1="20" x2="172" y2="172" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FB923C"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="42" fill="#0F172A"/>
+  <rect x="20" y="20" width="152" height="152" rx="34" fill="url(#bg)"/>
+  <path d="M69 131V61H93.5C107.2 61 116 69.8 116 82C116 94.2 107.2 103 93.5 103H82.5V131H69ZM82.5 91H92.5C97.6 91 102 87.4 102 82C102 76.6 97.6 73 92.5 73H82.5V91Z" fill="#0B1120"/>
+  <path d="M125 131L106 61H119.5L131 110L142.5 61H156L137 131H125Z" fill="#0B1120"/>
+</svg>

--- a/public/pwa/icon-512x512.svg
+++ b/public/pwa/icon-512x512.svg
@@ -1,0 +1,12 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="52" y1="52" x2="460" y2="460" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FB923C"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#0F172A"/>
+  <rect x="52" y="52" width="408" height="408" rx="92" fill="url(#bg)"/>
+  <path d="M183 349V163H248.5C286.4 163 311 187.4 311 219C311 250.6 286.4 275 248.5 275H219V349H183ZM219 243H245.5C261.4 243 275 231.8 275 219C275 206.2 261.4 195 245.5 195H219V243Z" fill="#0B1120"/>
+  <path d="M335 349L284 163H320.5L351.5 293L382.5 163H419L368 349H335Z" fill="#0B1120"/>
+</svg>


### PR DESCRIPTION
## Summary
- fix adventurer quest-detail runtime crash caused by `questData.quests[0]` access when API returns `{ quest }`
- normalize quest payload handling in payment flow for both legacy/new response shapes
- add missing PWA manifest and icons to remove `/pwa/icon-192x192.svg` 404s
- implement role-separated dashboard experiences (adventurer vs company) with centralized dashboard shell refresh
- add company and adventurer ranking APIs and user-position endpoint (`/api/rankings`, `/api/rankings/user`)
- redesign leaderboard to support both adventurer and company ranking modes
- refresh quest board pages to match new dashboard design and data contracts

## User-visible fixes
- opening a company-posted quest from adventurer quest board no longer shows "An error occurred while fetching quest details"
- no more PWA icon 404 spam for `/pwa/icon-192x192.svg`
- clearer separation of company/adventurer dashboards and ranking visibility on both sides

## Validation
- `npm run build`
- `npm run type-check`
- browser smoke: login -> `/dashboard/quests` -> open quest detail (no fetch crash)
- API smoke: `/api/rankings`, `/api/rankings?mode=company`, `/api/rankings/user`
