### PR TITLE
[codex] add quest workflow event trail

### DIFF
--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
+import { buildQuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 // PATCH /api/admin/qa-queue/[assignmentId] — approve or reject submission
 export async function PATCH(
@@ -12,6 +14,7 @@ export async function PATCH(
   const { id: adminId } = user;
 
   const { assignmentId } = await params;
+  const actor = buildQuestWorkflowActor(user);
 
   let body: { action?: string; notes?: string };
   try {
@@ -47,10 +50,34 @@ export async function PATCH(
   }
 
   if (action === 'approve') {
-    await prisma.questAssignment.update({
-      where: { id: assignmentId },
-      data: { status: 'review' },
+    await prisma.$transaction(async (tx) => {
+      await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: { status: 'review' },
+      });
+
+      await recordQuestWorkflowEvent(tx, {
+        questId: assignment.quest.id,
+        assignmentId,
+        submissionId: assignment.submissions[0]?.id ?? null,
+        actorUserId: actor.userId,
+        actorRole: actor.role,
+        eventType: 'assignment_status_changed',
+        payload: {
+          previousStatus: assignment.status,
+          nextStatus: 'review',
+          trigger: 'admin_qa_approve',
+        },
+      });
+
+      await syncQuestLifecycleStatus(tx, assignment.quest.id, {
+        ...actor,
+        assignmentId,
+        submissionId: assignment.submissions[0]?.id ?? null,
+        trigger: 'admin_qa_approve',
+      });
     });
+
     return NextResponse.json({ message: 'Submission approved — forwarded to client review', success: true });
   }
 
@@ -68,22 +95,59 @@ export async function PATCH(
   };
   const updatedNotes = JSON.stringify([...existingNotes, newNote]);
 
-  await prisma.$transaction([
-    prisma.questAssignment.update({
+  await prisma.$transaction(async (tx) => {
+    await tx.questAssignment.update({
       where: { id: assignmentId },
       data: { status: 'needs_rework' },
-    }),
-    prisma.quest.update({
+    });
+
+    await tx.quest.update({
       where: { id: assignment.quest.id },
       data: { revisionCount: { increment: 1 } },
-    }),
-    ...(latestSubmission
-      ? [prisma.questSubmission.update({
-          where: { id: latestSubmission.id },
-          data: { reviewNotes: updatedNotes },
-        })]
-      : []),
-  ]);
+    });
+
+    if (latestSubmission) {
+      await tx.questSubmission.update({
+        where: { id: latestSubmission.id },
+        data: { reviewNotes: updatedNotes },
+      });
+
+      await recordQuestWorkflowEvent(tx, {
+        questId: assignment.quest.id,
+        assignmentId,
+        submissionId: latestSubmission.id,
+        actorUserId: actor.userId,
+        actorRole: actor.role,
+        eventType: 'submission_reviewed',
+        payload: {
+          previousStatus: latestSubmission.status,
+          nextStatus: latestSubmission.status,
+          trigger: 'admin_qa_reject',
+        },
+      });
+    }
+
+    await recordQuestWorkflowEvent(tx, {
+      questId: assignment.quest.id,
+      assignmentId,
+      submissionId: latestSubmission?.id ?? null,
+      actorUserId: actor.userId,
+      actorRole: actor.role,
+      eventType: 'assignment_status_changed',
+      payload: {
+        previousStatus: assignment.status,
+        nextStatus: 'needs_rework',
+        trigger: 'admin_qa_reject',
+      },
+    });
+
+    await syncQuestLifecycleStatus(tx, assignment.quest.id, {
+      ...actor,
+      assignmentId,
+      submissionId: latestSubmission?.id ?? null,
+      trigger: 'admin_qa_reject',
+    });
+  });
 
   return NextResponse.json({ message: 'Submission rejected — returned to student for revision', success: true });
 }

--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { requireAuth } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
+import { buildQuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 const VALID_REVIEW_STATUSES = ['pending', 'under_review', 'approved', 'needs_rework', 'rejected'] as const;
 type ReviewStatus = (typeof VALID_REVIEW_STATUSES)[number];
@@ -96,6 +97,7 @@ export async function POST(request: NextRequest) {
     if (!authUser) {
       return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
+    const actor = buildQuestWorkflowActor(authUser);
 
     const body = (await request.json()) as Record<string, unknown>;
     const requiredFields = ['submissionId', 'quality_score', 'status'];
@@ -132,6 +134,7 @@ export async function POST(request: NextRequest) {
           select: {
             questId: true,
             userId: true,
+            status: true,
             quest: {
               select: {
                 companyId: true,
@@ -150,67 +153,126 @@ export async function POST(request: NextRequest) {
       return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
-    const data = await prisma.questSubmission.update({
-      where: { id: submissionId },
-      data: {
-        status,
-        reviewerId: authUser.id,
-        reviewedAt: new Date(),
-        reviewNotes: typeof body.review_notes === 'string' ? body.review_notes : null,
-        qualityScore,
-      },
-    });
-
     const wasAlreadyApproved = existingSubmission.status === 'approved';
-
-    if (status === 'approved' && !wasAlreadyApproved) {
-      await prisma.questAssignment.update({
-        where: { id: existingSubmission.assignmentId },
-        data: { status: 'completed', completedAt: new Date() },
+    const reviewResult = await prisma.$transaction(async (tx) => {
+      const data = await tx.questSubmission.update({
+        where: { id: submissionId },
+        data: {
+          status,
+          reviewerId: authUser.id,
+          reviewedAt: new Date(),
+          reviewNotes: typeof body.review_notes === 'string' ? body.review_notes : null,
+          qualityScore,
+        },
       });
 
-      const quest = await prisma.quest.findUnique({
-        where: { id: existingSubmission.assignment.questId },
-        select: { xpReward: true, skillPointsReward: true },
+      await recordQuestWorkflowEvent(tx, {
+        questId: existingSubmission.assignment.questId,
+        assignmentId: existingSubmission.assignmentId,
+        submissionId,
+        actorUserId: actor.userId,
+        actorRole: actor.role,
+        eventType: 'submission_reviewed',
+        payload: {
+          previousStatus: existingSubmission.status,
+          nextStatus: status,
+          qualityScore,
+        },
       });
 
-      if (!quest) {
-        throw new Error('Quest not found');
-      }
+      let rewardsPayload:
+        | { userId: string; xpReward: number; skillPointsReward: number }
+        | null = null;
 
-      // Record quest completion
-      try {
-        await prisma.questCompletion.create({
-          data: {
-            questId: existingSubmission.assignment.questId,
-            userId: existingSubmission.assignment.userId,
-            xpEarned: quest.xpReward,
-            skillPointsEarned: quest.skillPointsReward,
-            qualityScore,
+      if (status === 'approved' && !wasAlreadyApproved) {
+        await tx.questAssignment.update({
+          where: { id: existingSubmission.assignmentId },
+          data: { status: 'completed', completedAt: new Date() },
+        });
+
+        await recordQuestWorkflowEvent(tx, {
+          questId: existingSubmission.assignment.questId,
+          assignmentId: existingSubmission.assignmentId,
+          submissionId,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_status_changed',
+          payload: {
+            previousStatus: existingSubmission.assignment.status,
+            nextStatus: 'completed',
+            trigger: 'qa_review',
           },
         });
-      } catch (completionError) {
-        console.error('Error recording quest completion:', completionError);
+
+        const quest = await tx.quest.findUnique({
+          where: { id: existingSubmission.assignment.questId },
+          select: { xpReward: true, skillPointsReward: true },
+        });
+
+        if (!quest) {
+          throw new Error('Quest not found');
+        }
+
+        try {
+          await tx.questCompletion.create({
+            data: {
+              questId: existingSubmission.assignment.questId,
+              userId: existingSubmission.assignment.userId,
+              xpEarned: quest.xpReward,
+              skillPointsEarned: quest.skillPointsReward,
+              qualityScore,
+            },
+          });
+        } catch (completionError) {
+          console.error('Error recording quest completion:', completionError);
+        }
+
+        rewardsPayload = {
+          userId: existingSubmission.assignment.userId,
+          xpReward: quest.xpReward,
+          skillPointsReward: quest.skillPointsReward,
+        };
+      } else if (status === 'needs_rework' || status === 'rejected') {
+        await tx.questAssignment.update({
+          where: { id: existingSubmission.assignmentId },
+          data: { status: 'in_progress' },
+        });
+
+        await recordQuestWorkflowEvent(tx, {
+          questId: existingSubmission.assignment.questId,
+          assignmentId: existingSubmission.assignmentId,
+          submissionId,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_status_changed',
+          payload: {
+            previousStatus: existingSubmission.assignment.status,
+            nextStatus: 'in_progress',
+            trigger: 'qa_review',
+          },
+        });
       }
 
-      // Update user XP, level, rank, and skill points
+      await syncQuestLifecycleStatus(tx, existingSubmission.assignment.questId, {
+        ...actor,
+        assignmentId: existingSubmission.assignmentId,
+        submissionId,
+        trigger: 'qa_review',
+      });
+
+      return { submission: data, rewardsPayload };
+    });
+
+    if (reviewResult.rewardsPayload) {
       const { updateUserXpAndSkills } = await import('@/lib/xp-utils');
       await updateUserXpAndSkills(
-        existingSubmission.assignment.userId,
-        quest.xpReward,
-        quest.skillPointsReward
+        reviewResult.rewardsPayload.userId,
+        reviewResult.rewardsPayload.xpReward,
+        reviewResult.rewardsPayload.skillPointsReward
       );
     }
-    else if (status === 'needs_rework' || status === 'rejected') {
-      await prisma.questAssignment.update({
-        where: { id: existingSubmission.assignmentId },
-        data: { status: 'in_progress' },
-      });
-    }
 
-    await syncQuestLifecycleStatus(prisma, existingSubmission.assignment.questId);
-
-    return Response.json({ submission: data, success: true });
+    return Response.json({ submission: reviewResult.submission, success: true });
   } catch (error) {
     console.error('Error reviewing submission:', error);
     return Response.json({ error: 'Failed to review submission', success: false }, { status: 500 });

--- a/app/api/quests/[id]/assignments/route.ts
+++ b/app/api/quests/[id]/assignments/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db';
 import { AssignmentStatus } from '@prisma/client';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 import { getAuthUser } from '@/lib/api-auth';
+import { buildQuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 // GET /api/quests/[id]/assignments — list all assignments for a quest (company/admin only)
 export async function GET(
@@ -70,6 +71,7 @@ export async function PUT(
   try {
     const body = await req.json();
     const { assignmentId, status } = body;
+    const actor = buildQuestWorkflowActor(user);
 
     if (!assignmentId || !status) {
       return NextResponse.json({ error: 'assignmentId and status are required', success: false }, { status: 400 });
@@ -122,7 +124,24 @@ export async function PUT(
           },
         });
 
-        await syncQuestLifecycleStatus(tx, params.id);
+        await recordQuestWorkflowEvent(tx, {
+          questId: params.id,
+          assignmentId: assignment.id,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_status_changed',
+          payload: {
+            previousStatus: existingAssignment.status,
+            nextStatus: assignment.status,
+            decision: status,
+          },
+        });
+
+        await syncQuestLifecycleStatus(tx, params.id, {
+          ...actor,
+          assignmentId: assignment.id,
+          trigger: 'assignment_decision',
+        });
         return assignment;
       },
       { maxWait: 10_000, timeout: 20_000 }

--- a/app/api/quests/[id]/workflow-events/route.ts
+++ b/app/api/quests/[id]/workflow-events/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { getAuthUser } from '@/lib/api-auth';
+
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  const params = await props.params;
+  const user = await getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  try {
+    const quest = await prisma.quest.findUnique({
+      where: { id: params.id },
+      select: { companyId: true },
+    });
+
+    if (!quest) {
+      return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
+    }
+
+    if (user.role !== 'admin' && quest.companyId !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const requestedLimit = Number.parseInt(searchParams.get('limit') ?? '20', 10);
+    const limit = Number.isNaN(requestedLimit) ? 20 : Math.min(Math.max(requestedLimit, 1), 100);
+
+    const events = await prisma.questWorkflowEvent.findMany({
+      where: { questId: params.id },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+
+    return NextResponse.json({ events, success: true });
+  } catch (error) {
+    console.error('Error fetching quest workflow events:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch quest workflow events', success: false },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/quests/assignments/route.ts
+++ b/app/api/quests/assignments/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { AssignmentStatus, Prisma } from '@prisma/client';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 import { getAuthUser } from '@/lib/api-auth';
+import { buildQuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 export async function GET(request: NextRequest) {
   // Check authentication
@@ -114,6 +115,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { questId } = body;
     const userId = user.id; // Use authenticated user's ID
+    const actor = buildQuestWorkflowActor(user);
 
     // Validate required fields
     if (!questId) {
@@ -188,7 +190,24 @@ export async function POST(request: NextRequest) {
           },
         });
 
-        await syncQuestLifecycleStatus(tx, questId);
+        await recordQuestWorkflowEvent(tx, {
+          questId,
+          assignmentId: created.id,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_created',
+          payload: {
+            status: created.status,
+            maxParticipants: quest.maxParticipants,
+            questTrack: quest.track,
+          },
+        });
+
+        await syncQuestLifecycleStatus(tx, questId, {
+          ...actor,
+          assignmentId: created.id,
+          trigger: 'assignment_created',
+        });
         return created;
       },
       { maxWait: 10_000, timeout: 20_000 }
@@ -212,6 +231,7 @@ export async function PUT(request: NextRequest) {
     const body = await request.json();
     const { assignmentId, status, progress } = body;
     const userId = user.id; // Use authenticated user's ID
+    const actor = buildQuestWorkflowActor(user);
 
     // Validate required fields
     if (!assignmentId || !status) {
@@ -241,7 +261,7 @@ export async function PUT(request: NextRequest) {
     // Only the assigned user or an admin can update the assignment
     const assignment = await prisma.questAssignment.findUnique({
       where: { id: assignmentId },
-      select: { userId: true, questId: true },
+      select: { userId: true, questId: true, status: true },
     });
 
     if (!assignment) {
@@ -274,7 +294,24 @@ export async function PUT(request: NextRequest) {
           data: updateData,
         });
 
-        await syncQuestLifecycleStatus(tx, assignment.questId);
+        await recordQuestWorkflowEvent(tx, {
+          questId: assignment.questId,
+          assignmentId: updated.id,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_status_changed',
+          payload: {
+            previousStatus: assignment.status,
+            nextStatus: updated.status,
+            progress: progress ?? null,
+          },
+        });
+
+        await syncQuestLifecycleStatus(tx, assignment.questId, {
+          ...actor,
+          assignmentId: updated.id,
+          trigger: 'assignment_status_changed',
+        });
         return updated;
       },
       { maxWait: 10_000, timeout: 20_000 }

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { AssignmentStatus } from '@prisma/client';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 import { getAuthUser } from '@/lib/api-auth';
+import { buildQuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 export async function GET(request: NextRequest) {
   // Check authentication
@@ -98,6 +99,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { assignmentId, submissionContent, submissionNotes } = body;
     const userId = user.id; // Use authenticated user's ID
+    const actor = buildQuestWorkflowActor(user);
 
     // Validate required fields
     if (!assignmentId || !submissionContent) {
@@ -144,7 +146,39 @@ export async function POST(request: NextRequest) {
           data: { status: postSubmitStatus },
         });
 
-        await syncQuestLifecycleStatus(tx, assignment.questId);
+        await recordQuestWorkflowEvent(tx, {
+          questId: assignment.questId,
+          assignmentId,
+          submissionId: submission.id,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'submission_created',
+          payload: {
+            submissionStatus: submission.status,
+            questTrack: assignment.quest.track,
+          },
+        });
+
+        await recordQuestWorkflowEvent(tx, {
+          questId: assignment.questId,
+          assignmentId,
+          submissionId: submission.id,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'assignment_status_changed',
+          payload: {
+            previousStatus: assignment.status,
+            nextStatus: postSubmitStatus,
+            trigger: 'submission_created',
+          },
+        });
+
+        await syncQuestLifecycleStatus(tx, assignment.questId, {
+          ...actor,
+          assignmentId,
+          submissionId: submission.id,
+          trigger: 'submission_created',
+        });
         return submission;
       },
       { maxWait: 10_000, timeout: 20_000 }
@@ -168,6 +202,7 @@ export async function PUT(request: NextRequest) {
     const body = await request.json();
     const { submissionId, status, review_notes, quality_score } = body;
     const reviewerId = user.id; // Use authenticated user's ID
+    const actor = buildQuestWorkflowActor(user);
 
     // Validate required fields
     if (!submissionId || !status) {
@@ -192,6 +227,7 @@ export async function PUT(request: NextRequest) {
       select: {
         questId: true,
         userId: true,
+        status: true,
         quest: {
           select: {
             companyId: true,
@@ -243,7 +279,42 @@ export async function PUT(request: NextRequest) {
           });
         }
 
-        await syncQuestLifecycleStatus(tx, assignmentData.questId);
+        await recordQuestWorkflowEvent(tx, {
+          questId: assignmentData.questId,
+          assignmentId: submission.assignmentId,
+          submissionId,
+          actorUserId: actor.userId,
+          actorRole: actor.role,
+          eventType: 'submission_reviewed',
+          payload: {
+            previousStatus: submission.status,
+            nextStatus: updatedSubmission.status,
+            qualityScore: quality_score || null,
+          },
+        });
+
+        if (newAssignmentStatus) {
+          await recordQuestWorkflowEvent(tx, {
+            questId: assignmentData.questId,
+            assignmentId: submission.assignmentId,
+            submissionId,
+            actorUserId: actor.userId,
+            actorRole: actor.role,
+            eventType: 'assignment_status_changed',
+            payload: {
+              previousStatus: assignmentData.status,
+              nextStatus: newAssignmentStatus,
+              trigger: 'submission_review',
+            },
+          });
+        }
+
+        await syncQuestLifecycleStatus(tx, assignmentData.questId, {
+          ...actor,
+          assignmentId: submission.assignmentId,
+          submissionId,
+          trigger: 'submission_review',
+        });
 
         let rewardsPayload: { userId: string; xpReward: number; skillPointsReward: number; questTitle: string } | null = null;
         if (status === 'approved' && !wasAlreadyApproved) {

--- a/lib/quest-lifecycle.ts
+++ b/lib/quest-lifecycle.ts
@@ -1,4 +1,5 @@
 import { AssignmentStatus, Prisma, PrismaClient, QuestStatus } from '@prisma/client';
+import { QuestWorkflowActor, recordQuestWorkflowEvent } from '@/lib/quest-workflow-events';
 
 const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'review'];
 
@@ -39,9 +40,16 @@ function deriveQuestStatus(
 
 type DbClient = Prisma.TransactionClient | PrismaClient;
 
+type QuestLifecycleEventContext = QuestWorkflowActor & {
+  assignmentId?: string | null;
+  submissionId?: string | null;
+  trigger?: string;
+};
+
 export async function syncQuestLifecycleStatus(
   db: DbClient,
-  questId: string
+  questId: string,
+  eventContext: QuestLifecycleEventContext = {}
 ): Promise<QuestStatus | null> {
   const quest = await db.quest.findUnique({
     where: { id: questId },
@@ -66,6 +74,22 @@ export async function syncQuestLifecycleStatus(
     await db.quest.update({
       where: { id: questId },
       data: { status: nextStatus },
+    });
+
+    await recordQuestWorkflowEvent(db, {
+      questId,
+      assignmentId: eventContext.assignmentId,
+      submissionId: eventContext.submissionId,
+      actorUserId: eventContext.userId,
+      actorRole: eventContext.role,
+      eventType: 'quest_status_changed',
+      payload: {
+        previousStatus: quest.status,
+        nextStatus,
+        assignmentStatuses: assignments.map(a => a.status),
+        maxParticipants: quest.maxParticipants,
+        trigger: eventContext.trigger ?? 'lifecycle_sync',
+      },
     });
   }
 

--- a/lib/quest-workflow-events.ts
+++ b/lib/quest-workflow-events.ts
@@ -1,0 +1,50 @@
+import { Prisma, PrismaClient, QuestWorkflowEventType } from '@prisma/client';
+
+type DbClient = Prisma.TransactionClient | PrismaClient;
+
+export type QuestWorkflowActor = {
+  userId?: string | null;
+  role?: string | null;
+};
+
+type RecordQuestWorkflowEventInput = {
+  questId: string;
+  assignmentId?: string | null;
+  submissionId?: string | null;
+  actorUserId?: string | null;
+  actorRole?: string | null;
+  eventType: QuestWorkflowEventType;
+  payload?: Prisma.InputJsonValue | null;
+};
+
+function sanitizeActorValue(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildQuestWorkflowActor(
+  user?: { id?: string | null; role?: string | null } | null
+): QuestWorkflowActor {
+  return {
+    userId: sanitizeActorValue(user?.id),
+    role: sanitizeActorValue(user?.role),
+  };
+}
+
+export async function recordQuestWorkflowEvent(
+  db: DbClient,
+  input: RecordQuestWorkflowEventInput
+): Promise<void> {
+  await db.questWorkflowEvent.create({
+    data: {
+      questId: input.questId,
+      assignmentId: input.assignmentId ?? null,
+      submissionId: input.submissionId ?? null,
+      actorUserId: sanitizeActorValue(input.actorUserId),
+      actorRole: sanitizeActorValue(input.actorRole),
+      eventType: input.eventType,
+      payload: input.payload ?? Prisma.JsonNull,
+    },
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,14 @@ enum SubmissionStatus {
   rejected
 }
 
+enum QuestWorkflowEventType {
+  assignment_created
+  assignment_status_changed
+  submission_created
+  submission_reviewed
+  quest_status_changed
+}
+
 enum RevisionStatus {
   PENDING
   IN_PROGRESS
@@ -457,6 +465,24 @@ model QuestSubmission {
   @@index([assignmentId])
   @@index([status])
   @@map("quest_submissions")
+}
+
+model QuestWorkflowEvent {
+  id           String                 @id @default(uuid()) @db.Uuid
+  questId      String                 @map("quest_id") @db.Uuid
+  assignmentId String?                @map("assignment_id") @db.Uuid
+  submissionId String?                @map("submission_id") @db.Uuid
+  actorUserId  String?                @map("actor_user_id") @db.Uuid
+  actorRole    String?                @map("actor_role")
+  eventType    QuestWorkflowEventType @map("event_type")
+  payload      Json?
+  createdAt    DateTime               @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([questId, createdAt(sort: Desc)])
+  @@index([assignmentId, createdAt(sort: Desc)])
+  @@index([submissionId, createdAt(sort: Desc)])
+  @@index([actorUserId, createdAt(sort: Desc)])
+  @@map("quest_workflow_events")
 }
 
 model QuestCompletion {


### PR DESCRIPTION
## What changed

This adds a clean-room workflow provenance layer for quest execution.

- adds a `QuestWorkflowEvent` model and `QuestWorkflowEventType` enum in Prisma
- adds shared helpers in `lib/quest-workflow-events.ts` for actor capture and event recording
- records workflow events when assignments are created or change status
- records workflow events when submissions are created or reviewed
- records quest status changes inside `syncQuestLifecycleStatus`
- adds `GET /api/quests/[id]/workflow-events` for company/admin timeline access
- fixes the admin QA queue route to re-run lifecycle sync after approval/rejection so quest status stays consistent

## Why

The quest system has several parallel workflow paths, but no shared event trail tying together assignment changes, submission reviews, and derived quest status transitions. That makes it hard to build timelines, debug status drift, or safely add richer automation later.

This PR applies the same clean-room provenance pattern we have been using elsewhere: capture a small structured event at each workflow boundary, then expose the event stream through a bounded read API.

## Impact

- companies and admins can inspect recent workflow events per quest
- assignment/submission routes now leave an auditable trail for lifecycle changes
- admin QA approvals and rejections keep quest lifecycle status in sync instead of relying on stale derived state
- schema users will need to apply the updated Prisma schema before using the new event endpoint

## Validation

- `DATABASE_URL='postgresql://user:pass@localhost:5432/adventurers_guild' npx prisma@6.19.2 validate`
- `DATABASE_URL='postgresql://user:pass@localhost:5432/adventurers_guild' npx prisma@6.19.2 generate`
- `npm run type-check`
- `npm run lint -- --file app/api/quests/assignments/route.ts --file 'app/api/quests/[id]/assignments/route.ts' --file app/api/quests/submissions/route.ts --file 'app/api/admin/qa-queue/[assignmentId]/route.ts' --file app/api/qa/reviews/route.ts --file 'app/api/quests/[id]/workflow-events/route.ts' --file lib/quest-lifecycle.ts --file lib/quest-workflow-events.ts`
- `git diff --check`
