### PR TITLE
I’ve continued by making the repo runnable against your exact script and by adding an automated runner.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ SMTP_USER=your-email@gmail.com
 SMTP_PASS=your-app-password
 ADMIN_EMAIL=admin@adventurersguild.com
 
+# Bootcamp onboarding webhook
+BOOTCAMP_WEBHOOK_SECRET=generate-a-secure-random-string
+# Optional: return initialPassword from /api/onboard response (dev/testing only)
+BOOTCAMP_ONBOARD_RETURN_PASSWORD=false
+
 # Application
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 

--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
+import crypto from 'crypto';
 
 // PATCH /api/admin/qa-queue/[assignmentId] — approve or reject submission
 export async function PATCH(

--- a/app/api/onboard/route.ts
+++ b/app/api/onboard/route.ts
@@ -3,30 +3,43 @@ import { prisma, withDbRetry } from '@/lib/db';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 
-const VALID_BOOTCAMP_TRACKS = ['animal_advocacy', 'climate_action', 'ai_safety', 'hybrid'] as const;
+const VALID_BOOTCAMP_TRACKS = ['animal_advocacy', 'climate_action', 'ai_safety', 'hybrid', 'beginner'] as const;
 
 interface OnboardPayload {
   bootcampStudentId: string;
   name: string;
   email: string;
+  cohort?: string;
   bootcampTrack: (typeof VALID_BOOTCAMP_TRACKS)[number];
-  bootcampWeek: number;
-  webhookSecret: string;
+  bootcampWeek?: number;
+  webhookSecret?: string; // legacy: allow secret in body
+  initialPassword?: string; // optional: provided by bootcamp system for initial login
+}
+
+function readBearerToken(req: NextRequest): string | null {
+  const authHeader = req.headers.get('authorization') ?? req.headers.get('Authorization');
+  if (!authHeader) return null;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body: OnboardPayload = await request.json();
 
-    // 1. Validate webhook secret
+    // 1. Validate webhook secret (Authorization: Bearer ... OR body.webhookSecret)
     const expectedSecret = process.env.BOOTCAMP_WEBHOOK_SECRET;
-    if (!expectedSecret || body.webhookSecret !== expectedSecret) {
+    const providedSecret = readBearerToken(request) ?? body.webhookSecret ?? null;
+    if (!expectedSecret || !providedSecret || providedSecret !== expectedSecret) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // 2. Validate required fields
     if (!body.bootcampStudentId || !body.name || !body.email || !body.bootcampTrack) {
-      return Response.json({ error: 'Missing required fields: bootcampStudentId, name, email, bootcampTrack' }, { status: 400 });
+      return Response.json(
+        { error: 'Missing required fields: bootcampStudentId, name, email, bootcampTrack' },
+        { status: 400 }
+      );
     }
 
     const normalizedEmail = body.email.trim().toLowerCase();
@@ -87,8 +100,11 @@ export async function POST(request: NextRequest) {
     }
 
     // 5. Create User + AdventurerProfile + BootcampLink in transaction
-    const generatedPassword = crypto.randomBytes(16).toString('hex');
-    const passwordHash = await bcrypt.hash(generatedPassword, 12);
+    const passwordPlaintext =
+      typeof body.initialPassword === 'string' && body.initialPassword.trim().length >= 8
+        ? body.initialPassword.trim()
+        : crypto.randomBytes(16).toString('hex');
+    const passwordHash = await bcrypt.hash(passwordPlaintext, 12);
 
     const user = await withDbRetry(() =>
       prisma.$transaction(async (tx) => {
@@ -110,6 +126,7 @@ export async function POST(request: NextRequest) {
           data: {
             userId: newUser.id,
             bootcampStudentId: body.bootcampStudentId,
+            cohort: body.cohort?.trim() || null,
             bootcampTrack: body.bootcampTrack,
             bootcampWeek,
             eligibleForRealQuests: false,
@@ -120,11 +137,14 @@ export async function POST(request: NextRequest) {
       })
     );
 
+    const shouldReturnPassword = process.env.BOOTCAMP_ONBOARD_RETURN_PASSWORD === 'true';
+
     return Response.json(
       {
         success: true,
         adventurerId: user.id,
         rank: 'F',
+        ...(shouldReturnPassword ? { initialPassword: passwordPlaintext } : {}),
       },
       { status: 201 }
     );

--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -171,7 +171,7 @@ export async function POST(request: NextRequest) {
 
       const quest = await prisma.quest.findUnique({
         where: { id: existingSubmission.assignment.questId },
-        select: { xpReward: true, skillPointsReward: true },
+        select: { xpReward: true, skillPointsReward: true, title: true },
       });
 
       if (!quest) {
@@ -198,8 +198,39 @@ export async function POST(request: NextRequest) {
       await updateUserXpAndSkills(
         existingSubmission.assignment.userId,
         quest.xpReward,
-        quest.skillPointsReward
+        quest.skillPointsReward,
+        existingSubmission.assignment.questId
       );
+
+      // Bootcamp tutorial completion tracking (required for tutorial gating)
+      if (quest.title.startsWith('Tutorial:')) {
+        const bootcampLink = await prisma.bootcampLink.findUnique({
+          where: { userId: existingSubmission.assignment.userId },
+          select: { tutorialQuest1Complete: true, tutorialQuest2Complete: true },
+        });
+
+        if (bootcampLink) {
+          const updateData: {
+            tutorialQuest1Complete?: boolean;
+            tutorialQuest2Complete?: boolean;
+            eligibleForRealQuests?: boolean;
+          } = {};
+
+          if (quest.title.startsWith('Tutorial: First Blood')) updateData.tutorialQuest1Complete = true;
+          if (quest.title.startsWith('Tutorial: Party Up')) updateData.tutorialQuest2Complete = true;
+
+          const tq1 = updateData.tutorialQuest1Complete ?? bootcampLink.tutorialQuest1Complete;
+          const tq2 = updateData.tutorialQuest2Complete ?? bootcampLink.tutorialQuest2Complete;
+          if (tq1 && tq2) updateData.eligibleForRealQuests = true;
+
+          if (Object.keys(updateData).length > 0) {
+            await prisma.bootcampLink.update({
+              where: { userId: existingSubmission.assignment.userId },
+              data: updateData,
+            });
+          }
+        }
+      }
     }
     else if (status === 'needs_rework' || status === 'rejected') {
       await prisma.questAssignment.update({

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { GuildCard, GuildChip, GuildHero, GuildKpi, GuildPage, GuildPanel } from '@/components/guild/primitives';
+import { PartyPanel, type Party } from '@/components/quest/PartyPanel';
 import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface Quest {
@@ -48,6 +49,7 @@ interface Quest {
     name: string;
     email?: string;
   };
+  party?: Party | null;
 }
 
 interface Assignment {
@@ -172,6 +174,7 @@ export default function QuestDetailPage() {
   const isAssigned = !!assignment;
   const canAssign = quest?.status === 'available' && !isAssigned;
   const canSubmit = !!assignment && ['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status);
+  const showPartyPanel = (quest?.maxParticipants ?? 1) > 1;
 
   const rewardCards = useMemo(
     () =>
@@ -423,6 +426,22 @@ export default function QuestDetailPage() {
               </GuildPanel>
             </GuildCard>
           )}
+
+          {showPartyPanel && session?.user?.id ? (
+            <PartyPanel
+              questId={quest.id}
+              party={quest.party ?? null}
+              maxParticipants={quest.maxParticipants ?? 1}
+              isAssigned={isAssigned}
+              currentUserId={session.user.id}
+              onPartyCreated={(party) =>
+                setQuest((previous) => (previous ? { ...previous, party } : previous))
+              }
+              onMemberAdded={() => {
+                // Reserved for parent-side reactions to membership changes.
+              }}
+            />
+          ) : null}
 
           <GuildCard className="border-slate-200/80">
             <GuildPanel asChild className="border-0 bg-transparent shadow-none">

--- a/components/quest/PartyPanel.tsx
+++ b/components/quest/PartyPanel.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Crown, Trash2, UserPlus, Users } from 'lucide-react';
+import { toast } from 'sonner';
+import { GuildCard, GuildPanel } from '@/components/guild/primitives';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Progress } from '@/components/ui/progress';
+import { RankBadge, type Rank } from '@/components/ui/rank-badge';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
+
+interface PartyMemberUser {
+  id: string;
+  name: string | null;
+  rank: string | null;
+}
+
+interface PartyMember {
+  user: PartyMemberUser;
+  isLeader: boolean;
+}
+
+export interface Party {
+  id: string;
+  track: 'INTERN' | 'BOOTCAMP' | string;
+  maxSize: number;
+  leader: PartyMemberUser;
+  members: PartyMember[];
+}
+
+interface PartyPanelProps {
+  questId: string;
+  party: Party | null;
+  maxParticipants: number;
+  isAssigned: boolean;
+  currentUserId: string;
+  onPartyCreated: (party: Party) => void;
+  onMemberAdded: () => void;
+}
+
+const VALID_RANKS: Rank[] = ['F', 'E', 'D', 'C', 'B', 'A', 'S'];
+
+function toInitials(name: string | null): string {
+  if (!name) return '?';
+  const chunks = name.trim().split(/\s+/).filter(Boolean);
+  if (chunks.length === 0) return '?';
+  return chunks.slice(0, 2).map((chunk) => chunk[0]?.toUpperCase() || '').join('');
+}
+
+function toRank(rank: string | null): Rank | null {
+  if (!rank) return null;
+  return VALID_RANKS.includes(rank as Rank) ? (rank as Rank) : null;
+}
+
+export function PartyPanel({
+  questId,
+  party,
+  maxParticipants,
+  isAssigned,
+  currentUserId,
+  onPartyCreated,
+  onMemberAdded,
+}: PartyPanelProps) {
+  const [isCreatingParty, setIsCreatingParty] = useState(false);
+  const [isInviting, setIsInviting] = useState(false);
+  const [inviteUserId, setInviteUserId] = useState('');
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+
+  const isLeader = !!party && party.leader.id === currentUserId;
+  const isBootcamp = party?.track === 'BOOTCAMP';
+  const partyLabel = isBootcamp ? 'Pair' : 'Squad';
+  const capacity = party?.maxSize ?? maxParticipants;
+  const memberCount = party?.members.length ?? 0;
+  const progressValue = capacity > 0 ? Math.round((memberCount / capacity) * 100) : 0;
+  const emptySlots = Math.max(capacity - memberCount, 0);
+
+  const canInvite = useMemo(() => !!party && isLeader && memberCount < capacity, [party, isLeader, memberCount, capacity]);
+
+  const refreshParty = async (partyId: string) => {
+    const response = await fetchWithAuth(`/api/parties/${partyId}`);
+    const data = await response.json();
+    if (!data.success || !data.party) {
+      throw new Error(data.error || 'Failed to refresh party');
+    }
+    return data.party as Party;
+  };
+
+  const handleCreateParty = async () => {
+    try {
+      setIsCreatingParty(true);
+      const response = await fetchWithAuth('/api/parties', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questId }),
+      });
+
+      const data = await response.json();
+      if (!data.success || !data.party) {
+        toast.error(data.error || 'Failed to create party');
+        return;
+      }
+
+      onPartyCreated(data.party as Party);
+      toast.success('Party formed successfully');
+    } catch (error) {
+      console.error('Error creating party:', error);
+      toast.error('An error occurred while creating party');
+    } finally {
+      setIsCreatingParty(false);
+    }
+  };
+
+  const handleInviteMember = async () => {
+    if (!party) return;
+
+    const targetUserId = inviteUserId.trim();
+    if (!targetUserId) {
+      toast.error('Enter an adventurer user ID');
+      return;
+    }
+
+    try {
+      setIsInviting(true);
+      const response = await fetchWithAuth(`/api/parties/${party.id}/members`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: targetUserId }),
+      });
+
+      const data = await response.json();
+      if (!data.success || !data.party) {
+        toast.error(data.error || 'Failed to add member');
+        return;
+      }
+
+      onPartyCreated(data.party as Party);
+      onMemberAdded();
+      setInviteUserId('');
+      setIsInviteDialogOpen(false);
+      toast.success('Member added to party');
+    } catch (error) {
+      console.error('Error adding party member:', error);
+      toast.error('An error occurred while adding member');
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    if (!party) return;
+
+    try {
+      setRemovingUserId(userId);
+      const response = await fetchWithAuth(`/api/parties/${party.id}/members/${userId}`, {
+        method: 'DELETE',
+      });
+      const data = await response.json();
+
+      if (!data.success) {
+        toast.error(data.error || 'Failed to remove member');
+        return;
+      }
+
+      const refreshed = await refreshParty(party.id);
+      onPartyCreated(refreshed);
+      onMemberAdded();
+      toast.success('Member removed from party');
+    } catch (error) {
+      console.error('Error removing party member:', error);
+      toast.error('An error occurred while removing member');
+    } finally {
+      setRemovingUserId(null);
+    }
+  };
+
+  if (!party) {
+    return (
+      <GuildCard className="border-slate-200/80">
+        <GuildPanel asChild className="border-0 bg-transparent shadow-none">
+          <div className="space-y-4 p-6">
+            <div className="flex items-start gap-3">
+              <Users className="mt-0.5 h-5 w-5 text-orange-500" />
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900">Party Panel</h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  This quest supports up to {maxParticipants} adventurers.
+                </p>
+              </div>
+            </div>
+
+            {isAssigned ? (
+              <Button className="w-full" onClick={() => void handleCreateParty()} disabled={isCreatingParty}>
+                {isCreatingParty ? 'Forming Party...' : 'Form a Party'}
+              </Button>
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+                Join this quest to form the {maxParticipants === 2 ? 'pair' : 'squad'}.
+              </div>
+            )}
+          </div>
+        </GuildPanel>
+      </GuildCard>
+    );
+  }
+
+  return (
+    <GuildCard className="border-slate-200/80">
+      <GuildPanel asChild className="border-0 bg-transparent shadow-none">
+        <div className="space-y-4 p-6">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">{partyLabel} Panel</h2>
+              <p className="mt-1 text-sm text-slate-500">
+                {memberCount}/{capacity} members
+              </p>
+            </div>
+            <Badge variant="outline" className="uppercase">
+              {party.track}
+            </Badge>
+          </div>
+
+          <Progress value={progressValue} className="h-2" />
+
+          <div className="space-y-2">
+            {party.members.map((member) => {
+              const memberRank = toRank(member.user.rank);
+              return (
+                <div
+                  key={member.user.id}
+                  className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-3 py-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-9 w-9 border border-slate-200">
+                      <AvatarFallback className="bg-slate-100 text-xs font-semibold text-slate-700">
+                        {toInitials(member.user.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium text-slate-900">{member.user.name || 'Unknown Adventurer'}</p>
+                      {member.isLeader && <Crown className="h-4 w-4 text-amber-500" />}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {memberRank ? <RankBadge rank={memberRank} size="sm" /> : null}
+                    {isLeader && !member.isLeader ? (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => void handleRemoveMember(member.user.id)}
+                        disabled={removingUserId === member.user.id}
+                        aria-label={`Remove ${member.user.name || 'member'}`}
+                      >
+                        <Trash2 className="h-4 w-4 text-rose-600" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+
+            {Array.from({ length: emptySlots }).map((_, index) => (
+              <div
+                key={`empty-slot-${index}`}
+                className="flex items-center rounded-xl border border-dashed border-slate-300 px-3 py-2 text-sm text-slate-500"
+              >
+                Open member slot
+              </div>
+            ))}
+          </div>
+
+          {canInvite ? (
+            <Dialog open={isInviteDialogOpen} onOpenChange={setIsInviteDialogOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" className="w-full">
+                  <UserPlus className="h-4 w-4" />
+                  Invite Member
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Invite Adventurer</DialogTitle>
+                  <DialogDescription>
+                    Enter the adventurer user ID to add them to this {partyLabel.toLowerCase()}.
+                  </DialogDescription>
+                </DialogHeader>
+                <Input
+                  value={inviteUserId}
+                  onChange={(event) => setInviteUserId(event.target.value)}
+                  placeholder="User ID (UUID)"
+                />
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsInviteDialogOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button onClick={() => void handleInviteMember()} disabled={isInviting || !inviteUserId.trim()}>
+                    {isInviting ? 'Inviting...' : 'Add Member'}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          ) : null}
+        </div>
+      </GuildPanel>
+    </GuildCard>
+  );
+}

--- a/docs/bootcamp-pipeline.ps1
+++ b/docs/bootcamp-pipeline.ps1
@@ -1,0 +1,383 @@
+<#
+Bootcamp E2E pipeline runner (manual validation)
+
+Runs:
+- Onboard 5 students via /api/onboard (Bearer secret)
+- Verify tutorial gating + INTERN quest 403
+- Complete Tutorial 1 + Tutorial 2 (claim -> submit -> admin QA approve -> company approve)
+- Verify eligibleForRealQuests unlocks real BOOTCAMP quests
+- Party formation for BOOTCAMP E-rank quest (max participants 2)
+- Verify XP/rank via /api/users/me/stats (DB-backed)
+
+Prereqs:
+- App running (npm run dev)
+- DB pushed/seeded
+- .env.local includes DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL, BOOTCAMP_WEBHOOK_SECRET
+
+Usage:
+  pwsh -File .\docs\bootcamp-pipeline.ps1 -BaseUrl http://localhost:3000 -BootcampWebhookSecret $env:BOOTCAMP_WEBHOOK_SECRET
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $false)]
+  [string]$BaseUrl = 'http://localhost:3000',
+
+  [Parameter(Mandatory = $true)]
+  [string]$BootcampWebhookSecret,
+
+  [Parameter(Mandatory = $false)]
+  [string]$Cohort = 'test-cohort-1',
+
+  [Parameter(Mandatory = $false)]
+  [ValidateSet('beginner','animal_advocacy','climate_action','ai_safety','hybrid')]
+  [string]$BootcampTrack = 'beginner',
+
+  [Parameter(Mandatory = $false)]
+  [string]$InitialPassword = 'password123',
+
+  [Parameter(Mandatory = $false)]
+  [int]$StudentCount = 5,
+
+  [Parameter(Mandatory = $false)]
+  [string]$AdminEmail = 'admin@adventurersguild.com',
+
+  [Parameter(Mandatory = $false)]
+  [string]$CompanyEmail = 'contact@knightmedicare.com',
+
+  [Parameter(Mandatory = $false)]
+  [string]$SeedPassword = 'password123'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Normalize-BaseUrl([string]$u) {
+  $u = $u.Trim()
+  if ($u.EndsWith('/')) { return $u.Substring(0, $u.Length - 1) }
+  return $u
+}
+
+$BaseUrl = Normalize-BaseUrl $BaseUrl
+
+function Write-Step([string]$title) {
+  Write-Host "\n=== $title ===" -ForegroundColor Cyan
+}
+
+function Assert-True([bool]$cond, [string]$message) {
+  if (-not $cond) { throw "ASSERT FAILED: $message" }
+  Write-Host "PASS: $message" -ForegroundColor Green
+}
+
+function Invoke-ApiJson {
+  param(
+    [Parameter(Mandatory=$true)][ValidateSet('GET','POST','PUT','PATCH','DELETE')][string]$Method,
+    [Parameter(Mandatory=$true)][string]$Path,
+    [Parameter(Mandatory=$false)][Microsoft.PowerShell.Commands.WebRequestSession]$Session,
+    [Parameter(Mandatory=$false)][hashtable]$Headers,
+    [Parameter(Mandatory=$false)]$Body
+  )
+
+  $uri = "$BaseUrl$Path"
+
+  $sc = $null
+  $rh = $null
+  $params = @{
+    Uri = $uri
+    Method = $Method
+    SkipHttpErrorCheck = $true
+    StatusCodeVariable = 'sc'
+    ResponseHeadersVariable = 'rh'
+  }
+  if ($Session) { $params.WebSession = $Session }
+  if ($Headers) { $params.Headers = $Headers }
+
+  if ($null -ne $Body) {
+    $params.Body = ($Body | ConvertTo-Json -Depth 10)
+    $params.ContentType = 'application/json'
+  }
+
+  $json = Invoke-RestMethod @params
+
+  return [pscustomobject]@{
+    Status  = [int]$sc
+    Headers = $rh
+    Json    = $json
+  }
+}
+
+function New-Session() {
+  return [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+}
+
+function Sign-In {
+  param(
+    [Parameter(Mandatory=$true)][Microsoft.PowerShell.Commands.WebRequestSession]$Session,
+    [Parameter(Mandatory=$true)][string]$Email,
+    [Parameter(Mandatory=$true)][string]$Password
+  )
+
+  # 1) Fetch CSRF token
+  $csrf = Invoke-RestMethod -Uri "$BaseUrl/api/auth/csrf" -WebSession $Session
+  if (-not $csrf.csrfToken) { throw 'Failed to fetch CSRF token from NextAuth' }
+
+  # 2) Credentials callback (form-encoded)
+  $form = @{
+    csrfToken  = $csrf.csrfToken
+    email      = $Email
+    password   = $Password
+    callbackUrl = "$BaseUrl/dashboard"
+    json       = 'true'
+  }
+
+  try {
+    Invoke-WebRequest -Uri "$BaseUrl/api/auth/callback/credentials" -Method POST -Body $form -ContentType 'application/x-www-form-urlencoded' -WebSession $Session -MaximumRedirection 0 | Out-Null
+  } catch {
+    # NextAuth commonly returns 302; Invoke-WebRequest may throw depending on redirects.
+    # Cookies are still stored in $Session.
+  }
+
+  $cookies = $Session.Cookies.GetCookies([Uri]$BaseUrl)
+  $hasSessionCookie = $false
+  foreach ($c in $cookies) {
+    if ($c.Name -like '*session-token*') { $hasSessionCookie = $true }
+  }
+  if (-not $hasSessionCookie) {
+    throw "Login failed for $Email (no session-token cookie set)"
+  }
+}
+
+# Seed company userId referenced by prisma/seed.ts
+$SeedCompanyId = '33333333-3333-3333-3333-333333333333'
+
+Write-Step 'Step 0: Login admin + company'
+$adminSession = New-Session
+Sign-In -Session $adminSession -Email $AdminEmail -Password $SeedPassword
+Write-Host "Admin logged in: $AdminEmail" -ForegroundColor Green
+
+$companySession = New-Session
+Sign-In -Session $companySession -Email $CompanyEmail -Password $SeedPassword
+Write-Host "Company logged in: $CompanyEmail" -ForegroundColor Green
+
+Write-Step 'Step 0.1: Create 1 INTERN quest for 403 direct-URL test'
+$internQuest = Invoke-ApiJson -Method POST -Path '/api/admin/quests' -Session $adminSession -Body @{
+  title = 'INTERN: Direct URL Gate Test'
+  description = 'INTERN quest used to verify bootcamp students get 403 on direct access.'
+  questType = 'learning'
+  difficulty = 'F'
+  xpReward = 100
+  questCategory = 'backend'
+  track = 'INTERN'
+  source = 'CLIENT_PORTAL'
+  status = 'available'
+  companyId = $SeedCompanyId
+  requiredSkills = @()
+  maxParticipants = 1
+}
+Assert-True ($internQuest.Status -eq 201) "Created INTERN quest (status=201)"
+$internQuestId = $internQuest.Json.quest.id
+
+Write-Step 'Step 0.2: Create tutorial quests + a real BOOTCAMP quest + an E-rank party quest'
+# Tutorial 1 (F) and Tutorial 2 (E) are source=TUTORIAL so they show pre-unlock.
+$tut1 = Invoke-ApiJson -Method POST -Path '/api/admin/quests' -Session $adminSession -Body @{
+  title = 'Tutorial: First Blood'
+  description = 'Bootcamp tutorial quest 1.'
+  questType = 'learning'
+  difficulty = 'F'
+  xpReward = 600
+  questCategory = 'backend'
+  track = 'BOOTCAMP'
+  source = 'TUTORIAL'
+  status = 'available'
+  companyId = $SeedCompanyId
+  requiredSkills = @()
+  maxParticipants = 999
+}
+Assert-True ($tut1.Status -eq 201) 'Created Tutorial 1'
+$tut1Id = $tut1.Json.quest.id
+
+$tut2 = Invoke-ApiJson -Method POST -Path '/api/admin/quests' -Session $adminSession -Body @{
+  title = 'Tutorial: Party Up'
+  description = 'Bootcamp tutorial quest 2.'
+  questType = 'learning'
+  difficulty = 'E'
+  xpReward = 600
+  questCategory = 'backend'
+  track = 'BOOTCAMP'
+  source = 'TUTORIAL'
+  status = 'available'
+  companyId = $SeedCompanyId
+  requiredSkills = @()
+  maxParticipants = 999
+}
+Assert-True ($tut2.Status -eq 201) 'Created Tutorial 2'
+$tut2Id = $tut2.Json.quest.id
+
+$realQuest = Invoke-ApiJson -Method POST -Path '/api/admin/quests' -Session $adminSession -Body @{
+  title = 'BOOTCAMP: Real Quest (Unlock Test)'
+  description = 'Non-tutorial bootcamp quest that should only appear after tutorials.'
+  questType = 'learning'
+  difficulty = 'F'
+  xpReward = 250
+  questCategory = 'backend'
+  track = 'BOOTCAMP'
+  source = 'CLIENT_PORTAL'
+  status = 'available'
+  companyId = $SeedCompanyId
+  requiredSkills = @()
+  maxParticipants = 5
+}
+Assert-True ($realQuest.Status -eq 201) 'Created real BOOTCAMP quest'
+$realQuestId = $realQuest.Json.quest.id
+
+$partyQuest = Invoke-ApiJson -Method POST -Path '/api/admin/quests' -Session $adminSession -Body @{
+  title = 'BOOTCAMP: E-Rank Pair Quest'
+  description = 'Bootcamp pair quest for party formation testing.'
+  questType = 'learning'
+  difficulty = 'E'
+  xpReward = 300
+  questCategory = 'backend'
+  track = 'BOOTCAMP'
+  source = 'CLIENT_PORTAL'
+  status = 'available'
+  companyId = $SeedCompanyId
+  requiredSkills = @()
+  maxParticipants = 2
+}
+Assert-True ($partyQuest.Status -eq 201) 'Created BOOTCAMP party quest'
+$partyQuestId = $partyQuest.Json.quest.id
+
+Write-Step 'Step 1: Onboard students'
+$students = @()
+for ($i = 1; $i -le $StudentCount; $i++) {
+  $email = "test$i@bootcamp.dev"
+  $studentId = ('BC{0:D3}' -f $i)
+
+  $resp = Invoke-ApiJson -Method POST -Path '/api/onboard' -Headers @{
+    Authorization = "Bearer $BootcampWebhookSecret"
+  } -Body @{
+    name = "Test Student $i"
+    email = $email
+    bootcampStudentId = $studentId
+    cohort = $Cohort
+    bootcampTrack = $BootcampTrack
+    bootcampWeek = 1
+    initialPassword = $InitialPassword
+  }
+
+  Assert-True ($resp.Status -in 201,200) "Onboarded $email (status=$($resp.Status))"
+
+  $students += [pscustomobject]@{
+    Index = $i
+    Email = $email
+    AdventurerId = $resp.Json.adventurerId
+    Session = $null
+  }
+}
+
+Write-Step 'Step 2: Verify gating (quest list + INTERN quest 403)'
+foreach ($s in $students) {
+  $sess = New-Session
+  Sign-In -Session $sess -Email $s.Email -Password $InitialPassword
+  $s.Session = $sess
+
+  $q = Invoke-ApiJson -Method GET -Path '/api/quests?status=available&limit=50' -Session $sess
+  Assert-True ($q.Status -eq 200) "Fetched quest list for $($s.Email)"
+
+  $quests = @($q.Json.quests)
+  Assert-True ($quests.Count -ge 1) "Has at least 1 visible quest (tutorials)"
+
+  $nonBootcamp = $quests | Where-Object { $_.track -ne 'BOOTCAMP' }
+  Assert-True ($nonBootcamp.Count -eq 0) "Only sees BOOTCAMP track quests"
+
+  $nonTutorial = $quests | Where-Object { $_.source -ne 'TUTORIAL' }
+  Assert-True ($nonTutorial.Count -eq 0) "Only sees TUTORIAL quests before unlock"
+
+  $internDirect = Invoke-ApiJson -Method GET -Path ("/api/quests/$internQuestId") -Session $sess
+  Assert-True ($internDirect.Status -eq 403) "Direct INTERN quest access returns 403"
+}
+
+function Complete-QuestFlow {
+  param(
+    [Parameter(Mandatory=$true)][Microsoft.PowerShell.Commands.WebRequestSession]$StudentSession,
+    [Parameter(Mandatory=$true)][string]$QuestId,
+    [Parameter(Mandatory=$true)][string]$QuestLabel
+  )
+
+  # Claim
+  $claim = Invoke-ApiJson -Method POST -Path '/api/quests/assignments' -Session $StudentSession -Body @{ questId = $QuestId }
+  Assert-True ($claim.Status -eq 201) "Claimed $QuestLabel"
+  $assignmentId = $claim.Json.assignment.id
+
+  # Submit
+  $submit = Invoke-ApiJson -Method POST -Path '/api/quests/submissions' -Session $StudentSession -Body @{
+    assignmentId = $assignmentId
+    submissionContent = "https://example.com/submission/$assignmentId"
+    submissionNotes = 'Automated bootcamp pipeline validation'
+  }
+  Assert-True ($submit.Status -eq 201) "Submitted $QuestLabel"
+  $submissionId = $submit.Json.submission.id
+
+  # Admin QA approve (pending_admin_review -> review)
+  $qa = Invoke-ApiJson -Method PATCH -Path ("/api/admin/qa-queue/$assignmentId") -Session $adminSession -Body @{ action = 'approve' }
+  Assert-True ($qa.Status -eq 200) "Admin QA approved $QuestLabel (forwarded to client review)"
+
+  # Company approve (review -> completed) + XP grant
+  $approve = Invoke-ApiJson -Method POST -Path '/api/qa/reviews' -Session $companySession -Body @{
+    submissionId = $submissionId
+    quality_score = 90
+    status = 'approved'
+    review_notes = "Approved: $QuestLabel"
+  }
+  Assert-True ($approve.Status -eq 200) "Company approved $QuestLabel (completed + XP granted)"
+
+  return [pscustomobject]@{ AssignmentId = $assignmentId; SubmissionId = $submissionId }
+}
+
+Write-Step 'Step 3 + 4: Complete Tutorial Quest 1 and 2 for ALL students'
+foreach ($s in $students) {
+  Write-Host "\n-- Student $($s.Index): $($s.Email) --" -ForegroundColor Yellow
+
+  Complete-QuestFlow -StudentSession $s.Session -QuestId $tut1Id -QuestLabel 'Tutorial 1'
+  Complete-QuestFlow -StudentSession $s.Session -QuestId $tut2Id -QuestLabel 'Tutorial 2'
+
+  # Verify unlock: should now see non-tutorial BOOTCAMP quest
+  $q2 = Invoke-ApiJson -Method GET -Path '/api/quests?status=available&limit=50' -Session $s.Session
+  $quests2 = @($q2.Json.quests)
+  $nonTutorial2 = $quests2 | Where-Object { $_.source -ne 'TUTORIAL' }
+  Assert-True ($nonTutorial2.Count -ge 1) 'Sees real BOOTCAMP quests after tutorials'
+
+  # Verify can apply to real quest
+  $applyReal = Invoke-ApiJson -Method POST -Path '/api/quests/assignments' -Session $s.Session -Body @{ questId = $realQuestId }
+  Assert-True ($applyReal.Status -eq 201) 'Can claim a real BOOTCAMP quest after unlock'
+}
+
+Write-Step 'Step 6: Party formation (Students 1 + 2)'
+$student1 = $students | Where-Object { $_.Index -eq 1 } | Select-Object -First 1
+$student2 = $students | Where-Object { $_.Index -eq 2 } | Select-Object -First 1
+
+Assert-True ($null -ne $student1 -and $null -ne $student2) 'Have student 1 and 2'
+
+# Verify rank-up evidence via DB-backed stats endpoint (should be >= E after 2 tutorials at 600xp each)
+$stats1 = Invoke-ApiJson -Method GET -Path '/api/users/me/stats' -Session $student1.Session
+Assert-True ($stats1.Status -eq 200) 'Fetched /api/users/me/stats for student 1'
+Write-Host "Student1 rank=$($stats1.Json.rank) xp=$($stats1.Json.xp)" -ForegroundColor Green
+Assert-True ($stats1.Json.rank -in @('E','D','C','B','A','S')) 'Student 1 rank is E or higher'
+
+$partyCreate = Invoke-ApiJson -Method POST -Path '/api/parties' -Session $student1.Session -Body @{ questId = $partyQuestId }
+Assert-True ($partyCreate.Status -eq 201) 'Student 1 created party'
+$partyId = $partyCreate.Json.party.id
+
+$partyAdd = Invoke-ApiJson -Method POST -Path ("/api/parties/$partyId/members") -Session $student1.Session -Body @{ userId = $student2.AdventurerId }
+Assert-True ($partyAdd.Status -eq 201) 'Student 1 added Student 2 to party'
+
+# Both claim and complete the party quest
+$flow1 = Complete-QuestFlow -StudentSession $student1.Session -QuestId $partyQuestId -QuestLabel 'Party Quest (Student 1)'
+$flow2 = Complete-QuestFlow -StudentSession $student2.Session -QuestId $partyQuestId -QuestLabel 'Party Quest (Student 2)'
+
+Write-Step 'DONE: Pipeline evidence summary'
+Write-Host "Onboarded students: $StudentCount" -ForegroundColor Green
+Write-Host "Tutorial quests: $tut1Id, $tut2Id" -ForegroundColor Green
+Write-Host "Real quest (unlock test): $realQuestId" -ForegroundColor Green
+Write-Host "Party quest: $partyQuestId (partyId=$partyId)" -ForegroundColor Green
+Write-Host "INTERN 403 quest: $internQuestId" -ForegroundColor Green

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -214,7 +214,8 @@ model BootcampLink {
   id                     String    @id @default(uuid()) @db.Uuid
   userId                 String    @unique @map("user_id") @db.Uuid
   bootcampStudentId      String    @unique @map("bootcamp_student_id")
-  bootcampTrack          String    @map("bootcamp_track") // animal_advocacy | climate_action | ai_safety | hybrid
+  cohort                 String?   @map("cohort")
+  bootcampTrack          String    @map("bootcamp_track") // animal_advocacy | climate_action | ai_safety | hybrid | beginner
   bootcampWeek           Int       @default(1) @map("bootcamp_week")
   enrolledAt             DateTime  @default(now()) @map("enrolled_at") @db.Timestamptz
   graduatedAt            DateTime? @map("graduated_at") @db.Timestamptz


### PR DESCRIPTION
I’ve continued by making the repo runnable against your exact script and by adding an automated runner.

Changes made (so the pipeline can actually be exercised)
/api/onboard now supports:
Authorization: Bearer $BOOTCAMP_WEBHOOK_SECRET
bootcampTrack: "beginner" (your script value)
optional cohort
optional initialPassword (so students can log in)
Added BootcampLink.cohort to prisma\schema.prisma
Fixed tutorial unlock when using /api/qa/reviews (so Tutorial approvals flip eligibleForRealQuests)
Fixed missing crypto import in app\api\admin\qa-queue\[assignmentId]\route.ts (reject path)

Run it locally (end-to-end, 5 students, all steps)
Apply schema + seed, start server:
In a 2nd terminal, run the full pipeline script:
This script drives: onboard → gating checks (incl. INTERN 403) → tutorial 1+2 flows (claim/submit/QA/company approve) → unlock real quests → party formation (students 1+2) → rank evidence via /api/users/me/stats.