### PR TITLE
Fix auth/quest flows, harden APIs, and stabilize CI type-check

### DIFF
--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -92,6 +92,20 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    if (
+      typeof body.from_userId !== 'string' ||
+      typeof body.to_userId !== 'string' ||
+      typeof body.questId !== 'string' ||
+      !body.from_userId.trim() ||
+      !body.to_userId.trim() ||
+      !body.questId.trim()
+    ) {
+      return Response.json(
+        { error: 'from_userId, to_userId, and questId must be non-empty strings', success: false },
+        { status: 400 }
+      );
+    }
+
     if (authUser.role !== 'admin' && body.from_userId !== authUser.id) {
       return Response.json(
         { error: 'You can only initiate payments from your own account', success: false },
@@ -121,7 +135,7 @@ export async function POST(request: NextRequest) {
     // Verify that the quest exists and is completed
     const quest = await prisma.quest.findUnique({
       where: { id: body.questId },
-      select: { title: true, status: true, xpReward: true, skillPointsReward: true },
+      select: { title: true, status: true, xpReward: true, skillPointsReward: true, companyId: true },
     });
 
     if (!quest) {
@@ -130,6 +144,50 @@ export async function POST(request: NextRequest) {
 
     if (quest.status !== 'completed') {
       return Response.json({ error: 'Quest must be completed before payment', success: false }, { status: 400 });
+    }
+
+    if (!quest.companyId) {
+      return Response.json({ error: 'Quest is not linked to a company', success: false }, { status: 400 });
+    }
+
+    if (authUser.role !== 'admin' && quest.companyId !== authUser.id) {
+      return Response.json(
+        { error: 'You can only pay for your own quests', success: false },
+        { status: 403 }
+      );
+    }
+
+    if (authUser.role !== 'admin' && body.from_userId !== quest.companyId) {
+      return Response.json(
+        { error: 'from_userId must match the quest owner', success: false },
+        { status: 403 }
+      );
+    }
+
+    const recipient = await prisma.user.findUnique({
+      where: { id: body.to_userId },
+      select: { role: true, isActive: true },
+    });
+
+    if (!recipient || !recipient.isActive || recipient.role !== 'adventurer') {
+      return Response.json({ error: 'Invalid adventurer account', success: false }, { status: 400 });
+    }
+
+    const completionRecord = await prisma.questCompletion.findUnique({
+      where: {
+        questId_userId: {
+          questId: body.questId,
+          userId: body.to_userId,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (!completionRecord) {
+      return Response.json(
+        { error: 'Selected adventurer has not completed this quest', success: false },
+        { status: 400 }
+      );
     }
 
     // Check if a payment already exists for this quest

--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { requireAuth } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 const VALID_REVIEW_STATUSES = ['pending', 'under_review', 'approved', 'needs_rework', 'rejected'] as const;
 type ReviewStatus = (typeof VALID_REVIEW_STATUSES)[number];
@@ -200,12 +201,14 @@ export async function POST(request: NextRequest) {
         quest.skillPointsReward
       );
     }
-    else if (status === 'needs_rework') {
+    else if (status === 'needs_rework' || status === 'rejected') {
       await prisma.questAssignment.update({
         where: { id: existingSubmission.assignmentId },
         data: { status: 'in_progress' },
       });
     }
+
+    await syncQuestLifecycleStatus(prisma, existingSubmission.assignment.questId);
 
     return Response.json({ submission: data, success: true });
   } catch (error) {

--- a/app/api/quests/[id]/assignments/route.ts
+++ b/app/api/quests/[id]/assignments/route.ts
@@ -3,12 +3,14 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { AssignmentStatus } from '@prisma/client';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 // GET /api/quests/[id]/assignments — list all assignments for a quest (company/admin only)
 export async function GET(
   req: NextRequest,
   props: { params: Promise<{ id: string }> }
 ) {
+  void req;
   const params = await props.params;
   const session = await getServerSession(authOptions);
   if (!session?.user) {
@@ -93,32 +95,37 @@ export async function PUT(
       return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 403 });
     }
 
+    const existingAssignment = await prisma.questAssignment.findUnique({
+      where: { id: assignmentId },
+      select: { questId: true, status: true },
+    });
+
+    if (!existingAssignment || existingAssignment.questId !== params.id) {
+      return NextResponse.json({ error: 'Assignment not found for this quest', success: false }, { status: 404 });
+    }
+
+    if (existingAssignment.status !== 'assigned') {
+      return NextResponse.json(
+        { error: 'Only pending applicants can be accepted or rejected', success: false },
+        { status: 400 }
+      );
+    }
+
     // Map frontend status to DB enum
     const newStatus: AssignmentStatus = status === 'accepted' ? 'started' : 'cancelled';
 
-    const updated = await prisma.questAssignment.update({
-      where: { id: assignmentId },
-      data: {
-        status: newStatus,
-        ...(newStatus === 'started' ? { startedAt: new Date() } : {}),
-      },
-    });
-
-    // If rejected and no other active assignments, revert quest to available
-    if (newStatus === 'cancelled') {
-      const active = await prisma.questAssignment.count({
-        where: {
-          questId: params.id,
-          status: { notIn: ['cancelled', 'completed'] },
+    const updated = await prisma.$transaction(async (tx) => {
+      const assignment = await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: {
+          status: newStatus,
+          ...(newStatus === 'started' ? { startedAt: new Date() } : {}),
         },
       });
-      if (active === 0) {
-        await prisma.quest.update({
-          where: { id: params.id },
-          data: { status: 'available' },
-        });
-      }
-    }
+
+      await syncQuestLifecycleStatus(tx, params.id);
+      return assignment;
+    });
 
     return NextResponse.json({ assignment: updated, success: true });
   } catch (error) {

--- a/app/api/quests/[id]/route.ts
+++ b/app/api/quests/[id]/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/db';
+import { authOptions } from '@/lib/auth';
 
 export async function GET(
   req: NextRequest,
   props: { params: Promise<{ id: string }> }
 ) {
+  void req;
   const params = await props.params;
+  const session = await getServerSession(authOptions);
+
   try {
     const quest = await prisma.quest.findUnique({
       where: { id: params.id },
@@ -26,11 +31,12 @@ export async function GET(
                 name: true,
                 avatar: true,
                 rank: true,
-                xp: true
-              }
-            }
-          }
-        }
+                xp: true,
+                email: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -38,8 +44,43 @@ export async function GET(
       return NextResponse.json({ success: false, error: 'Quest not found' }, { status: 404 });
     }
 
-    return NextResponse.json({ success: true, quest });
+    const isAdmin = session?.user?.role === 'admin';
+    const isOwner =
+      session?.user?.role === 'company' &&
+      !!quest.companyId &&
+      session.user.id === quest.companyId;
+    const userId = session?.user?.id;
+
+    const assignments =
+      isAdmin || isOwner
+        ? quest.assignments
+        : userId
+          ? quest.assignments.filter((assignment) => assignment.userId === userId)
+          : [];
+
+    const sanitizedCompany = isAdmin || isOwner
+      ? quest.company
+      : quest.company
+        ? {
+            id: quest.company.id,
+            name: quest.company.name,
+            avatar: quest.company.avatar,
+          }
+        : null;
+
+    const normalizedQuest = {
+      ...quest,
+      company: sanitizedCompany,
+      assignments,
+    };
+
+    return NextResponse.json({
+      success: true,
+      quest: normalizedQuest,
+      quests: [normalizedQuest],
+    });
   } catch (error) {
+    console.error('Error fetching quest:', error);
     return NextResponse.json({ success: false, error: 'Failed to fetch quest' }, { status: 500 });
   }
 }

--- a/app/api/quests/assignments/route.ts
+++ b/app/api/quests/assignments/route.ts
@@ -3,7 +3,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
-import { Prisma } from '@prisma/client';
+import { AssignmentStatus, Prisma } from '@prisma/client';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 export async function GET(request: NextRequest) {
   // Check authentication
@@ -25,20 +26,14 @@ export async function GET(request: NextRequest) {
     const currentUserRole = session.user.role;
 
     // Build where clause based on permissions
-    const where: Record<string, unknown> = {};
+    const where: Prisma.QuestAssignmentWhereInput = {};
 
     if (currentUserRole === 'adventurer') {
       // Adventurers can only see their own assignments
       where.userId = currentUserId;
     } else if (currentUserRole === 'company') {
       // Companies can see assignments for their quests
-      const companyQuests = await prisma.quest.findMany({
-        where: { companyId: currentUserId },
-        select: { id: true },
-      });
-
-      const questIds = companyQuests.map((q) => q.id);
-      where.questId = { in: questIds };
+      where.quest = { companyId: currentUserId };
     } else if (currentUserRole === 'admin') {
       // Admins can see all assignments - no additional filter needed
     } else {
@@ -55,7 +50,19 @@ export async function GET(request: NextRequest) {
       where.questId = questId;
     }
     if (status) {
-      where.status = status;
+      const validStatuses: AssignmentStatus[] = [
+        'assigned',
+        'started',
+        'in_progress',
+        'submitted',
+        'review',
+        'completed',
+        'cancelled',
+      ];
+      if (!validStatuses.includes(status as AssignmentStatus)) {
+        return NextResponse.json({ error: 'Invalid status filter', success: false }, { status: 400 });
+      }
+      where.status = status as AssignmentStatus;
     }
 
     const assignments = await prisma.questAssignment.findMany({
@@ -93,6 +100,13 @@ export async function POST(request: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session || !session.user) {
     return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  if (session.user.role !== 'adventurer' && session.user.role !== 'admin') {
+    return NextResponse.json(
+      { error: 'Only adventurers can apply to quests', success: false },
+      { status: 403 }
+    );
   }
 
   try {
@@ -142,21 +156,18 @@ export async function POST(request: NextRequest) {
     }
 
     // Create the assignment
-    const assignment = await prisma.questAssignment.create({
-      data: {
-        questId: questId,
-        userId,
-        status: 'assigned',
-      },
-    });
-
-    // Update the quest status to 'in_progress' if it's the first assignment
-    if (quest.maxParticipants === 1 || !quest.maxParticipants) {
-      await prisma.quest.update({
-        where: { id: questId },
-        data: { status: 'in_progress' },
+    const assignment = await prisma.$transaction(async (tx) => {
+      const created = await tx.questAssignment.create({
+        data: {
+          questId: questId,
+          userId,
+          status: 'assigned',
+        },
       });
-    }
+
+      await syncQuestLifecycleStatus(tx, questId);
+      return created;
+    });
 
     return NextResponse.json({ assignment, success: true }, { status: 201 });
   } catch (error) {
@@ -182,11 +193,28 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Missing required fields', success: false }, { status: 400 });
     }
 
+    const requestedStatus = status as AssignmentStatus;
+    const adminStatuses: AssignmentStatus[] = [
+      'assigned',
+      'started',
+      'in_progress',
+      'submitted',
+      'review',
+      'completed',
+      'cancelled',
+    ];
+    const adventurerStatuses: AssignmentStatus[] = ['started', 'in_progress'];
+    const allowedStatuses = session.user.role === 'admin' ? adminStatuses : adventurerStatuses;
+
+    if (!allowedStatuses.includes(requestedStatus)) {
+      return NextResponse.json({ error: 'Invalid assignment status transition', success: false }, { status: 400 });
+    }
+
     // Check if the user has permission to update this assignment
     // Only the assigned user or an admin can update the assignment
     const assignment = await prisma.questAssignment.findUnique({
       where: { id: assignmentId },
-      select: { userId: true },
+      select: { userId: true, questId: true },
     });
 
     if (!assignment) {
@@ -198,21 +226,28 @@ export async function PUT(request: NextRequest) {
     }
 
     // Build update data
-    const updateData: Record<string, unknown> = { status };
+    const updateData: Record<string, unknown> = { status: requestedStatus };
     if (progress !== undefined) {
+      if (typeof progress !== 'number' || progress < 0 || progress > 100) {
+        return NextResponse.json({ error: 'progress must be a number between 0 and 100', success: false }, { status: 400 });
+      }
       updateData.progress = progress;
     }
-    if (status === 'started') {
+    if (requestedStatus === 'started') {
       updateData.startedAt = new Date();
     }
-    if (status === 'completed') {
+    if (requestedStatus === 'completed') {
       updateData.completedAt = new Date();
     }
 
-    // Update the assignment
-    const updatedAssignment = await prisma.questAssignment.update({
-      where: { id: assignmentId },
-      data: updateData,
+    const updatedAssignment = await prisma.$transaction(async (tx) => {
+      const updated = await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: updateData,
+      });
+
+      await syncQuestLifecycleStatus(tx, assignment.questId);
+      return updated;
     });
 
     return NextResponse.json({ assignment: updatedAssignment, success: true });

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import { AssignmentStatus } from '@prisma/client';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 export async function GET(request: NextRequest) {
   // Check authentication
@@ -107,7 +108,7 @@ export async function POST(request: NextRequest) {
     // Check if the assignment exists and belongs to the current user
     const assignment = await prisma.questAssignment.findUnique({
       where: { id: assignmentId },
-      select: { status: true, userId: true },
+      select: { status: true, userId: true, questId: true },
     });
 
     if (!assignment) {
@@ -123,20 +124,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid assignment state for submission', success: false }, { status: 400 });
     }
 
-    // Create the submission
-    const data = await prisma.questSubmission.create({
-      data: {
-        assignmentId: assignmentId,
-        userId,
-        submissionContent: submissionContent,
-        submissionNotes: submissionNotes || null,
-      },
-    });
+    const data = await prisma.$transaction(async (tx) => {
+      const submission = await tx.questSubmission.create({
+        data: {
+          assignmentId: assignmentId,
+          userId,
+          submissionContent: submissionContent,
+          submissionNotes: submissionNotes || null,
+        },
+      });
 
-    // Update assignment status to submitted
-    await prisma.questAssignment.update({
-      where: { id: assignmentId },
-      data: { status: 'submitted' },
+      await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: { status: 'submitted' },
+      });
+
+      await syncQuestLifecycleStatus(tx, assignment.questId);
+      return submission;
     });
 
     return NextResponse.json({ submission: data, success: true }, { status: 201 });
@@ -168,7 +172,7 @@ export async function PUT(request: NextRequest) {
     // First get the submission
     const submission = await prisma.questSubmission.findUnique({
       where: { id: submissionId },
-      select: { id: true, assignmentId: true },
+      select: { id: true, assignmentId: true, status: true },
     });
 
     if (!submission) {
@@ -180,6 +184,7 @@ export async function PUT(request: NextRequest) {
       where: { id: submission.assignmentId },
       select: {
         questId: true,
+        userId: true,
         quest: {
           select: {
             companyId: true,
@@ -198,76 +203,91 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized to review this submission', success: false }, { status: 403 });
     }
 
-    // Update the submission
-    const data = await prisma.questSubmission.update({
-      where: { id: submissionId },
-      data: {
-        status,
-        reviewNotes: review_notes || undefined,
-        qualityScore: quality_score || undefined,
-        reviewerId,
-        reviewedAt: status !== 'pending' ? new Date() : undefined,
-      },
-    });
+    const wasAlreadyApproved = submission.status === 'approved';
 
-    // Update assignment status based on submission status
-    let newAssignmentStatus = '';
-    if (status === 'approved') {
-      newAssignmentStatus = 'completed';
-    } else if (status === 'needs_rework' || status === 'rejected') {
-      newAssignmentStatus = 'in_progress'; // Allow rework
-    }
-
-    if (newAssignmentStatus) {
-      await prisma.questAssignment.update({
-        where: { id: submission.assignmentId },
-        data: { status: newAssignmentStatus as AssignmentStatus },
-      });
-    }
-
-    // If the submission was approved, record the quest completion
-    if (status === 'approved' && data.assignmentId) {
-      // Get assignment details to get the quest and user IDs
-      const approvedAssignment = await prisma.questAssignment.findUnique({
-        where: { id: data.assignmentId },
-        select: { questId: true, userId: true },
+    const reviewResult = await prisma.$transaction(async (tx) => {
+      const updatedSubmission = await tx.questSubmission.update({
+        where: { id: submissionId },
+        data: {
+          status,
+          reviewNotes: review_notes || undefined,
+          qualityScore: quality_score || undefined,
+          reviewerId,
+          reviewedAt: status !== 'pending' ? new Date() : undefined,
+        },
       });
 
-      if (!approvedAssignment) {
-        throw new Error('Assignment not found for completion recording');
+      let newAssignmentStatus: AssignmentStatus | null = null;
+      if (status === 'approved') {
+        newAssignmentStatus = 'completed';
+      } else if (status === 'needs_rework' || status === 'rejected') {
+        newAssignmentStatus = 'in_progress';
       }
 
-      // Get quest details to get the rewards
-      const quest = await prisma.quest.findUnique({
-        where: { id: approvedAssignment.questId },
-        select: { xpReward: true, skillPointsReward: true },
-      });
-
-      if (!quest) {
-        throw new Error('Quest not found for completion recording');
-      }
-
-      // Record the quest completion
-      try {
-        await prisma.questCompletion.create({
+      if (newAssignmentStatus) {
+        await tx.questAssignment.update({
+          where: { id: submission.assignmentId },
           data: {
-            questId: approvedAssignment.questId,
-            userId: approvedAssignment.userId,
+            status: newAssignmentStatus,
+            ...(newAssignmentStatus === 'completed' ? { completedAt: new Date() } : {}),
+          },
+        });
+      }
+
+      await syncQuestLifecycleStatus(tx, assignmentData.questId);
+
+      let rewardsPayload: { userId: string; xpReward: number; skillPointsReward: number } | null = null;
+      if (status === 'approved' && !wasAlreadyApproved) {
+        const quest = await tx.quest.findUnique({
+          where: { id: assignmentData.questId },
+          select: { xpReward: true, skillPointsReward: true },
+        });
+
+        if (!quest) {
+          throw new Error('Quest not found for completion recording');
+        }
+
+        await tx.questCompletion.upsert({
+          where: {
+            questId_userId: {
+              questId: assignmentData.questId,
+              userId: assignmentData.userId,
+            },
+          },
+          create: {
+            questId: assignmentData.questId,
+            userId: assignmentData.userId,
+            xpEarned: quest.xpReward,
+            skillPointsEarned: quest.skillPointsReward,
+            qualityScore: quality_score || null,
+          },
+          update: {
             xpEarned: quest.xpReward,
             skillPointsEarned: quest.skillPointsReward,
             qualityScore: quality_score || null,
           },
         });
-      } catch (completionError) {
-        console.error('Error recording quest completion:', completionError);
+
+        rewardsPayload = {
+          userId: assignmentData.userId,
+          xpReward: quest.xpReward,
+          skillPointsReward: quest.skillPointsReward,
+        };
       }
 
-      // Update user XP, level, rank, and skill points
+      return { submission: updatedSubmission, rewardsPayload };
+    });
+
+    if (reviewResult.rewardsPayload) {
       const { updateUserXpAndSkills } = await import('@/lib/xp-utils');
-      await updateUserXpAndSkills(approvedAssignment.userId, quest.xpReward, quest.skillPointsReward);
+      await updateUserXpAndSkills(
+        reviewResult.rewardsPayload.userId,
+        reviewResult.rewardsPayload.xpReward,
+        reviewResult.rewardsPayload.skillPointsReward
+      );
     }
 
-    return NextResponse.json({ submission: data, success: true });
+    return NextResponse.json({ submission: reviewResult.submission, success: true });
   } catch (error) {
     console.error('Error updating quest submission:', error);
     return NextResponse.json({ error: 'Failed to update quest submission', success: false }, { status: 500 });

--- a/app/dashboard/company/quests/[id]/page.tsx
+++ b/app/dashboard/company/quests/[id]/page.tsx
@@ -35,11 +35,11 @@ interface Applicant {
   id: string;
   userId: string;
   status: 'assigned' | 'started' | 'in_progress' | 'submitted' | 'review' | 'completed' | 'cancelled';
-  createdAt: string;
+  assignedAt: string;
   user: {
     name: string;
     email: string;
-    image?: string;
+    avatar?: string;
     rank: string;
     xp: number;
   };
@@ -65,10 +65,16 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
   const [quest, setQuest] = useState<QuestDetails | null>(null);
   const [loading, setLoading] = useState(true);
   const [processingId, setProcessingId] = useState<string | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
 
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/login');
+      return;
+    }
+
+    if (status === 'authenticated' && session?.user?.role !== 'company' && session.user.role !== 'admin') {
+      router.push('/dashboard');
       return;
     }
 
@@ -93,7 +99,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
     if (status === 'authenticated') {
       fetchQuestDetails();
     }
-  }, [id, status, router]);
+  }, [id, status, session, router]);
 
   const handleApplicantAction = async (assignmentId: string, action: 'accepted' | 'rejected') => {
     setProcessingId(assignmentId);
@@ -120,9 +126,37 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
         toast.error(data.error || 'Action failed');
       }
     } catch (error) {
+      console.error('Applicant action error:', error);
       toast.error('Something went wrong');
     } finally {
       setProcessingId(null);
+    }
+  };
+
+  const handleCloseQuest = async () => {
+    if (!quest) return;
+
+    try {
+      setIsClosing(true);
+      const response = await fetch('/api/company/quests', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questId: quest.id }),
+      });
+
+      const data = await response.json();
+      if (!data.success) {
+        toast.error(data.error || 'Failed to close quest');
+        return;
+      }
+
+      toast.success('Quest closed successfully');
+      router.push('/dashboard/company/quests');
+    } catch (error) {
+      console.error('Close quest error:', error);
+      toast.error('Failed to close quest');
+    } finally {
+      setIsClosing(false);
     }
   };
 
@@ -159,7 +193,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
         <div>
           <div className="flex items-center gap-3 mb-2">
             <h1 className="text-3xl font-bold">{quest.title}</h1>
-            <Badge variant={quest.status === 'open' ? 'default' : 'secondary'}>
+            <Badge variant={quest.status === 'available' ? 'default' : 'secondary'}>
               {quest.status}
             </Badge>
           </div>
@@ -171,8 +205,16 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
           </div>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline">Edit Quest</Button>
-          <Button variant="destructive">Close Quest</Button>
+          <Button variant="outline" onClick={() => toast.info('Quest editing is coming in a follow-up update')}>
+            Edit Quest
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleCloseQuest}
+            disabled={isClosing || ['completed', 'cancelled'].includes(quest.status)}
+          >
+            {isClosing ? 'Closing...' : 'Close Quest'}
+          </Button>
         </div>
       </div>
 
@@ -198,7 +240,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
                     <CardContent className="p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
                       <div className="flex items-center gap-4">
                         <Avatar className="h-12 w-12">
-                          <AvatarImage src={applicant.user.image} />
+                          <AvatarImage src={applicant.user.avatar} />
                           <AvatarFallback>{applicant.user.name[0]}</AvatarFallback>
                         </Avatar>
                         <div>
@@ -208,7 +250,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
                             <span>• {applicant.user.xp} XP</span>
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
-                            Applied {new Date(applicant.createdAt).toLocaleDateString()}
+                            Applied {new Date(applicant.assignedAt).toLocaleDateString()}
                           </p>
                         </div>
                       </div>
@@ -238,8 +280,16 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
                             </Button>
                           </>
                         ) : (
-                          <Badge variant={applicant.status === 'started' || applicant.status === 'completed' ? 'default' : 'destructive'}>
-                            {applicant.status.charAt(0).toUpperCase() + applicant.status.slice(1)}
+                          <Badge
+                            variant={
+                              ['started', 'in_progress', 'completed'].includes(applicant.status)
+                                ? 'default'
+                                : ['submitted', 'review'].includes(applicant.status)
+                                  ? 'secondary'
+                                  : 'destructive'
+                            }
+                          >
+                            {applicant.status.replace('_', ' ')}
                           </Badge>
                         )}
                         <DropdownMenu>
@@ -296,13 +346,13 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground">Accepted</span>
                 <span className="font-bold text-green-600">
-                  {quest.assignments.filter(a => a.status === 'started' || a.status === 'in_progress').length}
+                  {quest.assignments.filter(a => ['started', 'in_progress', 'completed'].includes(a.status)).length}
                 </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground">Pending Review</span>
                 <span className="font-bold text-yellow-600">
-                  {quest.assignments.filter(a => a.status === 'assigned').length}
+                  {quest.assignments.filter(a => ['submitted', 'review'].includes(a.status)).length}
                 </span>
               </div>
             </CardContent>

--- a/app/dashboard/my-quests/page.tsx
+++ b/app/dashboard/my-quests/page.tsx
@@ -96,8 +96,8 @@ export default async function MyQuestsPage() {
                   
                   {assignment.status === 'assigned' && (
                     <QuestSubmissionDialog 
-                      questId={assignment.quest.id} 
                       questTitle={assignment.quest.title} 
+                      assignmentId={assignment.id}
                     />
                   )}
                   

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -8,7 +8,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle, Target, Zap, Users, Clock, CheckCircle, XCircle } from 'lucide-react';
@@ -132,7 +131,6 @@ export default function QuestDetailPage() {
         },
         body: JSON.stringify({
           questId: id,
-          userId: session.user.id,
         }),
       });
 
@@ -174,7 +172,6 @@ export default function QuestDetailPage() {
           assignmentId: assignment.id,
           submissionContent: submissionContent,
           submissionNotes: submissionNotes,
-          userId: session.user.id,
         }),
       });
 
@@ -225,7 +222,9 @@ export default function QuestDetailPage() {
   }
 
   const canAssign = quest.status === 'available' && !isAssigned;
-  const canSubmit = isAssigned && assignment?.status === 'assigned' || assignment?.status === 'started' || assignment?.status === 'in_progress';
+  const canSubmit =
+    !!isAssigned &&
+    ['assigned', 'started', 'in_progress'].includes(assignment?.status || '');
 
   return (
     <div className="container mx-auto py-6 max-w-4xl">
@@ -354,7 +353,7 @@ export default function QuestDetailPage() {
         </Card>
       )}
 
-      {!isAssigned && quest.status === 'available' && (
+      {canAssign && (
         <Card className="mb-6">
           <CardHeader>
             <CardTitle>Accept This Quest</CardTitle>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next"
 import { GeistSans } from "geist/font/sans"
-import { GeistMono } from "geist/font/mono"
 import "./globals.css"
 import "../styles/accessibility.css"
 import { ThemeProvider } from "../components/theme-provider"
@@ -58,7 +57,7 @@ export default function RootLayout({
         <meta name="color-scheme" content="light dark" />
       </head>
       <body
-        className={`${GeistSans.variable} ${GeistMono.variable} font-sans antialiased`}
+        className={`${GeistSans.variable} font-sans antialiased`}
       >
         <A11ySkipLink />
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -25,15 +25,12 @@ export default function Navigation() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const pathname = usePathname();
+  const normalizedPath = pathname ? pathname.replace(/\/+$/, '') || '/' : null;
 
-  const isHome = pathname === '/home' || pathname === '/';
-  const isDashboard = pathname?.startsWith('/dashboard') || pathname === '/admin';
-  const isAuthPage =
-    pathname === '/login' ||
-    pathname === '/register' ||
-    pathname === '/register-company' ||
-    pathname === '/forgot-password' ||
-    pathname === '/reset-password';
+  const isHome = normalizedPath === '/home' || normalizedPath === '/';
+  const isDashboard = !!normalizedPath && (normalizedPath.startsWith('/dashboard') || normalizedPath.startsWith('/admin'));
+  const authRoutePrefixes = ['/login', '/register', '/register-company', '/forgot-password', '/reset-password'];
+  const isAuthPage = !!normalizedPath && authRoutePrefixes.some((prefix) => normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`));
 
   useEffect(() => {
     setMounted(true);

--- a/components/PaymentForm.tsx
+++ b/components/PaymentForm.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle, CreditCard, CheckCircle } from 'lucide-react';
+import { AlertCircle, CheckCircle } from 'lucide-react';
 import { validatePaymentInfo, formatCurrency } from '@/lib/payment-utils';
 import { processPayment } from '@/lib/payment-utils';
 
@@ -79,6 +79,12 @@ export default function PaymentForm({
     const validation = validatePaymentInfo(cardNumber, expiry, cvc);
     if (!validation.isValid) {
       setError(validation.error || 'Invalid card information');
+      setLoading(false);
+      return;
+    }
+
+    if (!adventurerId) {
+      setError('No adventurer selected for payment');
       setLoading(false);
       return;
     }

--- a/components/PaymentProcessor.tsx
+++ b/components/PaymentProcessor.tsx
@@ -34,6 +34,7 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
   const [error, setError] = useState<string | null>(null);
   const [showPaymentForm, setShowPaymentForm] = useState(false);
   const [paymentSuccess, setPaymentSuccess] = useState(false);
+  const [selectedAdventurerId, setSelectedAdventurerId] = useState<string>('');
 
   useEffect(() => {
     if (status === 'unauthenticated') {
@@ -88,21 +89,29 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
   const handleMakePayment = () => {
     if (!quest || !session?.user?.id) return;
     
-    // In a real implementation, we would need the adventurer ID
-    // For now, we'll get it from the assignment
     const processPayment = async () => {
       try {
-        // Find the adventurer who completed this quest
         const assignmentResponse = await fetch(`/api/quests/assignments?questId=${questId}`);
         const assignmentData = await assignmentResponse.json();
         
-        if (!assignmentData.success || assignmentData.assignments.length === 0) {
+        const assignments = Array.isArray(assignmentData.assignments) ? assignmentData.assignments : [];
+        if (!assignmentData.success || assignments.length === 0) {
           setError('No adventurer assigned to this quest');
           return;
         }
-        
-        const adventurerId = assignmentData.assignments[0].userId;
-        
+
+        const preferredAssignment =
+          assignments.find((assignment: { status?: string }) => assignment.status === 'completed') ??
+          assignments.find((assignment: { status?: string }) =>
+            ['submitted', 'review', 'in_progress', 'started', 'assigned'].includes(assignment.status || '')
+          );
+
+        if (!preferredAssignment?.userId) {
+          setError('Could not determine adventurer for payment');
+          return;
+        }
+
+        setSelectedAdventurerId(preferredAssignment.userId);
         setShowPaymentForm(true);
       } catch (err) {
         console.error('Error finding adventurer:', err);
@@ -114,8 +123,10 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
   };
 
   const handlePaymentSuccess = (transactionId: string) => {
+    void transactionId;
     setPaymentSuccess(true);
     setShowPaymentForm(false);
+    setSelectedAdventurerId('');
     
     // Optionally, redirect or update the quest status
     setTimeout(() => {
@@ -125,6 +136,7 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
 
   const handleCancelPayment = () => {
     setShowPaymentForm(false);
+    setSelectedAdventurerId('');
   };
 
   if (status === 'loading' || loading) {
@@ -196,13 +208,13 @@ export default function PaymentProcessor({ questId }: PaymentProcessorProps) {
     );
   }
 
-  if (showPaymentForm && quest.monetaryReward) {
+  if (showPaymentForm && quest.monetaryReward && selectedAdventurerId) {
     return (
       <div className="container mx-auto py-6">
         <PaymentForm
           questId={quest.id}
           companyId={session?.user?.id || ''}
-          adventurerId="" // Will be determined in the component
+          adventurerId={selectedAdventurerId}
           amount={quest.monetaryReward}
           currency="USD"
           onSuccess={handlePaymentSuccess}

--- a/components/quest-apply-button.tsx
+++ b/components/quest-apply-button.tsx
@@ -18,14 +18,18 @@ export function QuestApplyButton({ questId, isApplied = false }: QuestApplyButto
   const handleApply = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(`/api/quests/${questId}/apply`, {
+      const response = await fetch('/api/quests/assignments', {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ questId }),
       });
 
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.message || "Failed to apply");
+        throw new Error(data.error || data.message || "Failed to apply");
       }
 
       toast.success("Application submitted successfully!");

--- a/components/quest-submission-dialog.tsx
+++ b/components/quest-submission-dialog.tsx
@@ -19,11 +19,11 @@ import { Loader2, Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 interface QuestSubmissionDialogProps {
-  questId: string;
   questTitle: string;
+  assignmentId: string;
 }
 
-export function QuestSubmissionDialog({ questId, questTitle }: QuestSubmissionDialogProps) {
+export function QuestSubmissionDialog({ questTitle, assignmentId }: QuestSubmissionDialogProps) {
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [content, setContent] = useState("");
@@ -35,23 +35,30 @@ export function QuestSubmissionDialog({ questId, questTitle }: QuestSubmissionDi
     setIsLoading(true);
 
     try {
-      const response = await fetch(`/api/quests/${questId}/submit`, {
+      const submissionContent = link
+        ? `${content}\n\nDeliverable link: ${link}`
+        : content;
+
+      const response = await fetch('/api/quests/submissions', {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          content,
-          links: link ? [link] : [],
+          assignmentId,
+          submissionContent,
+          submissionNotes: link ? `Deliverable link: ${link}` : undefined,
         }),
       });
 
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.message || "Failed to submit");
+        throw new Error(data.error || data.message || "Failed to submit");
       }
 
       toast.success("Work submitted successfully!");
       setOpen(false);
+      setContent("");
+      setLink("");
       router.refresh();
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : String(error));

--- a/lib/quest-lifecycle.ts
+++ b/lib/quest-lifecycle.ts
@@ -1,0 +1,60 @@
+import { AssignmentStatus, Prisma, PrismaClient, QuestStatus } from '@prisma/client';
+
+const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'review'];
+const ACTIVE_STATUSES: AssignmentStatus[] = ['assigned', 'started', 'in_progress'];
+
+function deriveQuestStatus(statuses: AssignmentStatus[], currentStatus: QuestStatus): QuestStatus {
+  if (statuses.length === 0) {
+    if (currentStatus === 'completed' || currentStatus === 'cancelled') {
+      return currentStatus;
+    }
+    return 'available';
+  }
+
+  if (statuses.some((status) => REVIEW_STATUSES.includes(status))) {
+    return 'review';
+  }
+
+  if (statuses.some((status) => ACTIVE_STATUSES.includes(status))) {
+    return 'in_progress';
+  }
+
+  if (statuses.some((status) => status === 'completed')) {
+    return 'completed';
+  }
+
+  return 'available';
+}
+
+type DbClient = Prisma.TransactionClient | PrismaClient;
+
+export async function syncQuestLifecycleStatus(
+  db: DbClient,
+  questId: string
+): Promise<QuestStatus | null> {
+  const quest = await db.quest.findUnique({
+    where: { id: questId },
+    select: { status: true },
+  });
+
+  if (!quest) return null;
+  if (quest.status === 'cancelled') return quest.status;
+
+  const assignments = await db.questAssignment.findMany({
+    where: { questId },
+    select: { status: true },
+  });
+
+  const nextStatus = deriveQuestStatus(
+    assignments.map((assignment) => assignment.status),
+    quest.status
+  );
+  if (nextStatus !== quest.status) {
+    await db.quest.update({
+      where: { id: questId },
+      data: { status: nextStatus },
+    });
+  }
+
+  return nextStatus;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "type-check": "tsc --noEmit",
+    "type-check": "next typegen && tsc --noEmit",
     "deploy:vercel": "vercel --prod",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",


### PR DESCRIPTION
## Summary

This PR resolves the reported auth/quest flow failures and hardens backend contracts used by dashboard pages.

### Backend flow fixes
- Updated quest apply + submission UI calls to use current endpoints.
- Added `lib/quest-lifecycle.ts` and wired lifecycle sync into assignment/submission/review flows.
- Prevented duplicate reward grants on repeat approvals and made completion recording idempotent.
- Tightened quest detail API permissions and added backward-compatible response shape (`quest` + `quests[]`).
- Fixed assignment action scoping/validation in:
  - `app/api/quests/assignments/route.ts`
  - `app/api/quests/[id]/assignments/route.ts`
- Hardened payments endpoint validation, authorization, and recipient checks.

### Auth/UX reliability
- Ensured successful login redirects proceed correctly.
- Strengthened global navigation route detection to avoid duplicate nav on auth/dashboard routes.
- Removed unused preloaded mono font from root layout.

### CI stability
- Updated type-check script to generate Next route types before `tsc`:
  - `next typegen && tsc --noEmit`

## Validation
- `npm run lint` (warnings only)
- `npm run type-check`
- `npm run build`

All passed locally.
