### PR TITLE
feat: Guild Card — Public Adventurer Credential System

### DIFF
--- a/app/adventurer/[username]/page.tsx
+++ b/app/adventurer/[username]/page.tsx
@@ -1,0 +1,63 @@
+import { Metadata } from 'next';
+import { prisma } from '@/lib/db';
+import { notFound } from 'next/navigation';
+import { GuildCardProfile } from '@/components/guild-card/GuildCardProfile';
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { username } = await params;
+
+  const user = await prisma.user.findFirst({
+    where: { username, role: 'adventurer', isActive: true },
+    select: { name: true, username: true, rank: true, xp: true, adventurerProfile: { select: { primarySkills: true, totalQuestsCompleted: true } } },
+  });
+
+  if (!user) {
+    return { title: 'Adventurer Not Found | Adventurers Guild' };
+  }
+
+  const skills = user.adventurerProfile?.primarySkills?.slice(0, 3).join(', ') || 'Adventurer';
+  const quests = user.adventurerProfile?.totalQuestsCompleted || 0;
+
+  return {
+    title: `${user.name || user.username} — ${user.rank}-Rank Adventurer | Adventurers Guild`,
+    description: `${quests} quests completed · ${skills} · ${user.xp} XP`,
+    openGraph: {
+      title: `${user.name || user.username} — ${user.rank}-Rank Adventurer`,
+      description: `${quests} quests completed · ${skills}`,
+      images: [`/api/og/adventurer/${user.username}`],
+      type: 'profile',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${user.name || user.username} — ${user.rank}-Rank`,
+      description: `${quests} quests completed · ${skills} · ${user.xp} XP`,
+      images: [`/api/og/adventurer/${user.username}`],
+    },
+  };
+}
+
+export default async function GuildCardPage({ params }: PageProps) {
+  const { username } = await params;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://adventurersguild.space';
+
+  // Fetch from our own API to keep logic centralized
+  const res = await fetch(`${appUrl}/api/adventurer/${encodeURIComponent(username)}`, {
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    notFound();
+  }
+
+  const data = await res.json();
+  if (!data.success || !data.adventurer) {
+    notFound();
+  }
+
+  return <GuildCardProfile adventurer={data.adventurer} />;
+}

--- a/app/api/adventurer/[username]/route.ts
+++ b/app/api/adventurer/[username]/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+
+export async function GET(
+  _req: NextRequest,
+  props: { params: Promise<{ username: string }> }
+) {
+  const { username } = await props.params;
+
+  if (!username || username.length < 2 || username.length > 40) {
+    return NextResponse.json({ success: false, error: 'Invalid username' }, { status: 400 });
+  }
+
+  try {
+    // Look up by username first, fall back to UUID for backwards-compat
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUuid = uuidRegex.test(username);
+
+    const user = await prisma.user.findFirst({
+      where: isUuid
+        ? { id: username, role: 'adventurer', isActive: true }
+        : { username, role: 'adventurer', isActive: true },
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        rank: true,
+        xp: true,
+        skillPoints: true,
+        level: true,
+        bio: true,
+        location: true,
+        github: true,
+        linkedin: true,
+        avatar: true,
+        createdAt: true,
+        adventurerProfile: {
+          select: {
+            primarySkills: true,
+            specialization: true,
+            totalQuestsCompleted: true,
+            questCompletionRate: true,
+            currentStreak: true,
+            maxStreak: true,
+            availabilityStatus: true,
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ success: false, error: 'Adventurer not found' }, { status: 404 });
+    }
+
+    // Get completed quest history (public info only)
+    const completions = await prisma.questCompletion.findMany({
+      where: { userId: user.id },
+      include: {
+        quest: {
+          select: {
+            id: true,
+            title: true,
+            difficulty: true,
+            questCategory: true,
+            track: true,
+          },
+        },
+      },
+      orderBy: { completionDate: 'desc' },
+      take: 50,
+    });
+
+    // Calculate stats from completions
+    const totalXpFromCompletions = completions.reduce((sum, c) => sum + c.xpEarned, 0);
+    const withQuality = completions.filter(c => c.qualityScore !== null);
+    const avgQuality = withQuality.length > 0
+      ? withQuality.reduce((sum, c) => sum + (c.qualityScore ?? 0), 0) / withQuality.length
+      : null;
+
+    const guildCard = {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      rank: user.rank,
+      xp: user.xp,
+      skillPoints: user.skillPoints,
+      level: user.level,
+      bio: user.bio,
+      location: user.location,
+      github: user.github,
+      linkedin: user.linkedin,
+      avatar: user.avatar,
+      joinedAt: user.createdAt,
+      profile: user.adventurerProfile
+        ? {
+            skills: user.adventurerProfile.primarySkills,
+            specialization: user.adventurerProfile.specialization,
+            totalQuestsCompleted: user.adventurerProfile.totalQuestsCompleted,
+            completionRate: Number(user.adventurerProfile.questCompletionRate),
+            currentStreak: user.adventurerProfile.currentStreak,
+            maxStreak: user.adventurerProfile.maxStreak,
+            availability: user.adventurerProfile.availabilityStatus,
+          }
+        : null,
+      questHistory: completions.map((c) => ({
+        title: c.quest.title,
+        difficulty: c.quest.difficulty,
+        category: c.quest.questCategory,
+        track: c.quest.track,
+        xpEarned: c.xpEarned,
+        qualityScore: c.qualityScore,
+        completedAt: c.completionDate,
+      })),
+      stats: {
+        totalXpEarned: totalXpFromCompletions,
+        averageQuality: avgQuality ? Number(avgQuality.toFixed(1)) : null,
+        questCount: completions.length,
+      },
+    };
+
+    return NextResponse.json({ success: true, adventurer: guildCard });
+  } catch (error) {
+    console.error('Error fetching adventurer profile:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch profile' }, { status: 500 });
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -50,10 +50,22 @@ export async function POST(request: NextRequest) {
     // Hash password
     const passwordHash = await bcrypt.hash(password, 12);
 
+    // Generate a unique username from the name
+    const baseUsername = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '')
+      .slice(0, 20) || 'adventurer';
+    let username = baseUsername;
+    let suffix = 0;
+    while (await prisma.user.findUnique({ where: { username } })) {
+      suffix++;
+      username = `${baseUsername}${suffix}`;
+    }
+
     // Create user and profile in transaction
     const user = await withDbRetry(() => prisma.$transaction(async (tx) => {
       const newUser = await tx.user.create({
-        data: { name, email: normalizedEmail, passwordHash, role },
+        data: { name, email: normalizedEmail, passwordHash, role, username },
       });
 
       if (role === 'company') {

--- a/app/api/og/adventurer/[username]/route.tsx
+++ b/app/api/og/adventurer/[username]/route.tsx
@@ -1,0 +1,183 @@
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/db';
+
+export const runtime = 'nodejs';
+
+const RANK_COLORS: Record<string, string> = {
+  F: '#94a3b8',
+  E: '#22c55e',
+  D: '#3b82f6',
+  C: '#a855f7',
+  B: '#f59e0b',
+  A: '#ef4444',
+  S: '#f97316',
+};
+
+export async function GET(
+  _req: NextRequest,
+  props: { params: Promise<{ username: string }> }
+) {
+  const { username } = await props.params;
+
+  try {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUuid = uuidRegex.test(username);
+
+    const user = await prisma.user.findFirst({
+      where: isUuid
+        ? { id: username, role: 'adventurer', isActive: true }
+        : { username, role: 'adventurer', isActive: true },
+      select: {
+        name: true,
+        username: true,
+        rank: true,
+        xp: true,
+        adventurerProfile: {
+          select: {
+            primarySkills: true,
+            totalQuestsCompleted: true,
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return new ImageResponse(
+        (
+          <div style={{ display: 'flex', width: '100%', height: '100%', background: '#0f172a', color: '#fff', alignItems: 'center', justifyContent: 'center', fontSize: 32 }}>
+            Adventurer not found
+          </div>
+        ),
+        { width: 1200, height: 630 }
+      );
+    }
+
+    const rankColor = RANK_COLORS[user.rank] || '#94a3b8';
+    const skills = user.adventurerProfile?.primarySkills?.slice(0, 4) || [];
+    const quests = user.adventurerProfile?.totalQuestsCompleted || 0;
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 100%)',
+            padding: '60px',
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          {/* Top: Guild branding */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '40px' }}>
+            <div style={{ display: 'flex', fontSize: '24px', color: '#f97316', fontWeight: 700, letterSpacing: '-0.5px' }}>
+              ADVENTURERS GUILD
+            </div>
+            <div style={{ display: 'flex', fontSize: '18px', color: '#64748b' }}>
+              Guild Card
+            </div>
+          </div>
+
+          {/* Middle: Name + Rank */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '24px', marginBottom: '24px' }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '80px',
+                height: '80px',
+                borderRadius: '16px',
+                background: rankColor,
+                fontSize: '40px',
+                fontWeight: 800,
+                color: '#fff',
+              }}
+            >
+              {user.rank}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700, color: '#f8fafc', lineHeight: 1.1 }}>
+                {user.name || user.username || 'Adventurer'}
+              </div>
+              {user.username && (
+                <div style={{ display: 'flex', fontSize: '24px', color: '#94a3b8', marginTop: '4px' }}>
+                  @{user.username}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Stats row */}
+          <div style={{ display: 'flex', gap: '40px', marginBottom: '32px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', fontSize: '36px', fontWeight: 700, color: '#f97316' }}>
+                {user.xp.toLocaleString()}
+              </div>
+              <div style={{ display: 'flex', fontSize: '16px', color: '#64748b', textTransform: 'uppercase', letterSpacing: '1px' }}>
+                Total XP
+              </div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', fontSize: '36px', fontWeight: 700, color: '#22c55e' }}>
+                {quests}
+              </div>
+              <div style={{ display: 'flex', fontSize: '16px', color: '#64748b', textTransform: 'uppercase', letterSpacing: '1px' }}>
+                Quests Done
+              </div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', fontSize: '36px', fontWeight: 700, color: rankColor }}>
+                {user.rank}-Rank
+              </div>
+              <div style={{ display: 'flex', fontSize: '16px', color: '#64748b', textTransform: 'uppercase', letterSpacing: '1px' }}>
+                Rank
+              </div>
+            </div>
+          </div>
+
+          {/* Skills */}
+          {skills.length > 0 && (
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+              {skills.map((skill) => (
+                <div
+                  key={skill}
+                  style={{
+                    display: 'flex',
+                    padding: '8px 20px',
+                    borderRadius: '999px',
+                    background: 'rgba(249, 115, 22, 0.15)',
+                    border: '1px solid rgba(249, 115, 22, 0.3)',
+                    color: '#f97316',
+                    fontSize: '18px',
+                    fontWeight: 500,
+                  }}
+                >
+                  {skill}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Bottom: URL */}
+          <div style={{ display: 'flex', marginTop: 'auto', fontSize: '18px', color: '#475569' }}>
+            adventurersguild.space/adventurer/{user.username || 'profile'}
+          </div>
+        </div>
+      ),
+      { width: 1200, height: 630 }
+    );
+  } catch (error) {
+    console.error('Error generating OG image:', error);
+    return new ImageResponse(
+      (
+        <div style={{ display: 'flex', width: '100%', height: '100%', background: '#0f172a', color: '#fff', alignItems: 'center', justifyContent: 'center', fontSize: 32 }}>
+          Adventurers Guild
+        </div>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+}

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -15,6 +15,17 @@ export async function PATCH(request: NextRequest) {
     // Build user update payload (only allowed fields)
     const userUpdate: Record<string, string | null> = {};
     if (typeof body.name === 'string') userUpdate.name = body.name.trim() || null;
+    if (typeof body.username === 'string') {
+      const username = body.username.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+      if (username.length < 3 || username.length > 30) {
+        return Response.json({ error: 'Username must be 3-30 characters (letters, numbers, - _)', success: false }, { status: 400 });
+      }
+      const taken = await prisma.user.findUnique({ where: { username }, select: { id: true } });
+      if (taken && taken.id !== authUser.id) {
+        return Response.json({ error: 'Username already taken', success: false }, { status: 409 });
+      }
+      userUpdate.username = username;
+    }
     if (typeof body.bio === 'string') userUpdate.bio = body.bio.trim() || null;
     if (typeof body.location === 'string') userUpdate.location = body.location.trim() || null;
     if (typeof body.website === 'string') userUpdate.website = body.website.trim() || null;
@@ -29,7 +40,7 @@ export async function PATCH(request: NextRequest) {
     const updated = await prisma.user.update({
       where: { id: authUser.id },
       data: userUpdate,
-      select: { id: true, name: true, email: true, bio: true, location: true, website: true, github: true, linkedin: true, discord: true },
+      select: { id: true, name: true, username: true, email: true, bio: true, location: true, website: true, github: true, linkedin: true, discord: true },
     });
 
     // If company role, also update company profile fields

--- a/components/guild-card/GuildCardProfile.tsx
+++ b/components/guild-card/GuildCardProfile.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { RankBadge } from '@/components/ui/rank-badge';
+import {
+  GuildCard,
+  GuildPage,
+  GuildPanel,
+} from '@/components/guild/primitives';
+import {
+  Calendar,
+  ExternalLink,
+  Flame,
+  Github,
+  Linkedin,
+  MapPin,
+  Sparkles,
+  Star,
+  Swords,
+  Target,
+  Zap,
+} from 'lucide-react';
+
+interface QuestHistoryItem {
+  title: string;
+  difficulty: string;
+  category: string;
+  track: string;
+  xpEarned: number;
+  qualityScore: number | null;
+  completedAt: string;
+}
+
+interface Adventurer {
+  id: string;
+  name: string | null;
+  username: string | null;
+  rank: string;
+  xp: number;
+  skillPoints: number;
+  level: number;
+  bio: string | null;
+  location: string | null;
+  github: string | null;
+  linkedin: string | null;
+  avatar: string | null;
+  joinedAt: string;
+  profile: {
+    skills: string[];
+    specialization: string | null;
+    totalQuestsCompleted: number;
+    completionRate: number;
+    currentStreak: number;
+    maxStreak: number;
+    availability: string;
+  } | null;
+  questHistory: QuestHistoryItem[];
+  stats: {
+    totalXpEarned: number;
+    averageQuality: number | null;
+    questCount: number;
+  };
+}
+
+const RANK_THRESHOLDS: Record<string, { next: string; xpNeeded: number }> = {
+  F: { next: 'E', xpNeeded: 100 },
+  E: { next: 'D', xpNeeded: 300 },
+  D: { next: 'C', xpNeeded: 600 },
+  C: { next: 'B', xpNeeded: 1200 },
+  B: { next: 'A', xpNeeded: 2500 },
+  A: { next: 'S', xpNeeded: 5000 },
+  S: { next: 'S', xpNeeded: 99999 },
+};
+
+function difficultyColor(d: string) {
+  const map: Record<string, string> = {
+    F: 'bg-slate-100 text-slate-600 border-slate-200',
+    E: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    D: 'bg-blue-50 text-blue-700 border-blue-200',
+    C: 'bg-purple-50 text-purple-700 border-purple-200',
+    B: 'bg-amber-50 text-amber-700 border-amber-200',
+    A: 'bg-red-50 text-red-700 border-red-200',
+    S: 'bg-orange-50 text-orange-700 border-orange-200',
+  };
+  return map[d] || 'bg-slate-100 text-slate-600 border-slate-200';
+}
+
+export function GuildCardProfile({ adventurer }: { adventurer: Adventurer }) {
+  const a = adventurer;
+  const threshold = RANK_THRESHOLDS[a.rank] || RANK_THRESHOLDS.F;
+  const prevThreshold = Object.values(RANK_THRESHOLDS).find((t) => t.next === a.rank);
+  const prevXp = prevThreshold?.xpNeeded || 0;
+  const progress = a.rank === 'S' ? 100 : Math.min(100, Math.round(((a.xp - prevXp) / (threshold.xpNeeded - prevXp)) * 100));
+
+  return (
+    <GuildPage>
+      {/* Hero section */}
+      <div className="rounded-2xl bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-white sm:p-12">
+        <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
+          {/* Avatar / Rank */}
+          <div className="flex-shrink-0">
+            {a.avatar ? (
+              <img
+                src={a.avatar}
+                alt={a.name || 'Adventurer'}
+                className="h-24 w-24 rounded-2xl border-2 border-orange-500/30 object-cover"
+              />
+            ) : (
+              <RankBadge rank={a.rank as 'F' | 'E' | 'D' | 'C' | 'B' | 'A' | 'S'} size="xl" glow />
+            )}
+          </div>
+
+          {/* Name + meta */}
+          <div className="flex-1">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-bold sm:text-3xl">{a.name || 'Adventurer'}</h1>
+              <RankBadge rank={a.rank as 'F' | 'E' | 'D' | 'C' | 'B' | 'A' | 'S'} size="md" glow />
+            </div>
+            {a.username && (
+              <p className="mt-1 text-sm text-slate-400">@{a.username}</p>
+            )}
+            {a.bio && (
+              <p className="mt-2 max-w-xl text-sm text-slate-300">{a.bio}</p>
+            )}
+            <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-slate-400">
+              {a.location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="h-3 w-3" /> {a.location}
+                </span>
+              )}
+              <span className="flex items-center gap-1">
+                <Calendar className="h-3 w-3" /> Joined {new Date(a.joinedAt).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+              </span>
+              {a.github && (
+                <a href={`https://github.com/${a.github}`} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 hover:text-white">
+                  <Github className="h-3 w-3" /> {a.github}
+                </a>
+              )}
+              {a.linkedin && (
+                <a href={a.linkedin.startsWith('http') ? a.linkedin : `https://linkedin.com/in/${a.linkedin}`} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 hover:text-white">
+                  <Linkedin className="h-3 w-3" /> LinkedIn
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* XP progress bar */}
+        <div className="mt-8">
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>{a.rank}-Rank</span>
+            {a.rank !== 'S' && <span>{threshold.next}-Rank at {threshold.xpNeeded.toLocaleString()} XP</span>}
+          </div>
+          <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-slate-800">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-orange-500 to-amber-400 transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{a.xp.toLocaleString()} XP total</p>
+        </div>
+      </div>
+
+      {/* Stats grid */}
+      <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[
+          { label: 'Quests Completed', value: String(a.profile?.totalQuestsCompleted ?? 0), Icon: Swords, accent: 'text-orange-500' },
+          { label: 'Total XP', value: a.xp.toLocaleString(), Icon: Zap, accent: 'text-amber-500' },
+          { label: 'Avg Quality', value: a.stats.averageQuality ? `${a.stats.averageQuality}/10` : 'N/A', Icon: Star, accent: 'text-sky-500' },
+          { label: 'Best Streak', value: `${a.profile?.maxStreak ?? 0} days`, Icon: Flame, accent: 'text-rose-500' },
+        ].map(({ label, value, Icon, accent }) => (
+          <GuildCard key={label} className="border-slate-200/80">
+            <div className="p-4">
+              <div className="flex items-center gap-2">
+                <Icon className={`h-4 w-4 ${accent}`} />
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+              </div>
+              <p className="mt-2 text-2xl font-bold text-slate-900">{value}</p>
+            </div>
+          </GuildCard>
+        ))}
+      </div>
+
+      {/* Skills + Quest History */}
+      <div className="mt-6 grid gap-6 lg:grid-cols-3">
+        {/* Skills panel */}
+        <GuildCard className="border-slate-200/80 lg:col-span-1">
+          <GuildPanel asChild className="border-0 bg-transparent shadow-none">
+            <div className="space-y-4 p-6">
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                <Sparkles className="h-4 w-4 text-orange-500" /> Skills
+              </h2>
+              {a.profile?.skills && a.profile.skills.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {a.profile.skills.map((skill) => (
+                    <Badge key={skill} variant="outline" className="border-orange-200 bg-orange-50 text-orange-700">
+                      {skill}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-400">No skills listed yet</p>
+              )}
+              {a.profile?.specialization && (
+                <div className="mt-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Specialization</p>
+                  <p className="mt-1 text-sm font-medium text-slate-700">{a.profile.specialization}</p>
+                </div>
+              )}
+              {a.profile && (
+                <div className="mt-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Completion Rate</p>
+                  <p className="mt-1 text-sm font-medium text-slate-700">{a.profile.completionRate}%</p>
+                </div>
+              )}
+            </div>
+          </GuildPanel>
+        </GuildCard>
+
+        {/* Quest history */}
+        <GuildCard className="border-slate-200/80 lg:col-span-2">
+          <GuildPanel asChild className="border-0 bg-transparent shadow-none">
+            <div className="space-y-4 p-6">
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                <Target className="h-4 w-4 text-orange-500" /> Quest History
+              </h2>
+              {a.questHistory.length > 0 ? (
+                <div className="space-y-3">
+                  {a.questHistory.map((q, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 p-4"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-slate-900">{q.title}</p>
+                        <div className="mt-1 flex items-center gap-2 text-xs text-slate-500">
+                          <Badge variant="outline" className={`text-[10px] ${difficultyColor(q.difficulty)}`}>
+                            {q.difficulty}-Rank
+                          </Badge>
+                          <span>{new Date(q.completedAt).toLocaleDateString()}</span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 text-right">
+                        <div>
+                          <p className="text-sm font-semibold text-orange-600">+{q.xpEarned} XP</p>
+                          {q.qualityScore !== null && (
+                            <p className="text-xs text-slate-500">{q.qualityScore}/10</p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="py-8 text-center text-sm text-slate-400">
+                  No completed quests yet. The adventure begins soon.
+                </div>
+              )}
+            </div>
+          </GuildPanel>
+        </GuildCard>
+      </div>
+
+      {/* Footer: verification + share */}
+      <div className="mt-8 flex flex-col items-center justify-between gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500 sm:flex-row">
+        <span>
+          Verified Guild Card — Adventurers Guild
+        </span>
+        <a
+          href={`https://adventurersguild.space/adventurer/${a.username || a.id}`}
+          className="flex items-center gap-1 font-medium text-orange-600 hover:text-orange-700"
+        >
+          <ExternalLink className="h-3.5 w-3.5" /> Share this card
+        </a>
+      </div>
+    </GuildPage>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
+        "@vercel/og": "^0.11.1",
         "autoprefixer": "^10.4.20",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -3682,6 +3683,15 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3695,6 +3705,22 @@
       "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.5",
@@ -5059,6 +5085,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/og": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.11.1.tgz",
+      "integrity": "sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.25.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5456,6 +5498,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
@@ -5685,6 +5736,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001759",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
@@ -5829,7 +5889,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -5898,6 +5957,47 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -6307,6 +6407,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -6549,6 +6658,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7092,6 +7207,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7578,6 +7699,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ignore": {
@@ -8282,6 +8415,16 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8930,6 +9073,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8941,6 +9090,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/path-exists": {
@@ -9937,6 +10096,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/satori": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
+      "integrity": "sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -10201,6 +10382,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -10580,6 +10767,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -10885,6 +11078,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -11228,6 +11431,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@vercel/og": "^0.11.1",
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,7 @@ enum VerificationStatus {
 model User {
   id            String    @id @default(uuid()) @db.Uuid
   name          String?
+  username      String?   @unique
   email         String    @unique
   passwordHash  String    @map("password_hash")
   role          UserRole  @default(adventurer)
@@ -200,6 +201,7 @@ model User {
   partyMembers        PartyMember[]
 
   @@index([email])
+  @@index([username])
   @@index([role])
   @@index([rank])
   @@index([isActive])


### PR DESCRIPTION
## Summary

The **Guild Card** — AG's credential backbone. Makes rank visible and verifiable outside the platform.

- **Public profile page** at `/adventurer/[username]` — no auth required
- **Public API** at `/api/adventurer/[username]` — returns rank, XP, skills, quest history, quality scores
- **Dynamic OG image** at `/api/og/adventurer/[username]` — shareable card for X/LinkedIn (1200x630, dark theme, rank badge)
- **Username system** — unique slugs auto-generated on registration, editable via profile
- **OG meta tags** for social previews (Twitter card + OpenGraph)

### Why This Matters
Without a public credential, AG rank is invisible outside the platform. The Guild Card turns rank from an internal metric into an externally verifiable trust signal. Adventurers link their Guild Card on resumes, LinkedIn, job applications. Employers verify rank without logging in.

### Schema Change
Adds `username` (unique, indexed) to `User` model. Requires `npx prisma db push`.

### Files
| File | What |
|------|------|
| `prisma/schema.prisma` | `username` field on User |
| `app/api/adventurer/[username]/route.ts` | Public profile API |
| `app/api/og/adventurer/[username]/route.tsx` | OG image generator |
| `app/adventurer/[username]/page.tsx` | Server-rendered page with metadata |
| `components/guild-card/GuildCardProfile.tsx` | Guild Card UI component |
| `app/api/auth/register/route.ts` | Auto-username on signup |
| `app/api/users/me/route.ts` | Username update endpoint |

## Test Plan
- [ ] Run `npx prisma db push` to apply schema
- [ ] Register new user → verify username auto-generated
- [ ] Visit `/adventurer/[username]` → public profile renders
- [ ] Check `/api/og/adventurer/[username]` → OG image renders
- [ ] Test with https://www.opengraph.xyz/ → meta tags correct
- [ ] Update username via PATCH `/api/users/me` → validates uniqueness
- [ ] Type-check passes (`npx tsc --noEmit` — verified clean)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)