### PR TITLE
fix: improve marketing navigation and add go-to-top

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import A11ySkipLink from "../components/A11ySkipLink"
 import Navigation from "../components/Navigation"
 import ErrorBoundary from "../components/ErrorBoundary"
 import { Toaster } from "@/components/ui/sonner"
+import { GoToTop } from "@/components/ui/go-to-top"
 import { SiteFooter } from "@/components/site-footer"
 
 export const metadata: Metadata = {
@@ -71,6 +72,7 @@ export default function RootLayout({
               <SiteFooter />
             </div>
             <Toaster />
+            <GoToTop />
           </ThemeProvider>
         </SessionProvider>
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -24,6 +24,7 @@ export default function Navigation() {
   const [mounted, setMounted] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [activeSection, setActiveSection] = useState<'home' | 'features' | 'how-it-works'>('home');
   const pathname = usePathname();
   const normalizedPath = pathname ? pathname.replace(/\/+$/, '') || '/' : null;
 
@@ -47,6 +48,43 @@ export default function Navigation() {
     setMobileMenuOpen(false);
   }, [pathname]);
 
+  useEffect(() => {
+    if (!isHome) {
+      setActiveSection('home');
+      return;
+    }
+
+    const updateActiveSection = () => {
+      if (window.scrollY < 160) {
+        setActiveSection('home');
+        return;
+      }
+
+      const orderedSections: Array<'features' | 'how-it-works'> = ['features', 'how-it-works'];
+      let nextSection: 'home' | 'features' | 'how-it-works' = 'home';
+
+      for (const sectionId of orderedSections) {
+        const section = document.getElementById(sectionId);
+        if (!section) continue;
+
+        if (window.scrollY >= section.offsetTop - 180) {
+          nextSection = sectionId;
+        }
+      }
+
+      setActiveSection(nextSection);
+    };
+
+    updateActiveSection();
+    window.addEventListener('scroll', updateActiveSection, { passive: true });
+    window.addEventListener('resize', updateActiveSection);
+
+    return () => {
+      window.removeEventListener('scroll', updateActiveSection);
+      window.removeEventListener('resize', updateActiveSection);
+    };
+  }, [isHome]);
+
   // Dashboard and auth screens have dedicated layouts
   if (isDashboard || isAuthPage || !mounted) return null;
 
@@ -60,8 +98,9 @@ export default function Navigation() {
   const isTransparent = isHome && !scrolled && !mobileMenuOpen;
 
   const marketingLinks = [
-    { href: '/home#how-it-works', label: 'How It Works' },
+    { href: '/home', label: 'Home' },
     { href: '/home#features', label: 'Features' },
+    { href: '/home#how-it-works', label: 'How It Works' },
     { href: '/register-company', label: 'For Companies' },
   ];
 
@@ -74,9 +113,16 @@ export default function Navigation() {
       : [{ href: '/dashboard', label: 'Dashboard' }, { href: '/dashboard/quests', label: 'Quests' }];
 
   const activeHref = (href: string) => {
-    if (href.startsWith('/home#')) return isHome;
     if (!pathname) return false;
-    return pathname === href || pathname.startsWith(`${href}/`);
+
+    const [route, hash] = href.split('#');
+
+    if (route === '/home' && isHome) {
+      if (!hash) return activeSection === 'home';
+      return activeSection === hash;
+    }
+
+    return pathname === route || pathname.startsWith(`${route}/`);
   };
 
   const renderAuthButtons = () => {
@@ -361,6 +407,7 @@ function NavLink({
   return (
     <Link
       href={href}
+      aria-current={active ? 'page' : undefined}
       className={cn(
         'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
         transparent
@@ -394,6 +441,7 @@ function MobileNavLink({
     <Link
       href={href}
       onClick={onClick}
+      aria-current={active ? 'page' : undefined}
       className={cn(
         'text-sm font-medium py-2.5 px-3 rounded-lg transition-colors',
         transparent

--- a/components/ui/go-to-top.tsx
+++ b/components/ui/go-to-top.tsx
@@ -1,32 +1,45 @@
-"use client"
+'use client';
 
-import { useState, useEffect } from "react"
-import { Button } from "./button"
-import { ChevronUp } from "lucide-react"
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { ChevronUp } from 'lucide-react';
+import { Button } from './button';
 
 export function GoToTop() {
-  const [isVisible, setIsVisible] = useState(false)
+  const pathname = usePathname();
+  const [isVisible, setIsVisible] = useState(false);
+
+  const hiddenRoutePrefixes = ['/dashboard', '/admin', '/login', '/register', '/register-company', '/forgot-password', '/reset-password'];
+  const shouldHide = !!pathname && hiddenRoutePrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 
   useEffect(() => {
-    const toggleVisibility = () => {
-      // Show button after scrolling 300px
-      if (window.pageYOffset > 300) {
-        setIsVisible(true)
-      } else {
-        setIsVisible(false)
-      }
+    if (shouldHide) {
+      setIsVisible(false);
+      return;
     }
 
-    window.addEventListener("scroll", toggleVisibility)
-    return () => window.removeEventListener("scroll", toggleVisibility)
-  }, [])
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    toggleVisibility();
+    window.addEventListener('scroll', toggleVisibility, { passive: true });
+
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, [shouldHide]);
 
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
-      behavior: "smooth",
-    })
-  }
+      behavior: 'smooth',
+    });
+  };
+
+  if (shouldHide) return null;
 
   return (
     <>
@@ -40,5 +53,5 @@ export function GoToTop() {
         </Button>
       )}
     </>
-  )
-} 
+  );
+}


### PR DESCRIPTION
## Summary

This PR cleans up a pair of low-risk landing-page issues that still matched the current codebase after triaging the open issue list.

### What changed
- added a real `Home` link to the public marketing navigation
- made marketing nav highlighting respond to landing-page scroll position instead of treating all `/home#...` links as active at once
- added `aria-current` to active nav links for better accessibility semantics
- mounted the existing `GoToTop` control from the root layout
- limited the `GoToTop` button to public marketing/legal pages so dashboard and auth layouts stay uncluttered

### Why this approach
The repo already had a `GoToTop` component, but it was never wired into the shared layout. The nav also had path-based active styling, but the public hash links all rendered as active whenever the user was on `/home`, which made section state unclear. This PR fixes both behaviors without touching auth, API, schema, or dashboard flows.

## Issue triage notes

While reviewing the current open issues, I found that `#91` appears already addressed in the current branch state: both the login and register forms already use explicit `Label` components rather than placeholder-only inputs. I therefore started with the smaller unresolved UI items that still mapped cleanly to the codebase, especially the navigation behavior from `#29` and the floating back-to-top affordance from `#21`.

## Files changed
- `app/layout.tsx`
- `components/Navigation.tsx`
- `components/ui/go-to-top.tsx`

## Verification
- `npm run lint` ? (existing repo warnings remain, no new lint errors introduced)
- `npm run type-check` ?

## Follow-up candidates
The next good low-risk issue to tackle looks like `#77` (section-number contrast/visibility), since it should be a contained landing-page styling fix without backend or schema work.