### PR TITLE
Phase 2: Two-Track Architecture, Party System, QA Mediation & Bug Fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue:*)",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); print\\(d.get\\(''''data'''',{}\\).get\\(''''createDiscussion'''',{}\\).get\\(''''discussion'''',{}\\).get\\(''''url'''',''''error''''\\)\\)\")",
+      "Bash(python3 -c \":*)",
+      "Bash(git -C /Users/abi/Documents/Adventurers-Guild diff --name-only --diff-filter=U)",
+      "Bash(npx prisma:*)",
+      "Bash(mkdir -p /Users/abi/Documents/Adventurers-Guild/app/api/admin/qa-queue/[assignmentId])",
+      "Bash(mkdir -p /Users/abi/Documents/Adventurers-Guild/app/admin/qa-queue/[assignmentId])",
+      "Bash(git -C /Users/abi/Documents/Adventurers-Guild add -A)"
+    ],
+    "additionalDirectories": [
+      "/Users/abi/Documents/Adventurers-Guild/app/api/parties/[id]/members"
+    ]
+  }
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -152,6 +152,13 @@ export default function AdminDashboard() {
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </Button>
+            <Button variant="outline" asChild className="border-orange-500/30 text-orange-400 hover:bg-orange-500/10">
+              <Link href="/admin/qa-queue">
+                <Shield className="h-4 w-4" />
+                QA Queue
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
             <Button variant="outline" asChild>
               <Link href="/dashboard/quests">
                 <Target className="h-4 w-4" />

--- a/app/admin/qa-queue/page.tsx
+++ b/app/admin/qa-queue/page.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Shield, Clock, CheckCircle, XCircle, Loader2, ArrowLeft, ExternalLink } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+interface QueueItem {
+  id: string;
+  status: string;
+  updatedAt: string;
+  quest: {
+    id: string;
+    title: string;
+    track: string;
+    difficulty: string;
+    xpReward: number;
+    monetaryReward: string | null;
+  };
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    rank: string;
+    bootcampLink: { cohort: string | null; bootcampTrack: string; bootcampWeek: number } | null;
+  };
+  submissions: Array<{
+    id: string;
+    submissionContent: string;
+    submissionNotes: string | null;
+    submittedAt: string;
+    reviewNotes: unknown;
+  }>;
+}
+
+const TRACK_COLORS: Record<string, string> = {
+  BOOTCAMP: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  INTERN: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  OPEN: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+};
+
+export default function QAQueuePage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [rejectTarget, setRejectTarget] = useState<QueueItem | null>(null);
+  const [rejectNotes, setRejectNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/login');
+    if (status === 'authenticated' && session?.user?.role !== 'admin') router.push('/dashboard');
+  }, [status, session, router]);
+
+  const fetchQueue = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch('/api/admin/qa-queue');
+    const data = await res.json();
+    setItems(data.assignments ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchQueue(); }, [fetchQueue]);
+
+  const handleApprove = async (assignmentId: string) => {
+    setSubmitting(true);
+    await fetch(`/api/admin/qa-queue/${assignmentId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    });
+    setSubmitting(false);
+    fetchQueue();
+  };
+
+  const handleReject = async () => {
+    if (!rejectTarget || !rejectNotes.trim()) return;
+    setSubmitting(true);
+    await fetch(`/api/admin/qa-queue/${rejectTarget.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim() }),
+    });
+    setSubmitting(false);
+    setRejectTarget(null);
+    setRejectNotes('');
+    fetchQueue();
+  };
+
+  if (status === 'loading' || loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-slate-950">
+        <Loader2 className="w-6 h-6 animate-spin text-orange-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 p-6">
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-8">
+          <Link href="/admin" className="text-slate-400 hover:text-slate-200 transition-colors">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <Shield className="w-6 h-6 text-orange-500" />
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100">QA Queue</h1>
+            <p className="text-slate-400 text-sm">
+              {items.length} submission{items.length !== 1 ? 's' : ''} pending review
+            </p>
+          </div>
+        </div>
+
+        {items.length === 0 ? (
+          <Card className="bg-slate-900 border-slate-800 text-center py-16">
+            <CardContent>
+              <CheckCircle className="w-10 h-10 text-emerald-500 mx-auto mb-3" />
+              <p className="text-slate-300 font-medium">Queue is clear</p>
+              <p className="text-slate-500 text-sm mt-1">All submissions have been reviewed.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {items.map((item) => {
+              const submission = item.submissions[0];
+              return (
+                <Card key={item.id} className="bg-slate-900 border-slate-800">
+                  <CardHeader className="pb-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap mb-1">
+                          <Badge className={`text-xs border ${TRACK_COLORS[item.quest.track] ?? ''}`}>
+                            {item.quest.track}
+                          </Badge>
+                          <Badge variant="outline" className="text-xs border-slate-700 text-slate-400">
+                            {item.quest.difficulty}-rank
+                          </Badge>
+                        </div>
+                        <CardTitle className="text-base text-slate-100 truncate">
+                          {item.quest.title}
+                        </CardTitle>
+                      </div>
+                      <div className="flex items-center gap-1 text-slate-500 text-xs whitespace-nowrap">
+                        <Clock className="w-3.5 h-3.5" />
+                        {submission ? formatDistanceToNow(new Date(submission.submittedAt), { addSuffix: true }) : '—'}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {/* Student info */}
+                    <div className="flex items-center gap-3 p-3 bg-slate-950/60 rounded-lg">
+                      <div className="w-8 h-8 rounded-full bg-orange-500/20 flex items-center justify-center text-orange-400 font-bold text-sm">
+                        {item.user.rank}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-slate-200">{item.user.name}</p>
+                        <p className="text-xs text-slate-500">
+                          {item.user.bootcampLink
+                            ? `Bootcamp · ${item.user.bootcampLink.bootcampTrack} · Week ${item.user.bootcampLink.bootcampWeek}`
+                            : item.user.email}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Submission content */}
+                    {submission && (
+                      <div>
+                        <p className="text-xs text-slate-500 mb-1.5 uppercase tracking-wide font-medium">Submission</p>
+                        <p className="text-sm text-slate-300 bg-slate-950/60 rounded-lg p-3 whitespace-pre-wrap line-clamp-4">
+                          {submission.submissionContent}
+                        </p>
+                        {submission.submissionContent.startsWith('http') && (
+                          <a
+                            href={submission.submissionContent}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-orange-400 hover:text-orange-300 mt-1"
+                          >
+                            <ExternalLink className="w-3 h-3" />
+                            Open link
+                          </a>
+                        )}
+                        {submission.submissionNotes && (
+                          <p className="text-xs text-slate-500 mt-2 bg-slate-950/40 rounded p-2">
+                            <span className="text-slate-400 font-medium">Notes: </span>
+                            {submission.submissionNotes}
+                          </p>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Actions */}
+                    <div className="flex gap-2 pt-1">
+                      <Button
+                        size="sm"
+                        className="bg-emerald-600 hover:bg-emerald-500 text-white gap-1.5"
+                        onClick={() => handleApprove(item.id)}
+                        disabled={submitting}
+                      >
+                        <CheckCircle className="w-3.5 h-3.5" />
+                        Approve — Forward to Client
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="border-red-800 text-red-400 hover:bg-red-950/40 gap-1.5"
+                        onClick={() => { setRejectTarget(item); setRejectNotes(''); }}
+                        disabled={submitting}
+                      >
+                        <XCircle className="w-3.5 h-3.5" />
+                        Reject — Return to Student
+                      </Button>
+                      <Link href={`/admin/qa-queue/${item.id}`} className="ml-auto">
+                        <Button size="sm" variant="ghost" className="text-slate-400 hover:text-slate-200 text-xs">
+                          Full View
+                        </Button>
+                      </Link>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Reject modal */}
+      <Dialog open={!!rejectTarget} onOpenChange={(o) => { if (!o) { setRejectTarget(null); setRejectNotes(''); } }}>
+        <DialogContent className="bg-slate-900 border-slate-800 text-slate-100">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <XCircle className="w-5 h-5 text-red-400" />
+              Reject Submission
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-slate-400">
+              Rejection notes are required and will be shown to the student. Be specific about what needs to be fixed.
+            </p>
+            <Textarea
+              placeholder="e.g. The PR is missing a description. The CSS changes break on mobile at 375px. Please test at small screen sizes before resubmitting."
+              className="bg-slate-950 border-slate-700 text-slate-200 placeholder:text-slate-600 min-h-[100px]"
+              value={rejectNotes}
+              onChange={(e) => setRejectNotes(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" className="text-slate-400" onClick={() => { setRejectTarget(null); setRejectNotes(''); }}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-red-700 hover:bg-red-600 text-white"
+              onClick={handleReject}
+              disabled={!rejectNotes.trim() || submitting}
+            >
+              {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Send Back to Student'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+
+// PATCH /api/admin/qa-queue/[assignmentId] — approve or reject submission
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ assignmentId: string }> }
+) {
+  const user = await requireAuth(request, 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  const { id: adminId } = user;
+
+  const { assignmentId } = await params;
+
+  let body: { action?: string; notes?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON', success: false }, { status: 400 });
+  }
+
+  const { action, notes } = body;
+  if (!action || !['approve', 'reject'].includes(action)) {
+    return NextResponse.json({ error: 'action must be "approve" or "reject"', success: false }, { status: 400 });
+  }
+  if (action === 'reject' && (!notes || notes.trim().length === 0)) {
+    return NextResponse.json({ error: 'notes are required when rejecting', success: false }, { status: 400 });
+  }
+
+  const assignment = await prisma.questAssignment.findUnique({
+    where: { id: assignmentId },
+    include: {
+      quest: { select: { id: true } },
+      submissions: { orderBy: { submittedAt: 'desc' }, take: 1 },
+    },
+  });
+
+  if (!assignment) {
+    return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
+  }
+  if (assignment.status !== 'pending_admin_review') {
+    return NextResponse.json(
+      { error: 'Assignment is not in pending_admin_review status', success: false },
+      { status: 400 }
+    );
+  }
+
+  if (action === 'approve') {
+    await prisma.questAssignment.update({
+      where: { id: assignmentId },
+      data: { status: 'review' },
+    });
+    return NextResponse.json({ message: 'Submission approved — forwarded to client review', success: true });
+  }
+
+  // reject — append admin note to submission reviewNotes (stored as JSON string)
+  const latestSubmission = assignment.submissions[0];
+  let existingNotes: Record<string, string>[] = [];
+  if (latestSubmission?.reviewNotes) {
+    try { existingNotes = JSON.parse(latestSubmission.reviewNotes); } catch { existingNotes = []; }
+  }
+  const newNote: Record<string, string> = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    author: `Admin (${adminId})`,
+    note: notes!.trim(),
+  };
+  const updatedNotes = JSON.stringify([...existingNotes, newNote]);
+
+  await prisma.$transaction([
+    prisma.questAssignment.update({
+      where: { id: assignmentId },
+      data: { status: 'needs_rework' },
+    }),
+    prisma.quest.update({
+      where: { id: assignment.quest.id },
+      data: { revisionCount: { increment: 1 } },
+    }),
+    ...(latestSubmission
+      ? [prisma.questSubmission.update({
+          where: { id: latestSubmission.id },
+          data: { reviewNotes: updatedNotes },
+        })]
+      : []),
+  ]);
+
+  return NextResponse.json({ message: 'Submission rejected — returned to student for revision', success: true });
+}

--- a/app/api/admin/qa-queue/route.ts
+++ b/app/api/admin/qa-queue/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+
+// GET /api/admin/qa-queue — FIFO list of submissions pending QA review
+export async function GET(request: NextRequest) {
+  const user = await requireAuth(request, 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+
+  const assignments = await prisma.questAssignment.findMany({
+    where: { status: 'pending_admin_review' },
+    include: {
+      quest: {
+        select: { id: true, title: true, track: true, difficulty: true, xpReward: true, monetaryReward: true },
+      },
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          rank: true,
+          bootcampLink: { select: { bootcampTrack: true, bootcampWeek: true } },
+        },
+      },
+      submissions: {
+        orderBy: { submittedAt: 'desc' },
+        take: 1,
+        select: {
+          id: true,
+          submissionContent: true,
+          submissionNotes: true,
+          submittedAt: true,
+          reviewNotes: true,
+        },
+      },
+    },
+    orderBy: { assignedAt: 'asc' }, // oldest first — FIFO
+  });
+
+  return NextResponse.json({ assignments, total: assignments.length, success: true });
+}

--- a/app/api/matching/route.ts
+++ b/app/api/matching/route.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
   try {
-    const authUser = await getAuthUser();
+    const authUser = await getAuthUser(request);
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
@@ -186,7 +186,7 @@ export async function GET(request: NextRequest) {
 // Endpoint to get recommendations based on user activity
 export async function POST(request: NextRequest) {
   try {
-    const authUser = await getAuthUser();
+    const authUser = await getAuthUser(request);
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }

--- a/app/api/parties/[id]/members/[userId]/route.ts
+++ b/app/api/parties/[id]/members/[userId]/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+
+// DELETE /api/parties/[id]/members/[userId]
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; userId: string }> }
+) {
+  const user = await requireAuth(request, 'adventurer', 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  const { id: callerId, role } = user;
+
+  const { id: partyId, userId: targetUserId } = await params;
+
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { leaderId: true },
+  });
+
+  if (!party) {
+    return NextResponse.json({ error: 'Party not found', success: false }, { status: 404 });
+  }
+  if (role !== 'admin' && party.leaderId !== callerId) {
+    return NextResponse.json({ error: 'Only the party leader can remove members', success: false }, { status: 403 });
+  }
+  if (targetUserId === party.leaderId) {
+    return NextResponse.json({ error: 'The party leader cannot be removed', success: false }, { status: 400 });
+  }
+
+  const member = await prisma.partyMember.findUnique({
+    where: { partyId_userId: { partyId, userId: targetUserId } },
+  });
+  if (!member) {
+    return NextResponse.json({ error: 'User is not a member of this party', success: false }, { status: 404 });
+  }
+
+  await prisma.partyMember.delete({ where: { partyId_userId: { partyId, userId: targetUserId } } });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/parties/[id]/members/route.ts
+++ b/app/api/parties/[id]/members/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+import { QuestTrack } from '@prisma/client';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// POST /api/parties/[id]/members — add a member (leader only)
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await requireAuth(request, 'adventurer', 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  const { id: callerId, role } = user;
+
+  const { id: partyId } = await params;
+
+  let body: { userId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON', success: false }, { status: 400 });
+  }
+
+  const { userId: targetUserId } = body;
+  if (!targetUserId || !UUID_REGEX.test(targetUserId)) {
+    return NextResponse.json({ error: 'userId is required and must be a valid UUID', success: false }, { status: 400 });
+  }
+
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    include: { members: true },
+  });
+
+  if (!party) {
+    return NextResponse.json({ error: 'Party not found', success: false }, { status: 404 });
+  }
+  if (role !== 'admin' && party.leaderId !== callerId) {
+    return NextResponse.json({ error: 'Only the party leader can add members', success: false }, { status: 403 });
+  }
+  if (party.members.length >= party.maxSize) {
+    return NextResponse.json({ error: `Party is full (max ${party.maxSize} members)`, success: false }, { status: 400 });
+  }
+  if (party.members.some((m) => m.userId === targetUserId)) {
+    return NextResponse.json({ error: 'User is already a party member', success: false }, { status: 409 });
+  }
+
+  const targetUser = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { id: true, role: true },
+  });
+  if (!targetUser || targetUser.role !== 'adventurer') {
+    return NextResponse.json({ error: 'Target user not found or is not an adventurer', success: false }, { status: 400 });
+  }
+
+  if (party.track === QuestTrack.BOOTCAMP) {
+    const link = await prisma.bootcampLink.findUnique({ where: { userId: targetUserId }, select: { id: true } });
+    if (!link) {
+      return NextResponse.json({ error: 'Bootcamp track parties require bootcamp-enrolled members', success: false }, { status: 400 });
+    }
+  }
+
+  await prisma.partyMember.create({ data: { partyId, userId: targetUserId, isLeader: false } });
+
+  const updated = await prisma.party.findUnique({
+    where: { id: partyId },
+    include: {
+      leader: { select: { id: true, name: true, rank: true } },
+      members: {
+        include: { user: { select: { id: true, name: true, rank: true } } },
+        orderBy: { joinedAt: 'asc' },
+      },
+    },
+  });
+
+  return NextResponse.json({ party: updated, success: true }, { status: 201 });
+}

--- a/app/api/parties/[id]/route.ts
+++ b/app/api/parties/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+
+// GET /api/parties/[id]
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await requireAuth(request, 'adventurer', 'company', 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+
+  const { id } = await params;
+
+  const party = await prisma.party.findUnique({
+    where: { id },
+    include: {
+      leader: { select: { id: true, name: true, rank: true } },
+      members: {
+        include: { user: { select: { id: true, name: true, rank: true } } },
+        orderBy: { joinedAt: 'asc' },
+      },
+    },
+  });
+
+  if (!party) {
+    return NextResponse.json({ error: 'Party not found', success: false }, { status: 404 });
+  }
+
+  return NextResponse.json({ party, success: true });
+}

--- a/app/api/parties/route.ts
+++ b/app/api/parties/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireAuth } from '@/lib/api-auth';
+import { QuestTrack, UserRank } from '@prisma/client';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const RANK_ORDER: Record<UserRank, number> = {
+  F: 0, E: 1, D: 2, C: 3, B: 4, A: 5, S: 6,
+};
+
+// POST /api/parties — form a party for a quest
+export async function POST(request: NextRequest) {
+  const user = await requireAuth(request, 'adventurer', 'admin');
+  if (!user) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+
+  const { id: userId, role, rank } = user;
+
+  let body: { questId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON', success: false }, { status: 400 });
+  }
+
+  const { questId } = body;
+  if (!questId || !UUID_REGEX.test(questId)) {
+    return NextResponse.json({ error: 'questId is required and must be a valid UUID', success: false }, { status: 400 });
+  }
+
+  const quest = await prisma.quest.findUnique({
+    where: { id: questId },
+    select: { id: true, status: true, track: true, difficulty: true, party: { select: { id: true } } },
+  });
+
+  if (!quest) {
+    return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
+  }
+  if (!['available', 'in_progress'].includes(quest.status)) {
+    return NextResponse.json({ error: 'Quest is not available for a party', success: false }, { status: 400 });
+  }
+  if (quest.party) {
+    return NextResponse.json({ error: 'A party already exists for this quest', success: false }, { status: 409 });
+  }
+
+  // Rank check (skip for admin)
+  if (role !== 'admin' && rank) {
+    if (RANK_ORDER[rank as UserRank] < RANK_ORDER[quest.difficulty]) {
+      return NextResponse.json(
+        { error: `Quest requires rank ${quest.difficulty} or higher to lead`, success: false },
+        { status: 403 }
+      );
+    }
+
+    // Bootcamp quest: leader must have a BootcampLink
+    if (quest.track === QuestTrack.BOOTCAMP) {
+      const link = await prisma.bootcampLink.findUnique({ where: { userId }, select: { id: true } });
+      if (!link) {
+        return NextResponse.json({ error: 'Bootcamp track quests require a bootcamp enrollment', success: false }, { status: 403 });
+      }
+    }
+  }
+
+  const maxSize = quest.track === QuestTrack.BOOTCAMP ? 2 : 5;
+
+  const party = await prisma.$transaction(async (tx) => {
+    const created = await tx.party.create({
+      data: { questId, leaderId: userId, track: quest.track, maxSize },
+    });
+    await tx.partyMember.create({
+      data: { partyId: created.id, userId, isLeader: true },
+    });
+    return tx.party.findUnique({
+      where: { id: created.id },
+      include: {
+        leader: { select: { id: true, name: true, rank: true } },
+        members: {
+          include: { user: { select: { id: true, name: true, rank: true } } },
+          orderBy: { joinedAt: 'asc' },
+        },
+      },
+    });
+  });
+
+  return NextResponse.json({ party, success: true }, { status: 201 });
+}

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -233,7 +233,7 @@ export async function POST(request: NextRequest) {
     // Update company spending
     const { updateCompanySpending } = await import('@/lib/xp-utils');
     try {
-      await updateCompanySpending(body.from_userId, body.amount);
+      await updateCompanySpending(body.fromUserId, body.amount);
     } catch (e) {
       console.error('Error updating company spending:', e);
     }

--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -8,7 +8,7 @@ type ReviewStatus = (typeof VALID_REVIEW_STATUSES)[number];
 
 export async function GET(request: NextRequest) {
   try {
-    const authUser = await requireAuth('company', 'admin');
+    const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
@@ -92,7 +92,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const authUser = await requireAuth('company', 'admin');
+    const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
@@ -220,7 +220,7 @@ export async function POST(request: NextRequest) {
 // API to get quality statistics
 export async function PUT(request: NextRequest) {
   try {
-    const authUser = await requireAuth('company', 'admin');
+    const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }

--- a/app/api/quests/[id]/route.ts
+++ b/app/api/quests/[id]/route.ts
@@ -70,6 +70,15 @@ export async function GET(
             },
           },
         },
+        party: {
+          include: {
+            leader: { select: { id: true, name: true, rank: true } },
+            members: {
+              include: { user: { select: { id: true, name: true, rank: true } } },
+              orderBy: { joinedAt: 'asc' },
+            },
+          },
+        },
       },
     });
 

--- a/app/api/quests/assignments/route.ts
+++ b/app/api/quests/assignments/route.ts
@@ -54,9 +54,11 @@ export async function GET(request: NextRequest) {
         'started',
         'in_progress',
         'submitted',
+        'pending_admin_review',
         'review',
         'completed',
         'cancelled',
+        'needs_rework',
       ];
       if (!validStatuses.includes(status as AssignmentStatus)) {
         return NextResponse.json({ error: 'Invalid status filter', success: false }, { status: 400 });
@@ -153,7 +155,7 @@ export async function POST(request: NextRequest) {
       const count = await prisma.questAssignment.count({
         where: {
           questId: questId,
-          status: { in: ['started', 'in_progress', 'submitted', 'review', 'completed'] },
+          status: { in: ['started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed'] },
         },
       });
 
@@ -162,11 +164,12 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Check if user is already assigned to this quest
+    // Check if user is already assigned to this quest (ignore cancelled)
     const existingAssignment = await prisma.questAssignment.findFirst({
       where: {
         questId: questId,
         userId,
+        status: { not: 'cancelled' },
       },
     });
 
@@ -221,9 +224,11 @@ export async function PUT(request: NextRequest) {
       'started',
       'in_progress',
       'submitted',
+      'pending_admin_review',
       'review',
       'completed',
       'cancelled',
+      'needs_rework',
     ];
     const adventurerStatuses: AssignmentStatus[] = ['started', 'in_progress'];
     const allowedStatuses = user.role === 'admin' ? adminStatuses : adventurerStatuses;

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -107,7 +107,7 @@ export async function POST(request: NextRequest) {
     // Check if the assignment exists and belongs to the current user
     const assignment = await prisma.questAssignment.findUnique({
       where: { id: assignmentId },
-      select: { status: true, userId: true, questId: true },
+      select: { status: true, userId: true, questId: true, quest: { select: { track: true } } },
     });
 
     if (!assignment) {
@@ -123,6 +123,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid assignment state for submission', success: false }, { status: 400 });
     }
 
+    // BOOTCAMP and INTERN quests go to pending_admin_review (Open Paws QA gate)
+    // OPEN track goes directly to submitted (client sees immediately)
+    const postSubmitStatus =
+      assignment.quest.track !== 'OPEN' ? 'pending_admin_review' : 'submitted';
+
     const data = await prisma.$transaction(
       async (tx) => {
         const submission = await tx.questSubmission.create({
@@ -136,7 +141,7 @@ export async function POST(request: NextRequest) {
 
         await tx.questAssignment.update({
           where: { id: assignmentId },
-          data: { status: 'submitted' },
+          data: { status: postSubmitStatus },
         });
 
         await syncQuestLifecycleStatus(tx, assignment.questId);

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -119,7 +119,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized to submit for this assignment', success: false }, { status: 403 });
     }
 
-    if (!['assigned', 'started', 'in_progress'].includes(assignment.status)) {
+    if (!['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status)) {
       return NextResponse.json({ error: 'Invalid assignment state for submission', success: false }, { status: 400 });
     }
 

--- a/app/api/users/me/stats/route.ts
+++ b/app/api/users/me/stats/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
     const activeCount = await prisma.questAssignment.count({
       where: {
         userId,
-        status: { in: ['assigned', 'in_progress'] },
+        status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework'] },
       },
     });
 

--- a/app/dashboard/company/quests/page.tsx
+++ b/app/dashboard/company/quests/page.tsx
@@ -122,7 +122,7 @@ export default function CompanyQuestsPage() {
   if (status === 'loading' || loading) {
     return (
       <GuildPage>
-        <GuildPanel className="flex min-h-[320px] items-center justify-center">
+        <GuildPanel className="flex min-h-[160px] sm:min-h-[320px] items-center justify-center">
           <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-primary" />
         </GuildPanel>
       </GuildPage>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -253,7 +253,7 @@ export default async function DashboardPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             {activeAssignments.length === 0 ? (
-              <div className="flex h-[200px] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-slate-300 text-slate-500">
+              <div className="flex h-[120px] sm:h-[200px] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-slate-300 text-slate-500">
                 <p>No active quests yet.</p>
                 <Button size="sm" asChild>
                   <Link href="/dashboard/quests">Browse Quest Board</Link>

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -68,7 +68,10 @@ function assignmentStatusClass(status: string) {
     case 'in_progress':
       return 'bg-amber-100 text-amber-700 border-amber-300';
     case 'submitted':
+    case 'pending_admin_review':
       return 'bg-violet-100 text-violet-700 border-violet-300';
+    case 'needs_rework':
+      return 'bg-orange-100 text-orange-700 border-orange-300';
     case 'completed':
       return 'bg-emerald-100 text-emerald-700 border-emerald-300';
     case 'cancelled':
@@ -167,7 +170,7 @@ export default function QuestDetailPage() {
 
   const isAssigned = !!assignment;
   const canAssign = quest?.status === 'available' && !isAssigned;
-  const canSubmit = !!assignment && ['assigned', 'started', 'in_progress'].includes(assignment.status);
+  const canSubmit = !!assignment && ['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status);
 
   const rewardCards = useMemo(
     () =>
@@ -337,15 +340,17 @@ export default function QuestDetailPage() {
                       </p>
                     </div>
                     <Badge variant="outline" className={assignmentStatusClass(assignment.status)}>
-                      {assignment.status.replace('_', ' ')}
+                      {assignment.status.replaceAll('_', ' ')}
                     </Badge>
                   </div>
                   <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
                     {assignment.status === 'completed'
                       ? 'This quest is complete on your ledger.'
-                      : assignment.status === 'submitted'
+                      : assignment.status === 'submitted' || assignment.status === 'pending_admin_review'
                         ? 'Your delivery is in review.'
-                        : 'You are currently responsible for this quest. Keep delivery momentum high.'}
+                        : assignment.status === 'needs_rework'
+                          ? 'Your submission needs revision. Check reviewer feedback and resubmit.'
+                          : 'You are currently responsible for this quest. Keep delivery momentum high.'}
                   </div>
                   {assignment.status === 'completed' && (
                     <div className="flex items-center gap-2 text-sm font-medium text-emerald-700">
@@ -376,6 +381,12 @@ export default function QuestDetailPage() {
                           body: JSON.stringify({ questId }),
                         });
 
+                        if (!response.ok && response.status === 401) {
+                          toast.error('Session expired — please log in again');
+                          router.push('/login');
+                          return;
+                        }
+
                         const data = await response.json();
                         if (!data.success) {
                           toast.error(data.error || 'Failed to assign to quest');
@@ -404,7 +415,7 @@ export default function QuestDetailPage() {
                   <div>
                     <h2 className="text-lg font-semibold text-slate-900">Quest not claimable</h2>
                     <p className="mt-1 text-sm text-slate-500">
-                      This quest is currently {quest.status.replace('_', ' ')}.
+                      This quest is currently {quest.status.replaceAll('_', ' ')}.
                     </p>
                   </div>
                 </div>

--- a/components/ui/animated-shader-hero.tsx
+++ b/components/ui/animated-shader-hero.tsx
@@ -296,6 +296,17 @@ void main(){gl_Position=position;}`;
   useEffect(() => {
     if (!canvasRef.current) return;
 
+    // Skip WebGL on low-end devices — go straight to CSS gradient fallback.
+    // navigator.deviceMemory (GB) and hardwareConcurrency (logical cores) are
+    // available in Chrome/Android — the primary low-end mobile environment.
+    const nav = navigator as Navigator & { deviceMemory?: number };
+    const lowMem = nav.deviceMemory !== undefined && nav.deviceMemory < 2;
+    const lowCpu = navigator.hardwareConcurrency !== undefined && navigator.hardwareConcurrency < 4;
+    if (lowMem || lowCpu) {
+      setWebglFailed(true);
+      return;
+    }
+
     const canvas = canvasRef.current;
     const dpr = Math.max(1, 0.5 * window.devicePixelRatio);
 

--- a/docs/GROWTH_PLAN_2026_Q2.md
+++ b/docs/GROWTH_PLAN_2026_Q2.md
@@ -1,0 +1,287 @@
+# Adventurers Guild — Growth & Outreach Plan (Q2 2026)
+
+> Updated: 2026-03-21
+> Owner: Abid Khan
+> Goal: 50 active adventurers, 5 external companies, 1 hire by AG rank — by July 2026
+
+---
+
+## 1. Content & Social Media
+
+### X (Twitter) — @AdventurersGuild / @LarytheLord
+
+**Posting schedule**: 3x/week minimum
+
+**Content pillars:**
+
+| Day | Pillar | Example Posts |
+|-----|--------|-------------|
+| **Monday** | Build in public | "Week 8 of building AG: shipped the Party System. Here's how squads of 3-5 devs coordinate on quests..." (screenshot of party panel) |
+| **Tuesday** | Dev career advice | "Entry-level dev hiring collapsed 78% since 2019. The question isn't how to get hired — it's how to build proof you can ship. Here's what AG does differently..." |
+| **Thursday** | Feature showcase | "Your Guild Card is your dev credential. Rank, quests completed, quality scores — all verifiable. No more 'trust me I can code'." (Guild Card screenshot) |
+| **Saturday** | Community highlight | "Shoutout to @Adil2009700 for crushing the mobile UX rewrite. 54 files, clean PR. This is what B-rank work looks like." |
+
+**Hooks that work for dev audiences:**
+- "I built [feature] in [timeframe]. Here's the architecture decision that made it possible..."
+- "Why [famous platform] failed at [thing AG solves]..."
+- "Replit shut down Bounties. Here's why AG won't follow the same path..."
+- "[Number] quests completed this week on AG. Here's what our adventurers shipped..."
+- Thread: "I'm building the Adventurers Guild from Solo Leveling, but for real developers. Here's the full story..."
+
+**Key hashtags**: #buildinpublic #devtools #opensourceindia #webdev #nextjs #futureowork
+
+### LinkedIn
+
+**Posting schedule**: 2x/week
+
+**Different angle**: Professional/career focused, not dev-technical
+
+| Type | Content |
+|------|---------|
+| **Thought leadership** | "The junior developer hiring crisis is real. Here's data: [stats]. Here's what we're building to fix it." |
+| **Milestone posts** | "Adventurers Guild just shipped Phase 2: squad system, QA mediation, and two-track architecture for 70 developers." |
+| **Hiring signal** | "What if a developer's rank told you more than their resume? AG rank = verified quests completed + quality scores + progression history." |
+| **Bootcamp launch** | "We're onboarding 50 coding bootcamp students onto real client projects through the Adventurers Guild. Here's how the pipeline works..." |
+
+**Who to tag**: Open Paws team, GSSoC, NASSCOM, Indian startup founders in your network
+
+### Replit Community
+
+**Why**: Replit just shut down Bounties and moved users to Contra. AG is a direct alternative for Replit developers looking for paid coding work with progression.
+
+**Actions:**
+- [ ] Post in Replit community forums: "Building an alternative to Bounties — with XP, ranks, and progression. Open source."
+- [ ] Create a Repl that demos AG's quest flow (or links to live site)
+- [ ] Engage in "what happened to Bounties" threads with genuine value (not spam)
+- [ ] Cross-post to r/replit on Reddit
+
+### Dev.to / Hashnode / Medium
+
+**Write 2 articles:**
+
+1. **"I Built a Real Adventurers Guild for Developers — From Solo Leveling to Production"**
+   - The story: anime inspiration → real platform → how it works
+   - Technical depth: Next.js 15, Prisma, ranking algorithm
+   - Call to action: try the platform, contribute on GitHub
+
+2. **"Why Replit Bounties Failed and What Developer Marketplaces Get Wrong"**
+   - Analysis: quality control, retention, economics
+   - How AG is different: credential system, QA mediation, rank = trust
+   - Data-backed (when available after bootcamp)
+
+---
+
+## 2. Tester Recruitment
+
+### Who We Need
+
+| Type | Count | Where to Find |
+|------|-------|--------------|
+| **Adventurer testers** (developers who try quests) | 20 | College networks, Discord, X |
+| **Company testers** (people who post quests) | 5 | Founder friends, AARC, Open Paws network |
+| **QA testers** (people who break things) | 3 | GSSoC community, existing contributors |
+
+### Tester Onboarding Script
+
+**For adventurer testers** (DM/email template):
+```
+Hey [name],
+
+I'm building Adventurers Guild — a platform where developers complete real
+coding quests, earn XP, rank up (F→S), and get paid. Think Upwork meets RPG
+progression.
+
+Would you be up for testing it? Takes ~30 min:
+1. Register at adventurersguild.space
+2. Browse the quest board
+3. Claim a quest and try to submit
+4. Tell me what broke / confused you
+
+Your feedback directly shapes the product. And you'll be one of the
+first-ever ranked adventurers on the platform.
+
+Interested?
+```
+
+**For company testers:**
+```
+Hey [name],
+
+I'm building Adventurers Guild — a dev marketplace where developers are
+ranked by verified quest completions (not self-reported skills). You post a
+task, ranked developers deliver it.
+
+Would you try posting one task? I'll personally ensure quality:
+- No cost (free during beta)
+- I'll match you with a developer
+- You just review the delivery
+
+If the output is good, you've found a talent pipeline. If not, you've spent
+10 minutes and given me invaluable feedback.
+
+Game?
+```
+
+### Where to Recruit
+
+| Channel | Action | Timeline |
+|---------|--------|----------|
+| **Your college CS group** | Post in WhatsApp/Telegram group | Week 1 |
+| **GSSoC Discord** | Post in #projects-showcase | Week 1 |
+| **r/developersIndia** | Post asking for beta testers | Week 2 |
+| **r/webdev, r/nextjs** | Share the build-in-public story | Week 2 |
+| **Indie Hackers** | Post product launch + looking for testers | Week 2 |
+| **Product Hunt** | Ship page (not full launch yet — "coming soon") | Week 3 |
+| **X DMs** | DM 10 dev influencers with small followings (1-10K) | Week 2-3 |
+| **LinkedIn** | Post "looking for beta testers" with clear ask | Week 1 |
+| **Hackathon networks** | Reach out to past hackathon teammates | Week 1-2 |
+
+---
+
+## 3. Company Outreach (Getting the First 5)
+
+### Target Profile
+- Indian SaaS startups with 5-30 engineers
+- Have a backlog of "nice to have" features nobody has time for
+- Technical founder who can appreciate the platform
+- Budget: even ₹5K-20K per quest is fine to prove the model
+
+### Outreach List (Build This Week)
+
+| Source | How to Find | Expected Yield |
+|--------|------------|----------------|
+| **AARC network** | People you've met at AARC events | 2-3 warm intros |
+| **Hackathon contacts** | Teams you competed with/against | 2-3 founders |
+| **Open Paws network** | Sam's contacts, partner orgs | 1-2 orgs |
+| **YC India founders** | LinkedIn search "YC + India + founder" | Cold outreach |
+| **IndieHackers India** | Active builders with side projects | 2-3 makers |
+
+### The Pitch (30-second version)
+> "I built a platform where developers complete real coding tasks and earn a verified rank. You post a task, a ranked developer delivers it. You only pay if you approve. No upfront cost to try — post your first quest free."
+
+### The Ask (Make It Easy)
+Don't ask them to "try the platform." Ask them:
+> "Do you have ONE task sitting in your backlog that nobody has time for? Give it to me. I'll get it done through AG and you tell me if the quality was acceptable."
+
+You do the matchmaking manually. The platform facilitates the delivery. The company just reviews output.
+
+---
+
+## 4. Community Building
+
+### Discord Server
+
+- [ ] Create AG Discord server (if not exists)
+- [ ] Channels: #quest-board, #party-finder, #guild-hall (general), #help, #showcase
+- [ ] Bot: post new quests automatically when created
+- [ ] Weekly "Guild Meeting" voice chat (15 min, casual) — builds community
+
+### GitHub as Community
+
+- [x] Discussions enabled with context (#112-#118, #124-#125, #139)
+- [x] Contributor-friendly issues with full specs (#134-#138)
+- [ ] CONTRIBUTING.md with clear guidelines
+- [ ] "Good first issue" label actively maintained
+- [ ] Respond to every PR within 24 hours
+- [ ] Welcome comment bot for first-time contributors
+
+### College Ambassador Program (Start Small)
+
+**Phase 1 (April):** 3 colleges
+- Find 1 CS student per college who's active on GitHub
+- Give them: "Adventurers Guild Campus Rep" title
+- Their job: recruit 10 students from their college to register
+- Reward: early B-rank status + featured on the platform
+
+**Phase 2 (May-June):** Scale to 10 colleges if Phase 1 works
+
+---
+
+## 5. Partnerships & Grants
+
+### Immediate (This Month)
+
+| Action | Timeline | Notes |
+|--------|----------|-------|
+| Apply to Startup India (DPIIT recognition) | This week | Free, takes 10 min, unlocks tax benefits |
+| Apply to AWS Activate / GCP for Startups | This week | Free cloud credits |
+| Research NASSCOM 10,000 Startups | This week | Shortlist for April application |
+| Research 100X.VC | This week | ₹25L SAFE, designed for early stage |
+
+### April
+
+| Action | Timeline | Notes |
+|--------|----------|-------|
+| Apply to first grant (NASSCOM or 100X.VC) | April 10 | Need investor one-pager with real data |
+| Apply to Google for Startups Accelerator India | April 15 | If AI matching feature is planned |
+| Submit to lablab.ai hackathon | When next one opens | Build AG feature as hackathon project |
+
+---
+
+## 6. Weekly Rhythm
+
+Starting this week, maintain this cadence:
+
+### Daily
+- Check GitHub for new PRs/issues/comments — respond within 24h
+- 1 X post (even if short)
+
+### Weekly (Every Monday)
+- [ ] Review metrics: registered users, quests completed this week, active users
+- [ ] Review open PRs — merge or comment
+- [ ] Plan the week's content (3 X posts, 2 LinkedIn posts)
+- [ ] Reach out to 2 new potential company testers
+
+### Bi-weekly (Every Other Friday)
+- [ ] Update ROADMAP with progress
+- [ ] Write a build-in-public thread summarizing 2 weeks of progress
+- [ ] Check competitor activity (Contra, Andela, new entrants)
+
+### Monthly
+- [ ] Cohort analysis: are users from 30 days ago still active?
+- [ ] Review financial model assumptions against real data
+- [ ] Update investor one-pager
+
+---
+
+## 7. Success Metrics (Track Weekly)
+
+| Metric | Current | April Target | May Target | July Target |
+|--------|---------|-------------|------------|-------------|
+| Registered users | ~500 | 550 | 600 | 800 |
+| Active users (weekly) | Unknown | 30 | 50 | 100 |
+| Quests completed | Unknown | 10 | 30 | 100 |
+| External companies | 0 | 1 | 3 | 5 |
+| Quest completion rate | Unknown | >50% | >60% | >70% |
+| Guild Card views | 0 | 50 | 200 | 1,000 |
+| Hires by AG rank | 0 | 0 | 0 | 1 |
+
+---
+
+## 8. Content Calendar — Next 2 Weeks
+
+### Week of Mar 24
+
+| Day | Platform | Content |
+|-----|----------|---------|
+| Mon | X | "We just shipped the Party System for @AdventurersGuild. Squads of 3-5 devs can now team up on quests. Here's how it works..." [thread with screenshots] |
+| Tue | LinkedIn | "The junior developer hiring crisis: 78% collapse in entry-level Big Tech hiring since 2019. Here's what we're building to fix it." |
+| Wed | X | "Every quest completed on AG becomes a verified credential. Your Guild Card is coming next week — rank, quests, quality scores, all shareable." |
+| Thu | Dev.to | Publish article: "I Built a Real Adventurers Guild for Developers" |
+| Fri | X | "Looking for 20 developers to beta test Adventurers Guild. Claim quests, earn XP, rank up. DM me or register at adventurersguild.space" |
+| Sat | LinkedIn | "Shoutout to our contributors this week: [names]. Open source collaboration at its best." |
+
+### Week of Mar 31
+
+| Day | Platform | Content |
+|-----|----------|---------|
+| Mon | X | "Guild Card is LIVE. Your developer credential — rank, completed quests, skills — all on one shareable page. Here's mine:" [screenshot] |
+| Tue | Reddit | Post to r/developersIndia: "Built an open-source platform where devs earn verified rank by completing real coding quests — looking for feedback" |
+| Wed | X | "Replit shut down Bounties. Here's why developer task marketplaces keep failing — and what we're doing differently." [thread] |
+| Thu | LinkedIn | "We're onboarding 50 bootcamp students onto real client projects this May through Adventurers Guild. Here's the pipeline:" |
+| Fri | X | Contributor highlight + open issues showcase |
+| Sat | Indie Hackers | Post: "Adventurers Guild — gamified dev marketplace with F-to-S ranking. Looking for feedback." |
+
+---
+
+*This plan is a living document. Update weekly with real metrics and adjust based on what's working.*

--- a/docs/IMPLEMENTATION_TASKS.md
+++ b/docs/IMPLEMENTATION_TASKS.md
@@ -2,7 +2,7 @@
 
 Task queue for the Open Paws Bootcamp integration and platform scale-up. Tasks are ordered by dependency. Do not skip ahead.
 
-**Current date**: 2026-03-16
+**Current date**: 2026-03-21
 **Sprint target**: Platform operational for intern + bootcamp launch by May 2026
 
 ---
@@ -13,7 +13,8 @@ Task queue for the Open Paws Bootcamp integration and platform scale-up. Tasks a
 |-------|--------|-------|
 | Phase 0: Schema & Prerequisites | ✅ Complete | All schema changes merged |
 | Phase 1: Bootcamp Integration | ✅ Complete | All 5 tasks done (PR #103) |
-| Phase 2: Squad System + Payments | 🔨 In Progress | 4 tasks, target ~April 13 |
+| Phase 2: Squad System + Payments | ✅ Core done | 2.A + 2.B done, 2.C + 2.D delegated |
+| Phase 2.5: Credential System | 🔨 In Progress | Guild Card, Analytics, Streaks — NEW |
 | Phase 3: Platform Polish + Scale | ⏳ Planned | 6 tasks, target ~May 11 |
 
 ---
@@ -71,16 +72,17 @@ Task queue for the Open Paws Bootcamp integration and platform scale-up. Tasks a
 
 ---
 
-## 🔨 Phase 2: Squad System + Payment Infrastructure
+## ✅ Phase 2: Squad System + Payment Infrastructure
 
 **Target: ~April 13, 2026 (2 weeks)**
 **GitHub issues**: See linked issues for full spec.
+**Updated**: 2026-03-21
 
 ---
 
-### Task 2.A: Squad/Party System — Schema and API
+### ~~Task 2.A: Squad/Party System — Schema and API~~ ✅
 
-**GitHub issue**: [#TBD Squad/Party System](https://github.com/LarytheLord/Adventurers-Guild/issues)
+**GitHub issue**: [#104](https://github.com/LarytheLord/Adventurers-Guild/issues/104) (closed)
 **Full spec**: [`docs/SQUAD_PARTY_SYSTEM.md`](./SQUAD_PARTY_SYSTEM.md)
 **Rank**: S
 
@@ -143,9 +145,9 @@ model PartyMember {
 
 ---
 
-### Task 2.B: Admin QA Mediation Layer
+### ~~Task 2.B: Admin QA Mediation Layer~~ ✅
 
-**GitHub issue**: [#TBD Admin QA Mediation](https://github.com/LarytheLord/Adventurers-Guild/issues)
+**GitHub issue**: [#105](https://github.com/LarytheLord/Adventurers-Guild/issues/105) (closed)
 **Full spec**: [`docs/ADMIN_QA_MEDIATION.md`](./ADMIN_QA_MEDIATION.md)
 **Rank**: A
 

--- a/docs/MARKETING_AUTOMATION.md
+++ b/docs/MARKETING_AUTOMATION.md
@@ -1,0 +1,289 @@
+# Marketing Automation Plan — 4 Accounts
+
+> Updated: 2026-03-23
+> Accounts: X (personal @LarytheLord + project @AG), LinkedIn (personal + project page)
+> Automation: Claude Cowork for drafting + scheduling
+
+---
+
+## Account Strategy — Different Voice, Different Audience
+
+### Account 1: X — Personal (@LarytheLord / Abid)
+**Voice**: Founder building in public. Technical, honest, personal.
+**Audience**: Indian dev community, indie hackers, CS students
+**Content ratio**: 60% build-in-public, 20% dev career advice, 20% AG showcases
+
+### Account 2: X — Project (@AdventurersGuild or similar)
+**Voice**: The Guild itself. Authoritative, game-themed, community-focused.
+**Audience**: Developers looking for work, companies looking for talent
+**Content ratio**: 40% quest/feature announcements, 30% adventurer highlights, 30% dev industry takes
+
+### Account 3: LinkedIn — Personal (Abid Khan)
+**Voice**: Professional founder. Strategic, growth-focused, data-driven.
+**Audience**: VCs, startup founders, HR/hiring managers, EdTech community
+**Content ratio**: 40% thought leadership, 30% milestone posts, 30% hiring/talent insights
+
+### Account 4: LinkedIn — Project Page (Adventurers Guild)
+**Voice**: Product/company page. Feature-focused, credibility-building.
+**Audience**: Companies considering AG, developers evaluating platforms
+**Content ratio**: 50% product updates, 30% case studies/testimonials, 20% industry data
+
+---
+
+## Weekly Posting Schedule
+
+| Day | X Personal | X Project | LinkedIn Personal | LinkedIn Project |
+|-----|-----------|-----------|-------------------|-----------------|
+| **Mon** | Build log thread | Quest of the week | — | Product update |
+| **Tue** | — | Dev tip/resource | Thought leadership | — |
+| **Wed** | Technical deep dive | — | — | Feature spotlight |
+| **Thu** | — | Adventurer highlight | — | — |
+| **Fri** | Reflection/numbers | Community call-out | Milestone/data post | — |
+| **Sat** | — | — | — | — |
+| **Sun** | Week preview | — | — | — |
+
+**Total**: 10 posts/week across 4 accounts (manageable with automation)
+
+---
+
+## Content Templates for Claude Cowork Automation
+
+### Template 1: X Personal — Build Log (Monday)
+```
+Prompt: Write a build-in-public X thread (4-6 tweets) about this week's progress on Adventurers Guild.
+
+Context:
+- What was built: [insert features/fixes]
+- Key numbers: [users, quests completed, PRs merged]
+- Technical decisions made: [insert]
+- What's next: [insert]
+
+Tone: Honest, technical, first-person. No corporate speak. Use "I" not "we".
+Include 1 screenshot placeholder.
+End with: what should I build next? (engagement hook)
+```
+
+### Template 2: X Project — Quest of the Week (Monday)
+```
+Prompt: Write a single tweet announcing this week's featured quest on Adventurers Guild.
+
+Context:
+- Quest title: [insert]
+- Difficulty: [F/E/D/C/B/A/S]
+- Reward: [XP + optional $]
+- Skills: [insert]
+- Link: adventurersguild.space
+
+Tone: Game-themed, exciting. Use guild terminology (quest, adventurer, rank).
+Format: Short, punchy. Emoji OK (sword, shield, scroll).
+```
+
+### Template 3: LinkedIn Personal — Thought Leadership (Tuesday)
+```
+Prompt: Write a LinkedIn post about [topic] related to the developer hiring market.
+
+Topics rotation:
+- Week 1: Junior developer hiring crisis (78% Big Tech collapse)
+- Week 2: Why portfolios beat resumes
+- Week 3: AI-assisted development is the new baseline
+- Week 4: The credential gap — what replaces the CS degree?
+
+Tone: Professional but not stuffy. Data-backed. Personal anecdote if relevant.
+Length: 150-200 words. No hashtag spam (max 3).
+End with: question to drive comments.
+```
+
+### Template 4: X Project — Adventurer Highlight (Thursday)
+```
+Prompt: Write a tweet highlighting a contributor or adventurer on the platform.
+
+Context:
+- Who: [name/handle]
+- What they did: [PR merged, quest completed, rank-up]
+- Impact: [what it means for the platform]
+
+Tone: Celebratory, community-focused. Tag the person.
+```
+
+### Template 5: LinkedIn Project — Feature Spotlight (Wednesday)
+```
+Prompt: Write a LinkedIn post showcasing a specific AG feature.
+
+Feature rotation:
+- Week 1: Rank system (F→S progression with real work)
+- Week 2: Party/Squad system (team-based quest delivery)
+- Week 3: QA Mediation (admin review layer for quality)
+- Week 4: Guild Card (coming soon — verifiable credential)
+
+Tone: Product-focused, benefit-driven. "Here's what this means for you."
+Include: screenshot/mockup placeholder.
+Length: 100-150 words.
+```
+
+---
+
+## Automation Workflow with Claude Cowork
+
+### Weekly Prep (Sunday evening, 30 min)
+
+1. **Input week's data**: What was built, key numbers, notable events
+2. **Generate all 10 posts** using templates above
+3. **Review and edit** — personal touch on personal accounts
+4. **Schedule** using Buffer/Typefully/manual scheduling
+5. **Queue engagement responses** — prepare replies for likely comments
+
+### Daily (5 min)
+
+1. Check notifications on all 4 accounts
+2. Reply to comments/DMs (prioritize: companies > developers > general)
+3. Engage with 2-3 relevant posts from others (retweet with comment)
+
+### Automation Script Structure
+
+```
+Input: weekly_context.json
+{
+  "week_number": 1,
+  "features_shipped": ["Party System", "QA Mediation", "Claim Quest bug fix"],
+  "prs_merged": 3,
+  "contributors_active": ["Adil2009700", "aryansondharva"],
+  "quests_completed": 5,
+  "new_users": 12,
+  "featured_quest": { "title": "...", "difficulty": "D", "reward": "500 XP" },
+  "highlight_person": { "name": "Adil", "handle": "@Adil2009700", "achievement": "54-file mobile UX rewrite" },
+  "thought_leadership_topic": "junior_hiring_crisis",
+  "feature_spotlight": "rank_system"
+}
+
+Output: 10 post drafts with platform labels
+```
+
+---
+
+## Content Pillars by Platform
+
+### X (Both Accounts)
+1. **Build in Public** — Show the process, not just the result
+2. **Dev Career** — Position AG as the answer to "how do I get experience?"
+3. **Community** — Highlight contributors, celebrate rank-ups
+4. **Industry Takes** — Comment on dev hiring, freelancing, AI trends
+5. **Product** — New features, quest announcements, milestones
+
+### LinkedIn (Both Accounts)
+1. **Thought Leadership** — Data-backed takes on dev hiring market
+2. **Milestones** — "We hit X users / Y quests / Z completions"
+3. **Talent Signal** — "What if rank told you more than a resume?"
+4. **Bootcamp Pipeline** — Document the Open Paws bootcamp journey
+5. **Case Studies** — (Future) Real companies that hired AG-ranked devs
+
+---
+
+## Key Hashtags
+
+**X**: #buildinpublic #devtools #webdev #nextjs #opensourceindia #freelancedev #100DaysOfCode
+**LinkedIn**: #developertools #futureofwork #edtech #startupindia #remotework #hiringtrends
+
+---
+
+## Engagement Strategy
+
+### Who to Engage With (Build Relationships)
+- **Indian dev Twitter**: @AkshatShrivasta, @gaborcselle, Indian YC founders
+- **Build in public community**: @levelsio, @marclouvion, @tdinh_me
+- **EdTech/HR**: @TalentBoard, Indian HR influencers
+- **Dev communities**: @hashaborad, @ThePracticalDev, @IndieHackers
+
+### Response Templates
+**For "what is this?"**: "AG is where developers complete real coding quests, earn XP, rank up (F→S), and build a verified credential. Think Upwork meets RPG progression. Try it: adventurersguild.space"
+
+**For "how is this different from X?"**: "Unlike [platform], AG rank is earned through verified, QA-reviewed work — not self-reported skills. Your Guild Card shows every quest you completed, your quality scores, and your progression. It's a credential, not just a profile."
+
+**For companies asking**: "Post a task on AG and a ranked developer delivers it. You only pay if you approve. No upfront cost during beta. Want to try with one task?"
+
+---
+
+## Month 1 Goals
+
+| Metric | Target |
+|--------|--------|
+| X Personal followers | +200 |
+| X Project followers | +100 |
+| LinkedIn Personal connections | +50 relevant |
+| LinkedIn Project page followers | +30 |
+| Impressions (total, all 4) | 50,000 |
+| DMs from potential companies | 3 |
+| DMs from potential adventurers | 10 |
+| Blog article views (Dev.to) | 1,000 |
+
+---
+
+## First Week Content (Ready to Post)
+
+### Monday — X Personal (Build Log Thread)
+```
+Week 1 of building Adventurers Guild in public.
+
+This week we shipped:
+→ Squad/Party System — teams of 3-5 can now quest together
+→ Admin QA Mediation — every submission reviewed before client sees it
+→ Fixed a "Claim Quest" bug that was silently failing
+
+54 files changed. 8500+ lines. 4 API bugs caught in a full codebase audit.
+
+Next up: the Guild Card — your public, verifiable developer credential.
+
+If your AG rank could replace a tech interview, would you grind for it?
+```
+
+### Monday — X Project (Quest of the Week)
+```
+⚔️ Quest of the Week
+
+Looking for your first quest? We've got F-rank tasks perfect for getting started.
+
+Claim a quest → Complete it → Earn XP → Rank up
+
+Your journey from F-Rank to S-Rank starts with one quest.
+
+adventurersguild.space
+```
+
+### Tuesday — LinkedIn Personal (Thought Leadership)
+```
+Big Tech slashed entry-level hiring by 78% since 2019.
+
+Bootcamps are losing credibility. Degrees alone don't cut it anymore.
+
+What employers actually want: proof you can ship. Deployed apps. Meaningful PRs. Real work.
+
+That's why I'm building Adventurers Guild — a platform where developers earn a verified rank by completing real coding quests for real companies.
+
+Your rank isn't self-reported. It's earned through QA-reviewed deliverables.
+
+The question isn't "can this replace a CS degree?" — it's "can verified work history become the new hiring signal?"
+
+We're about to find out. 50 bootcamp students start in May.
+
+What would you trust more in a candidate: a degree, or 30 completed and reviewed coding deliverables?
+
+#futureofwork #developertools #startupindia
+```
+
+### Wednesday — LinkedIn Project (Feature Spotlight)
+```
+Introducing the Rank System ⚔️
+
+On Adventurers Guild, every developer starts at F-Rank and climbs through real work:
+
+F → E → D → C → B → A → S
+
+Each rank is earned by completing quests reviewed by QA. No shortcuts. No self-reporting.
+
+What this means for companies: when you see a B-Rank developer, you know they've delivered 30+ verified projects.
+
+What this means for developers: your rank is a credential that follows you. Shareable. Verifiable. Meaningful.
+
+Coming soon: the Guild Card — your public developer credential page.
+
+#developertools #hiringtrends
+```

--- a/docs/ROADMAP_2026_Q2.md
+++ b/docs/ROADMAP_2026_Q2.md
@@ -1,0 +1,140 @@
+# Adventurers Guild — Q2 2026 Roadmap
+
+> Updated: 2026-03-21
+> Strategy: **Credential Engine first, Marketplace second**
+> Hard deadline: Intern onboarding May 2026
+
+---
+
+## Strategic Context
+
+AG's moat is not the marketplace. It's the **credential**. The Guild Card — a verifiable public profile showing rank, completed quests, quality scores, and skills — is what makes AG rank valuable to employers. Everything we build should make the credential more trusted, more visible, and more useful.
+
+**Sequence**: Credential → Recognition → Marketplace flywheel
+
+---
+
+## Work Distribution
+
+| Owner | Focus | Issues |
+|-------|-------|--------|
+| **Abid (core)** | Architecture, Guild Card API, bootcamp pipeline, payments, outreach | #134 API, schema work |
+| **Adil** | Mobile UX, dashboard polish, useApiFetch migration | PR #131, ongoing UI |
+| **New contributors** | Feature issues with full specs | #134 UI, #135, #136, #137, #138 |
+| **Junior dev** | Stripe Connect, Event Audit Trail | #106, #108 |
+
+---
+
+## Phase 2 Status (Target: April 13)
+
+| Task | Status | Owner |
+|------|--------|-------|
+| 2.A Squad/Party System — Schema + API | ✅ Done | Abid |
+| 2.B Admin QA Mediation Layer | ✅ Done | Abid |
+| 2.C Stripe Connect — Payout Onboarding | ⏳ Open (#106) | Junior dev |
+| 2.D API Key Budget Tracking | 🔨 PR #131 | Adil |
+| 2.E **Claim Quest Bug Fix** | ✅ Done | Abid |
+| 2.F **Status propagation (7 code paths)** | ✅ Done | Abid |
+
+---
+
+## Phase 2.5: Credential System (NEW — Target: April 7)
+
+This is the new priority phase inserted before Phase 3. Without this, rank is invisible outside the platform.
+
+### Task 2.5.A: Guild Card — Public Adventurer Profile ⭐ TOP PRIORITY
+
+**GitHub issue**: #134
+**Why first**: Without a public credential, AG rank means nothing externally. This is the single feature that turns AG from "a platform" into "a credential."
+
+**Scope**:
+- Public page at `/adventurer/[username]`
+- API at `/api/adventurer/[username]` (no auth required)
+- OG image at `/api/og/adventurer/[username]` (for LinkedIn/X sharing)
+- Shows: rank badge, XP, skills, completed quest history, quality scores
+- Does NOT expose: email, in-progress work, internal notes
+
+**Owner**: Abid (API + schema) + contributor (UI)
+
+### Task 2.5.B: Admin Analytics Dashboard
+
+**GitHub issue**: #135
+**Why now**: We have zero visibility into platform health. Need DAU, quest completion rate, rank distribution before bootcamp launch.
+
+**Scope**:
+- API at `/api/admin/analytics`
+- Page at `/admin/analytics` with recharts
+- Metrics: DAU/WAU/MAU, quest completion rate, avg time-to-complete, rank distribution, quests by track
+
+**Owner**: Contributor
+
+### Task 2.5.C: Quest Streak System
+
+**GitHub issue**: #136
+**Why now**: Retention mechanic needed before bootcamp cohort arrives. Must be in place when 50 students start.
+
+**Scope**:
+- Schema: streak fields on AdventurerProfile
+- Logic: `lib/streak-utils.ts` called after quest completion
+- XP multiplier: 1.0x → 2.0x based on streak length
+- Dashboard display: streak count + multiplier badge
+
+**Owner**: Contributor
+
+---
+
+## Phase 3: Platform Polish + Scale (Target: May 11)
+
+| Task | Issue | Priority | Owner |
+|------|-------|----------|-------|
+| Party Panel UI | #137 | High | Contributor |
+| Quest Board Filters | #138 | High | Contributor |
+| Squad-Aware Quest Board | #111 | Medium | Contributor |
+| Hackathon → Quest Pipeline | #110 | Medium | Abid |
+| Admin Revenue Dashboard | #109 | Medium | Junior dev |
+| Event Audit Trail | #108 | Medium | Junior dev |
+
+---
+
+## Phase 4: Go-to-Market (May-July — concurrent with bootcamp)
+
+### What We Build
+- [ ] Stripe Connect real payments (intern track)
+- [ ] Company onboarding flow (guided quest posting)
+- [ ] Employer talent search (browse ranked adventurers)
+- [ ] Guild Card verification API (employers can verify rank programmatically)
+
+### What We Do (Non-Code)
+- [ ] Run bootcamp cohort through full lifecycle
+- [ ] Document completion rates, quality metrics, time-to-complete
+- [ ] Get 3 external companies to post quests
+- [ ] Get 1 hire based on AG rank
+- [ ] Write the investor one-pager with real data
+
+---
+
+## Key Milestones
+
+| Date | Milestone | Success Criteria |
+|------|-----------|-----------------|
+| **Mar 28** | Guild Card v1 live | Public profile page works, OG tags render |
+| **Apr 7** | Analytics + Streaks live | Admin can see DAU, completion rates |
+| **Apr 13** | Phase 2 complete | All Phase 2 tasks done, PR #131 merged |
+| **Apr 20** | Bootcamp dry run | 5 test students complete full lifecycle |
+| **May 1** | Platform ready for interns | All critical paths tested, payments working |
+| **May 15** | Intern cohort starts | 20 interns onboarded, quests posted |
+| **Jun 1** | First external company | 1 non-Open Paws company posts a paid quest |
+| **Jul 15** | Bootcamp results | Completion rate, quality scores, hire outcomes documented |
+
+---
+
+## What NOT to Build Before May
+
+- International expansion / multi-currency
+- AI matching / recommendation engine
+- Adventurer Pro subscription tier
+- In-platform code review (GitHub is fine)
+- DevSync integration
+- Mobile app (responsive web is sufficient)
+
+These are all good ideas. They're Phase 5+.

--- a/lib/quest-lifecycle.ts
+++ b/lib/quest-lifecycle.ts
@@ -3,7 +3,9 @@ import { AssignmentStatus, Prisma, PrismaClient, QuestStatus } from '@prisma/cli
 const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'review'];
 
 // Statuses that mean a company has accepted the adventurer (slot is filled)
-const FILLED_STATUSES: AssignmentStatus[] = ['started', 'in_progress', 'submitted', 'review', 'completed'];
+const FILLED_STATUSES: AssignmentStatus[] = [
+  'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed',
+];
 
 function deriveQuestStatus(
   statuses: AssignmentStatus[],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,9 +77,11 @@ enum AssignmentStatus {
   started
   in_progress
   submitted
+  pending_admin_review
   review
   completed
   cancelled
+  needs_rework
 }
 
 enum SubmissionStatus {
@@ -194,6 +196,8 @@ model User {
   mentorships         Mentorship[]          @relation("MentorUser")
   menteeships         Mentorship[]          @relation("MenteeUser")
   bootcampLink        BootcampLink?
+  ledParties          Party[]               @relation("PartyLeader")
+  partyMembers        PartyMember[]
 
   @@index([email])
   @@index([role])
@@ -294,6 +298,7 @@ model Quest {
   completions        QuestCompletion[]
   transactions       Transaction[]
   revisionRequests   RevisionRequest[]
+  party              Party?
 
   @@index([companyId])
   @@index([status])
@@ -582,5 +587,35 @@ model ErrorLog {
   @@index([severity])
   @@index([timestamp])
   @@map("error_logs")
+}
+
+model Party {
+  id        String     @id @default(uuid()) @db.Uuid
+  questId   String     @unique @map("quest_id") @db.Uuid
+  leaderId  String     @map("leader_id") @db.Uuid
+  track     QuestTrack
+  maxSize   Int        @default(5) @map("max_size")
+  createdAt DateTime   @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime   @updatedAt @map("updated_at") @db.Timestamptz
+
+  quest   Quest         @relation(fields: [questId], references: [id])
+  leader  User          @relation("PartyLeader", fields: [leaderId], references: [id])
+  members PartyMember[]
+
+  @@map("parties")
+}
+
+model PartyMember {
+  id       String   @id @default(uuid()) @db.Uuid
+  partyId  String   @map("party_id") @db.Uuid
+  userId   String   @map("user_id") @db.Uuid
+  isLeader Boolean  @default(false) @map("is_leader")
+  joinedAt DateTime @default(now()) @map("joined_at") @db.Timestamptz
+
+  party Party @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id])
+
+  @@unique([partyId, userId])
+  @@map("party_members")
 }
 


### PR DESCRIPTION
## Summary

Complete Phase 0 + 1 + 2 implementation bringing the platform from a basic quest marketplace to a production-ready two-track talent pipeline.

### Phase 0: Schema & Infrastructure
- `QuestTrack` (OPEN/INTERN/BOOTCAMP), `QuestSource` (CLIENT/INTERNAL/TUTORIAL/HACKATHON) enums
- `BootcampLink` model tying bootcamp students to adventurer accounts
- `parentQuestId` for sub-quest relationships
- Tutorial quest gating (`eligibleForRealQuests` after 2 tutorials)

### Phase 1: Bootcamp Integration
- Onboard webhook (`POST /api/webhooks/bootcamp/onboard`)
- Quest track filtering at API level (bootcamp students can't see INTERN quests)
- Revision flow with `maxRevisions` + `revisionCount`
- Sub-quest display on parent quest pages
- Hackathon quest import endpoint
- Discord notification utilities
- Transparency notice component

### Phase 2: Party System + QA Mediation
- **Squad/Party System** (#104): `Party` + `PartyMember` models, 4 API routes (create party, get party, add/remove members), rank + track enforcement, BOOTCAMP max 2 / INTERN max 5
- **Admin QA Mediation** (#105): `pending_admin_review` + `needs_rework` assignment statuses, admin QA queue page + API, FIFO review ordering, reject-with-notes flow, revision count tracking
- Non-OPEN track submissions route through admin QA before reaching client

### Bug Fixes
- **Claim Quest button not working** — 7 bugs from Phase-2 status additions not propagated: cancelled assignments blocking re-claim, FILLED_STATUSES missing new statuses, submissions API blocking resubmission from needs_rework, frontend canSubmit missing needs_rework, status badge replaceAll fix, session-expired 401 handling
- **Mobile performance** — WebGL low-end device detection (deviceMemory < 2, hardwareConcurrency < 4), CSS gradient fallback, responsive height fixes (#126 #128)
- **Merged community PRs** — #120 (marketing nav), #121 (footer payment icons)

### Infrastructure
- Stripe + Razorpay dual payment provider skeleton
- API key budget tracking model
- Comprehensive contributor onboarding docs
- 8 GitHub Discussions for junior dev context

## Changed Files
89 files changed, 8555 insertions, 1696 deletions

## Test Plan
- [ ] Type-check passes (`tsc --noEmit` — verified clean)
- [ ] Quest lifecycle: create → claim → submit → QA review → approve/reject → resubmit
- [ ] Bootcamp student can only see BOOTCAMP track quests
- [ ] Party creation enforces rank >= quest difficulty and track-specific size limits
- [ ] Admin QA queue shows pending_admin_review assignments in FIFO order
- [ ] Claim Quest button works for fresh users and users with prior cancelled assignments
- [ ] Mobile: WebGL hero falls back to CSS gradient on low-end devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)