### PR TITLE
[FIX] Migrated all client fetch calls to fetchWithAuth

### DIFF
--- a/app/admin/qa-queue/page.tsx
+++ b/app/admin/qa-queue/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog';
 import { Shield, Clock, CheckCircle, XCircle, Loader2, ArrowLeft, ExternalLink } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface QueueItem {
   id: string;
@@ -68,7 +69,7 @@ export default function QAQueuePage() {
 
   const fetchQueue = useCallback(async () => {
     setLoading(true);
-    const res = await fetch('/api/admin/qa-queue');
+    const res = await fetchWithAuth('/api/admin/qa-queue');
     const data = await res.json();
     setItems(data.assignments ?? []);
     setLoading(false);
@@ -78,7 +79,7 @@ export default function QAQueuePage() {
 
   const handleApprove = async (assignmentId: string) => {
     setSubmitting(true);
-    await fetch(`/api/admin/qa-queue/${assignmentId}`, {
+    await fetchWithAuth(`/api/admin/qa-queue/${assignmentId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'approve' }),
@@ -90,7 +91,7 @@ export default function QAQueuePage() {
   const handleReject = async () => {
     if (!rejectTarget || !rejectNotes.trim()) return;
     setSubmitting(true);
-    await fetch(`/api/admin/qa-queue/${rejectTarget.id}`, {
+    await fetchWithAuth(`/api/admin/qa-queue/${rejectTarget.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim() }),

--- a/app/admin/quests/page.tsx
+++ b/app/admin/quests/page.tsx
@@ -45,6 +45,7 @@ import {
 import { toast } from 'sonner';
 import { useApiFetch } from '@/lib/hooks';
 import { QUEST_STATUS_COLORS, QUEST_STATUS_LABELS, RANK_COLORS } from '@/lib/quest-constants';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface AdminNote {
   id: string;
@@ -147,7 +148,7 @@ export default function AdminQuestsPage() {
   const handleStatusChange = async (questId: string, newStatus: string) => {
     setChangingStatusId(questId);
     try {
-      const response = await fetch('/api/admin/quests', {
+      const response = await fetchWithAuth('/api/admin/quests', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questId, status: newStatus }),
@@ -183,7 +184,7 @@ export default function AdminQuestsPage() {
 
     setSavingNote(true);
     try {
-      const response = await fetch('/api/admin/quests', {
+      const response = await fetchWithAuth('/api/admin/quests', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questId: noteQuest.id, addNote: newNoteText.trim() }),
@@ -218,7 +219,7 @@ export default function AdminQuestsPage() {
     }
 
     try {
-      const response = await fetch('/api/admin/quests', {
+      const response = await fetchWithAuth('/api/admin/quests', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questId }),

--- a/app/dashboard/company/create-quest/page.tsx
+++ b/app/dashboard/company/create-quest/page.tsx
@@ -31,6 +31,7 @@ import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { GuildCard, GuildChip, GuildHero, GuildPage } from '@/components/guild/primitives';
 import { QUEST_CATEGORIES, QUEST_TYPES, DIFFICULTY_RANKS, getQuestListPath } from '@/lib/quest-constants';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 export default function CreateQuestPage() {
   const { data: session, status } = useSession();
@@ -108,7 +109,7 @@ export default function CreateQuestPage() {
         deadline: form.deadline || null,
       };
 
-      const response = await fetch('/api/company/quests', {
+      const response = await fetchWithAuth('/api/company/quests', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/app/dashboard/company/profile/page.tsx
+++ b/app/dashboard/company/profile/page.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useApiFetch } from '@/lib/hooks';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 export default function CompanyProfilePage() {
   const { data: session, status } = useSession();
@@ -56,7 +57,7 @@ export default function CompanyProfilePage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch('/api/users/me', {
+      const res = await fetchWithAuth('/api/users/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/app/dashboard/company/quests/[id]/edit/page.tsx
+++ b/app/dashboard/company/quests/[id]/edit/page.tsx
@@ -30,6 +30,7 @@ import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { GuildCard, GuildChip, GuildHero, GuildPage } from '@/components/guild/primitives';
 import { QUEST_CATEGORIES, QUEST_TYPES, DIFFICULTY_RANKS } from '@/lib/quest-constants';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface QuestData {
   id: string;
@@ -89,7 +90,7 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
 
     const fetchQuest = async () => {
       try {
-        const res = await fetch(`/api/quests/${id}`);
+        const res = await fetchWithAuth(`/api/quests/${id}`);
         const data = await res.json();
         if (!data.success) {
           toast.error('Quest not found');
@@ -175,7 +176,7 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
         deadline: form.deadline || null,
       };
 
-      const response = await fetch('/api/company/quests', {
+      const response = await fetchWithAuth('/api/company/quests', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/app/dashboard/company/quests/[id]/page.tsx
+++ b/app/dashboard/company/quests/[id]/page.tsx
@@ -33,6 +33,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface Submission {
   id: string;
@@ -91,7 +92,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
 
     const fetchQuestDetails = async () => {
       try {
-        const response = await fetch(`/api/quests/${id}`);
+        const response = await fetchWithAuth(`/api/quests/${id}`);
         const data = await response.json();
 
         if (data.success) {
@@ -116,7 +117,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
     setProcessingId(assignmentId);
     const dbStatus: Applicant['status'] = action === 'accepted' ? 'started' : 'cancelled';
     try {
-      const response = await fetch(`/api/quests/${id}/assignments`, {
+      const response = await fetchWithAuth(`/api/quests/${id}/assignments`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ assignmentId, status: action }),
@@ -150,7 +151,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
   ) => {
     setProcessingId(assignmentId);
     try {
-      const response = await fetch('/api/quests/submissions', {
+      const response = await fetchWithAuth('/api/quests/submissions', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ submissionId, status: action }),
@@ -185,7 +186,7 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
 
     try {
       setIsClosing(true);
-      const response = await fetch('/api/company/quests', {
+      const response = await fetchWithAuth('/api/company/quests', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questId: quest.id }),

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useApiFetch } from '@/lib/hooks';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface UserProfile {
   xp: number;
@@ -69,7 +70,7 @@ export default function ProfilePage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch('/api/users/me', {
+      const res = await fetchWithAuth('/api/users/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: name.trim() }),

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { GuildCard, GuildChip, GuildHero, GuildKpi, GuildPage, GuildPanel } from '@/components/guild/primitives';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface Quest {
   id: string;
@@ -127,7 +128,7 @@ export default function QuestDetailPage() {
         setLoading(true);
         setError(null);
 
-        const questResponse = await fetch(`/api/quests/${questId}`);
+        const questResponse = await fetchWithAuth(`/api/quests/${questId}`);
         const questData = await questResponse.json();
 
         if (!questData.success) {
@@ -144,7 +145,7 @@ export default function QuestDetailPage() {
         setQuest(normalizedQuest);
 
         if (session?.user?.id) {
-          const assignmentResponse = await fetch(
+          const assignmentResponse = await fetchWithAuth(
             `/api/quests/assignments?userId=${session.user.id}&questId=${questId}`
           );
           const assignmentData = await assignmentResponse.json();
@@ -375,7 +376,7 @@ export default function QuestDetailPage() {
                     className="w-full"
                     onClick={async () => {
                       try {
-                        const response = await fetch('/api/quests/assignments', {
+                        const response = await fetchWithAuth('/api/quests/assignments', {
                           method: 'POST',
                           headers: { 'Content-Type': 'application/json' },
                           body: JSON.stringify({ questId }),
@@ -498,7 +499,7 @@ export default function QuestDetailPage() {
                   setIsSubmitting(true);
 
                   try {
-                    const response = await fetch('/api/quests/submissions', {
+                    const response = await fetchWithAuth('/api/quests/submissions', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({


### PR DESCRIPTION
## Changes
Replaced all raw the `fetch()` calls in client components with `fetchWithAuth()` from `lib/fetch-with-auth.ts`. This utility auto-redirects to `/login` when the server returns 401 (session expired), instead of showing a confusing error or silently failing.

## Acceptance Criteria Checklist
- [x] All listed files use `fetchWithAuth` for authenticated API calls
- [x] Public/pre-auth pages still use regular `fetch`
- [x] Type-check passes
- [x] No behavior change for successful requests (only 401 handling improves)

## Peer Review Checklist (for reviewer)
- [ ] Code does what the quest brief asks
- [ ] All acceptance criteria met
- [ ] Follows existing code patterns
- [ ] No obvious bugs or edge cases
- [ ] Comfortable sending to client

## Additional comments
On running `npx tsc --noEmit` (as directed to), the test passed initially. But before committing I synced my branch with the master. The new changes to the master branch do not pass this test. I just wanted to clarify that the test failing isn't related to the changes I made, but due to another file app/api/admin/activity/route.ts