### PR TITLE
Polish frontend visual system and landing composition

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -123,7 +123,7 @@ export default function ForgotPasswordPage() {
           <div className="mt-6 pt-6 border-t border-slate-100 text-center">
             <p className="text-sm text-slate-500">
               Remember your password?{' '}
-              <Link href="/login" className="text-indigo-600 hover:text-indigo-500 font-medium transition-colors">
+              <Link href="/login" className="text-orange-500 hover:text-orange-400 font-medium transition-colors">
                 Sign in
               </Link>
             </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,10 @@
     @apply bg-background text-foreground antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
+  a:not([class]) {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 @layer components {

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -9,6 +9,7 @@ import HowItWorks from '@/components/landing/HowItWorks';
 import StatsSection from '@/components/landing/StatsSection';
 import CTASection from '@/components/landing/CTASection';
 import QuestShowcase from '@/components/landing/QuestShowcase';
+import LogoMarquee from '@/components/landing/LogoMarquee';
 import { RankBadge } from '@/components/ui/rank-badge';
 
 const RANKS = ['F', 'E', 'D', 'C', 'B', 'A', 'S'] as const;
@@ -92,6 +93,8 @@ export default function HomePage() {
           <p className="text-[10px] text-white/25 tracking-wide">Everyone starts at F-Rank</p>
         </div>
       </div>
+
+      <LogoMarquee />
 
       <section id="features">
         <StatsSection />

--- a/app/register-company/page.tsx
+++ b/app/register-company/page.tsx
@@ -162,7 +162,7 @@ export default function RegisterCompanyPage() {
             Already have an account?{' '}
             <button 
               onClick={() => router.push('/login')} 
-              className="text-primary hover:underline"
+              className="text-orange-500 hover:text-orange-400 hover:underline"
             >
               Sign in
             </button>
@@ -171,7 +171,7 @@ export default function RegisterCompanyPage() {
             Are you an adventurer?{' '}
             <button 
               onClick={() => router.push('/register')} 
-              className="text-primary hover:underline"
+              className="text-orange-500 hover:text-orange-400 hover:underline"
             >
               Register as adventurer
             </button>

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -7,71 +7,56 @@ import { ArrowRight } from 'lucide-react';
 
 export default function CTASection() {
   return (
-    <section className="relative py-24 md:py-32 bg-slate-950 border-t border-slate-800/60 overflow-hidden">
-      {/* Subtle radial glow — barely visible */}
+    <section className="relative overflow-hidden border-t border-slate-800/60 bg-slate-950 py-24 md:py-32">
       <div
         className="absolute inset-0 pointer-events-none"
         style={{
           background:
-            'radial-gradient(ellipse 80% 50% at 50% 100%, rgba(249,115,22,0.05), transparent)',
+            'radial-gradient(ellipse 80% 60% at 10% 100%, rgba(249,115,22,0.10), transparent), radial-gradient(ellipse 65% 50% at 90% 0%, rgba(14,165,233,0.10), transparent)',
         }}
       />
 
-      <div className="relative container px-6 mx-auto max-w-3xl text-center">
+      <div className="relative container mx-auto max-w-4xl px-6">
         <motion.p
           initial={{ opacity: 0, y: 8 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.4 }}
-          className="text-[11px] font-semibold tracking-[0.15em] text-orange-400/60 uppercase mb-4"
+          className="mb-4 text-center text-[11px] font-semibold uppercase tracking-[0.15em] text-orange-400/70"
         >
           Your next chapter
-        </motion.p>
-
-        <motion.h2
-          initial={{ opacity: 0, y: 12 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.4, delay: 0.04 }}
-          className="text-4xl md:text-5xl font-bold tracking-[-0.02em] text-white mb-5"
-        >
-          Your Next Quest Awaits
-        </motion.h2>
-
-        <motion.p
-          initial={{ opacity: 0, y: 12 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.4, delay: 0.08 }}
-          className="text-lg text-slate-400 mb-10 max-w-xl mx-auto leading-relaxed"
-        >
-          Join the guild, start coding real projects, and build a portfolio that opens doors.
         </motion.p>
 
         <motion.div
           initial={{ opacity: 0, y: 12 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.4, delay: 0.14 }}
-          className="flex flex-col sm:flex-row items-center justify-center gap-3"
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="rounded-2xl border border-slate-800 bg-slate-900/85 p-6 shadow-[0_24px_44px_-32px_rgba(15,23,42,0.8)] sm:p-8"
         >
-          <Button
-            asChild
-            size="lg"
-            className="h-12 px-7 text-sm font-semibold rounded-lg bg-orange-500 hover:bg-orange-600 text-black shadow-lg shadow-orange-500/20 transition-all"
-          >
-            <Link href="/register" className="flex items-center gap-2">
-              Enter the Guild <ArrowRight className="w-4 h-4" />
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            size="lg"
-            className="h-12 px-7 text-sm font-medium rounded-lg border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white bg-transparent transition-colors"
-          >
-            <Link href="/register-company">Post quests as a company</Link>
-          </Button>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="rounded-xl border border-orange-300/20 bg-gradient-to-b from-orange-500/10 to-orange-500/0 p-5">
+              <h3 className="text-lg font-semibold text-white">For Adventurers</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-300">
+                Claim quests, submit production code, and build rank-based reputation that compounds over time.
+              </p>
+              <Button asChild size="lg" className="mt-5 h-11 rounded-xl px-6 text-sm">
+                <Link href="/register" className="flex items-center gap-2">
+                  Enter the Guild <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+
+            <div className="rounded-xl border border-slate-700 bg-slate-950/50 p-5">
+              <h3 className="text-lg font-semibold text-white">For Companies</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-300">
+                Post real development quests, evaluate submissions quickly, and pay only when delivery meets standards.
+              </p>
+              <Button asChild variant="outline" size="lg" className="mt-5 h-11 rounded-xl border-slate-600 bg-transparent px-6 text-sm text-slate-200 hover:bg-slate-800">
+                <Link href="/register-company">Launch a Company Account</Link>
+              </Button>
+            </div>
+          </div>
         </motion.div>
       </div>
     </section>

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -1,32 +1,39 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import { BookUser, Coins, FileSearch, ShieldCheck } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 const steps = [
   {
     number: '01',
+    icon: BookUser,
     title: 'Create your character',
     description:
-      'Sign up and pick your specialization. You start as an F-Rank adventurer with access to beginner quests.',
+      'Register as an adventurer or company, then complete profile verification to unlock guild privileges.',
   },
   {
     number: '02',
+    icon: FileSearch,
     title: 'Accept quests',
     description:
-      'Browse real coding tasks from companies. Pick one that matches your skills, write the code, and submit.',
+      'Browse live quests by rank, reward, and stack. Companies review applicants and assign the right talent.',
   },
   {
     number: '03',
+    icon: ShieldCheck,
     title: 'Level up & earn',
     description:
-      'Get paid for completed work. Earn XP to rank up, unlock harder quests, and build your reputation.',
+      'Ship work, pass QA review, receive payout, and gain XP to climb from F-Rank to elite guild tiers.',
   },
 ];
 
 export default function HowItWorks() {
   return (
-    <section className="py-20 md:py-28 bg-white">
-      <div className="container px-6 mx-auto max-w-6xl">
+    <section className="relative overflow-hidden bg-white py-20 md:py-28">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(249,115,22,0.13),transparent_35%),radial-gradient(circle_at_80%_100%,rgba(14,165,233,0.08),transparent_40%)]" />
+      <div className="container relative mx-auto max-w-6xl px-6">
         <motion.div
           initial={{ opacity: 0, y: 12 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -34,19 +41,20 @@ export default function HowItWorks() {
           transition={{ duration: 0.4 }}
           className="text-center mb-16"
         >
-          <p className="text-[11px] font-semibold tracking-[0.15em] text-orange-500/70 uppercase mb-3">
+          <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.15em] text-orange-500/80">
             How it works
           </p>
-          <h2 className="text-3xl md:text-4xl font-bold tracking-[-0.02em] text-slate-900">
-            Three steps to your first quest
+          <h2 className="text-3xl font-bold tracking-[-0.02em] text-slate-900 md:text-4xl">
+            The Guild operating loop
           </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm text-slate-600 sm:text-base">
+            A clear pipeline for both sides: transparent matching, quality gates, and trustworthy delivery.
+          </p>
         </motion.div>
 
-        <div className="relative max-w-4xl mx-auto">
-          {/* Connecting line — desktop only */}
-          <div className="hidden md:block absolute top-5 left-[16.67%] right-[16.67%] h-px bg-gradient-to-r from-orange-400/60 via-orange-400/30 to-orange-400/60" />
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-12 md:gap-8">
+        <div className="relative mx-auto max-w-5xl">
+          <div className="absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-gradient-to-b from-orange-200 via-orange-100 to-transparent lg:block" />
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
             {steps.map((step, index) => (
               <motion.div
                 key={step.number}
@@ -54,16 +62,28 @@ export default function HowItWorks() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.1 }}
-                className="text-center"
+                className="relative rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.45)]"
               >
-                <div className="relative inline-flex items-center justify-center w-10 h-10 rounded-full bg-slate-100 text-sm font-bold text-slate-300 mb-5 z-10">
-                  {step.number}
+                <div className="mb-4 flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">{step.number}</span>
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-orange-200 bg-orange-50">
+                    <step.icon className="h-4 w-4 text-orange-600" />
+                  </div>
                 </div>
-                <h3 className="text-lg font-semibold text-slate-900 mb-2">{step.title}</h3>
-                <p className="text-sm text-slate-500 leading-relaxed">{step.description}</p>
+                <h3 className="mb-2 text-left text-lg font-semibold text-slate-900">{step.title}</h3>
+                <p className="text-left text-sm leading-relaxed text-slate-600">{step.description}</p>
               </motion.div>
             ))}
           </div>
+        </div>
+
+        <div className="mt-10 flex justify-center">
+          <Button asChild variant="outline" className="h-11 rounded-xl border-slate-300 px-6">
+            <Link href="/register">
+              <Coins className="h-4 w-4" />
+              Start Your First Quest
+            </Link>
+          </Button>
         </div>
       </div>
     </section>

--- a/components/landing/LogoMarquee.tsx
+++ b/components/landing/LogoMarquee.tsx
@@ -1,39 +1,50 @@
 'use client';
 
 const tags = [
-    { label: "GSSoC", color: "bg-orange-50 text-orange-600 border-orange-200" },
-    { label: "AI Grants", color: "bg-violet-50 text-violet-600 border-violet-200" },
-    { label: "Open Source", color: "bg-emerald-50 text-emerald-600 border-emerald-200" },
-    { label: "Hacktoberfest", color: "bg-blue-50 text-blue-600 border-blue-200" },
-    { label: "GSSoC", color: "bg-orange-50 text-orange-600 border-orange-200" },
-    { label: "AI Grants", color: "bg-violet-50 text-violet-600 border-violet-200" },
-    { label: "Open Source", color: "bg-emerald-50 text-emerald-600 border-emerald-200" },
-    { label: "Hacktoberfest", color: "bg-blue-50 text-blue-600 border-blue-200" },
+  "Neon Postgres",
+  "Next.js 15",
+  "TypeScript",
+  "Prisma ORM",
+  "Stripe-ready payouts",
+  "Quest-based workflows",
+  "Human QA reviews",
+  "Rank progression F to S",
 ];
 
 export default function LogoMarquee() {
-    return (
-        <section className="py-8 border-y border-slate-100 overflow-hidden">
-            <div className="relative flex overflow-x-hidden">
-                {/* Fade edges */}
-                <div className="absolute left-0 top-0 bottom-0 w-20 bg-gradient-to-r from-white to-transparent z-10" />
-                <div className="absolute right-0 top-0 bottom-0 w-20 bg-gradient-to-l from-white to-transparent z-10" />
+  return (
+    <section className="overflow-hidden border-y border-slate-200 bg-slate-50 py-6">
+      <div className="mx-auto mb-4 w-full max-w-6xl px-6">
+        <p className="text-center text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+          Built For Serious Delivery
+        </p>
+      </div>
 
-                <div className="animate-scroll flex whitespace-nowrap items-center">
-                    {tags.map((tag, index) => (
-                        <div key={index} className={`mx-4 text-xs font-semibold px-4 py-1.5 rounded-full border ${tag.color} select-none`}>
-                            {tag.label}
-                        </div>
-                    ))}
-                </div>
-                <div className="absolute top-0 animate-scroll flex whitespace-nowrap items-center" aria-hidden="true">
-                    {tags.map((tag, index) => (
-                        <div key={index} className={`mx-4 text-xs font-semibold px-4 py-1.5 rounded-full border ${tag.color} select-none`}>
-                            {tag.label}
-                        </div>
-                    ))}
-                </div>
+      <div className="relative flex overflow-x-hidden">
+        <div className="absolute left-0 top-0 bottom-0 z-10 w-20 bg-gradient-to-r from-slate-50 to-transparent" />
+        <div className="absolute right-0 top-0 bottom-0 z-10 w-20 bg-gradient-to-l from-slate-50 to-transparent" />
+
+        <div className="animate-scroll flex items-center whitespace-nowrap">
+          {tags.map((tag, index) => (
+            <div
+              key={`${tag}-${index}`}
+              className="mx-2 select-none rounded-full border border-slate-300 bg-white px-4 py-1.5 text-xs font-semibold text-slate-700 shadow-sm"
+            >
+              {tag}
             </div>
-        </section>
-    );
+          ))}
+        </div>
+        <div className="absolute top-0 animate-scroll flex items-center whitespace-nowrap" aria-hidden="true">
+          {tags.map((tag, index) => (
+            <div
+              key={`${tag}-clone-${index}`}
+              className="mx-2 select-none rounded-full border border-slate-300 bg-white px-4 py-1.5 text-xs font-semibold text-slate-700 shadow-sm"
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/components/landing/StatsSection.tsx
+++ b/components/landing/StatsSection.tsx
@@ -2,7 +2,7 @@
 
 import { useInView } from 'framer-motion';
 import { useRef, useEffect, useState } from 'react';
-import { Sword, Trophy, Scroll, Shield } from 'lucide-react';
+import { Sword, Trophy, Scroll, Shield, ArrowUpRight } from 'lucide-react';
 
 const stats = [
   { value: 500, suffix: '+', label: 'Adventurers', Icon: Sword },
@@ -62,15 +62,33 @@ function Counter({
 
 export default function StatsSection() {
   return (
-    <section className="py-16 md:py-20 bg-slate-950 border-y border-slate-800/60">
-      <div className="container px-6 mx-auto max-w-4xl">
-        <p className="text-center text-[11px] font-semibold tracking-[0.15em] text-orange-400/60 uppercase mb-10">
-          Guild Registry
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-          {stats.map((s) => (
-            <Counter key={s.label} {...s} />
-          ))}
+    <section className="border-y border-slate-800/70 bg-slate-950 py-16 md:py-20">
+      <div className="container mx-auto max-w-5xl px-6">
+        <div className="mb-10 flex flex-col gap-3 text-center">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.15em] text-orange-400/70">
+            Guild Registry
+          </p>
+          <h2 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
+            Live activity across the guild
+          </h2>
+          <p className="mx-auto max-w-2xl text-sm text-slate-400">
+            Real projects, real payouts, and measured growth for both adventurers and companies.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4 sm:p-6">
+          <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+            {stats.map((s) => (
+              <Counter key={s.label} {...s} />
+            ))}
+          </div>
+
+          <div className="mt-6 border-t border-slate-800 pt-4 text-center">
+            <span className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              Metrics refresh daily
+              <ArrowUpRight className="h-3.5 w-3.5 text-orange-400" />
+            </span>
+          </div>
         </div>
       </div>
     </section>

--- a/components/quest-card.tsx
+++ b/components/quest-card.tsx
@@ -18,10 +18,10 @@ export function QuestCard({ id, rank, title, company, reward, xp, tags }: QuestC
     'F': 'bg-gray-500 hover:bg-gray-600',
     'E': 'bg-slate-500 hover:bg-slate-600',
     'D': 'bg-green-500 hover:bg-green-600',
-    'C': 'bg-blue-500 hover:bg-blue-600',
-    'B': 'bg-purple-500 hover:bg-purple-600',
-    'A': 'bg-red-500 hover:bg-red-600',
-    'S': 'bg-yellow-500 hover:bg-yellow-600',
+    'C': 'bg-emerald-500 hover:bg-emerald-600',
+    'B': 'bg-amber-500 hover:bg-amber-600',
+    'A': 'bg-orange-500 hover:bg-orange-600',
+    'S': 'bg-red-500 hover:bg-red-600',
   };
 
   return (


### PR DESCRIPTION
## Summary

This PR delivers a focused frontend polish pass across the highest-visibility surfaces to remove unprofessional styling artifacts (default browser link colors, placeholder trust tags, inconsistent accents) and improve overall visual coherence.

## What changed

### Global style consistency
- Added a base rule for unclassed links so they inherit text color and remove browser-default blue/purple states.
- File: `app/globals.css`

### Home page trust strip + section upgrades
- Mounted the trust strip component in the home page flow below hero.
- Replaced placeholder trust-strip tags (including old generic items) with platform-relevant labels.
- Refreshed trust strip visual style to align with guild branding.
- Files:
  - `app/home/page.tsx`
  - `components/landing/LogoMarquee.tsx`

### Landing section redesign
- `How It Works`: restructured cards with clearer hierarchy, iconography, and role-aware messaging.
- `Stats`: upgraded framing and headline to improve credibility/readability.
- `CTA`: converted to two role-specific action cards (adventurer vs company) with stronger visual contrast and copy.
- Files:
  - `components/landing/HowItWorks.tsx`
  - `components/landing/StatsSection.tsx`
  - `components/landing/CTASection.tsx`

### Accent/link cleanup on auth-adjacent screens
- Replaced remaining indigo/primary drift links with brand-aligned orange treatment.
- Files:
  - `app/forgot-password/page.tsx`
  - `app/register-company/page.tsx`

### Legacy component color normalization
- Updated `quest-card` rank color mapping to reduce outdated purple/blue-heavy styling and align with current palette.
- File:
  - `components/quest-card.tsx`

## Validation

Executed locally:
- `npm run lint` (warnings only)
- `npm run type-check`
- `npm run build`

All passed successfully.
