### PR TITLE
docs: NSoC compliance — README overhaul + fix db setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 This document is the source of truth for how work gets done on this project — whether you're a human developer or an AI agent picking up a GitHub issue.
 
+> **NSoC 2026 participants** — Welcome! This project is part of Nexus Spring of Code 2026 (April 15 – May 30). Issues labeled `NSoC-2026` are the active contribution targets. Join our [Discord](https://discord.gg/7hQYkEx5) for help.
+
 ---
 
 ## Table of Contents
@@ -90,11 +92,8 @@ RAZORPAY_KEY_SECRET="..."
 # Generate Prisma client
 npx prisma generate
 
-# Apply migrations (dev only)
-npx prisma migrate dev
-
-# Seed with sample data
-npm run db:seed
+# Push schema to your Neon database (do NOT use migrate dev — Neon serverless requires db push)
+npm run db:push
 ```
 
 ### 4. Run the dev server
@@ -174,13 +173,13 @@ Never edit a file you haven't read in the current session. Check the surrounding
 
 ### 5. Schema changes
 
-Every schema change requires a migration:
+After editing `prisma/schema.prisma`, push the changes to your Neon database:
 
 ```bash
-npx prisma migrate dev --name describe-what-changed
+npm run db:push
 ```
 
-Always use `@default()` for new required fields so existing rows aren't broken.
+**Do NOT use `prisma migrate dev`** — this project uses Neon serverless PostgreSQL which requires `db push`. Always use `@default()` for new required fields so existing rows aren't broken.
 
 ### 6. Run checks before opening a PR
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # The Adventurers Guild
 
 [![GitHub contributors](https://img.shields.io/github/contributors/LarytheLord/adventurers-guild?style=flat-square)](https://github.com/LarytheLord/adventurers-guild/graphs/contributors)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Discord](https://img.shields.io/discord/7hQYkEx5?label=Discord&logo=discord&style=flat-square)](https://discord.gg/7hQYkEx5)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Discord](https://img.shields.io/discord/7hQYkEx5?label=Discord&logo=discord&style=flat-square)](https://discord.gg/7hQYkEx5)
 [![Website](https://img.shields.io/badge/Website-Live-blue?style=flat-square)](https://adventurersguild.vercel.app)
+[![NSoC 2026](https://img.shields.io/badge/NSoC-2026-orange?style=flat-square)](https://nsoc.in)
 [![Sponsor Us](https://img.shields.io/badge/Sponsor%20Us-Razorpay-0C73EB?style=for-the-badge&logo=razorpay&logoColor=white)](https://razorpay.me/@LarytheLord)
 
 ## Revolutionizing Computer Science Education
@@ -11,45 +13,54 @@
 
 Part of the **Open Paws** ecosystem, integrating with the Open Paws Bootcamp and Internship Programme.
 
+![Quest Board](public/images/quest-board.png)
+
+---
+
 ## Key Features
 
 ### Core Functionality
-- **Gamified Learning**: Progress from F-Rank to S-Rank through real-world projects
-- **Quest System**: Complete authentic projects commissioned by real companies
-- **Two-Track Architecture**: Open quests for everyone, plus dedicated Bootcamp and Intern tracks
-- **Ranking System**: Compete with peers through XP and rank progression
-- **Payment Integration**: Earn monetary rewards for completed quests
-- **Company Portal**: Post quests and find talented developers
+- **Guild Card** — Verifiable public profile showing rank, XP, skills, and completed quest history. Share on LinkedIn. Employers can verify rank programmatically.
+- **Gamified Ranking** — Progress from F-Rank to S-Rank through real-world projects. Rank is the credential.
+- **Quest System** — Complete authentic projects commissioned by real companies. XP multipliers for streaks.
+- **Two-Track Architecture** — Open quests for everyone, plus dedicated Bootcamp and Intern tracks.
+- **Payment Integration** — Earn monetary rewards for completed quests.
+- **Company Portal** — Post quests, review applicants, and find ranked developers.
+- **Admin QA Layer** — Submissions go through `pending_admin_review` before company sees them.
 
 ### Quest Pipelines
-- **Backlog Conversion**: Open Paws backlog items converted to quests
-- **Hackathon-to-Quest**: Top hackathon prototypes become platform quests
-- **External Clients**: Companies post quests through the Company Portal
+- **External Clients** — Companies post quests through the Company Portal.
+- **Bootcamp Track** — Open Paws bootcamp students complete F/E rank quests as part of their curriculum.
+- **Intern Track** — 20 paid interns handle D+ rank quests in squads of 3–5.
 
 ### Authentication & Security
-- **Role-Based Access**: Adventurers, Companies, and Admins
-- **Secure Authentication**: NextAuth.js (credentials + JWT session strategy)
-- **Track Enforcement**: API-level access control for quest track visibility
+- **Role-Based Access** — Adventurers, Companies, and Admins with distinct permissions.
+- **Secure Authentication** — NextAuth.js (credentials + JWT session strategy, 30-day sessions).
+- **Track Enforcement** — API-level access control for quest track visibility.
+
+---
 
 ## Technology Stack
 
-- **Frontend**: Next.js 15, React, TypeScript, Tailwind CSS
-- **UI Components**: shadcn/ui with Lucide React icons
-- **Database**: Neon (PostgreSQL) with Prisma ORM
-- **Authentication**: NextAuth.js (Credentials Provider)
-- **Deployment**: Vercel
-- **Code Review**: GitHub PR-based workflow
-- **Communication**: Discord for team coordination
-- **Payment Processing**: Internal quest transaction pipeline (Stripe Connect planned)
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 15 (App Router) |
+| Language | TypeScript |
+| Database | Neon (serverless PostgreSQL) via Prisma 6 ORM |
+| Auth | NextAuth.js v4 (Credentials Provider, JWT strategy) |
+| UI | shadcn/ui + Tailwind CSS + Radix UI + Lucide React |
+| Deployment | Vercel |
+| Payments | Internal pipeline (Stripe Connect planned) |
 
-## Prerequisites
-
-- Node.js (LTS version recommended)
-- npm
-- Git
-- Neon account (for serverless PostgreSQL)
+---
 
 ## Getting Started
+
+### Prerequisites
+- Node.js LTS
+- npm
+- Git
+- A [Neon](https://neon.tech) account (free tier works)
 
 ### 1. Clone the Repository
 ```bash
@@ -63,86 +74,109 @@ npm install
 ```
 
 ### 3. Environment Configuration
-Create a `.env.local` file in the root directory:
-
+Copy the example env file:
 ```bash
-# Database
+cp .env.example .env.local
+```
+
+Fill in the required values:
+```bash
+# Database — get from Neon dashboard
 DATABASE_URL="postgresql://user:password@your-neon-host.neon.tech/neondb?sslmode=require"
 DATABASE_URL_UNPOOLED="postgresql://user:password@your-neon-host-direct.neon.tech/neondb?sslmode=require"
 
-# Authentication
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=generate-with-openssl-rand-base64-32
+# Authentication — generate with: openssl rand -base64 32
+NEXTAUTH_SECRET="your-secret-here"
+NEXTAUTH_URL="http://localhost:3000"
 
 # Application
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
 ```
 
-### 4. Run Locally
+### 4. Set Up the Database
 ```bash
+# Generate Prisma client
 npx prisma generate
+
+# Push schema to your Neon database (no migration files needed)
+npm run db:push
+```
+
+### 5. Run the Dev Server
+```bash
 npm run dev
 ```
 
-The application will be available at `http://localhost:3000`
+The application will be available at `http://localhost:3000`.
+
+---
 
 ## User Roles
 
-### Adventurers (Students/Developers)
-- Browse and accept quests matching their rank
-- Earn XP, skill points, and monetary rewards
-- Climb the ranks from F to S
-- Build portfolio with real projects
+| Role | Access | Profile |
+|------|--------|---------|
+| **Adventurer** | Quest board, apply/submit, dashboard, Guild Card | `AdventurerProfile` (skills, XP, streak, rank) |
+| **Company** | Company dashboard, post quests, review submissions | `CompanyProfile` (companyName, questsPosted) |
+| **Admin** | All routes + `/admin/**`, quest/user management, QA mediation | Full platform access |
 
-### Companies
-- Post quests for adventurers to complete
-- Access to ranked, pre-vetted talent
-- Pay for completed work
-- Review and approve submissions
+### Ranking System
+`F → E → D → C → B → A → S` — XP thresholds determine rank. Higher rank = harder quests with bigger rewards.
 
-### Admins
-- Manage users and quests
-- Moderate the platform
-- Handle disputes and escalations
-- Monitor platform health
+---
 
 ## How It Works
 
-### For Adventurers:
-1. **Join the Guild**: Create your adventurer profile
-2. **Choose Quests**: Browse available quests matching your skills and rank
-3. **Accept Quest**: Commit to completing a project
-4. **Submit Work**: Complete the quest via GitHub PR and submit for review
-5. **Get Reviewed**: Senior engineers review your code
-6. **Earn Rewards**: Receive XP, skill points, and monetary rewards
-7. **Climb Ranks**: Progress from F-Rank to S-Rank
+### For Adventurers
+1. **Join the Guild** — Create your adventurer profile
+2. **Browse Quests** — Filter by rank, track, and skills
+3. **Claim a Quest** — Commit to completing a project
+4. **Submit Work** — Complete via GitHub PR and submit for review
+5. **Get Reviewed** — QA review, then company approval
+6. **Earn Rewards** — XP, rank progression, and monetary rewards
+7. **Build Your Guild Card** — Public verifiable credential you can share
 
-### For Companies:
-1. **Register**: Create your company profile
-2. **Post Quests**: Describe the project you need completed
-3. **Review Applicants**: Select the right adventurers for your project
-4. **Review Work**: Approve completed projects
-5. **Pay Adventurers**: Reward successful quest completion
+### For Companies
+1. **Register** — Create your company profile
+2. **Post Quests** — Describe the project with clear specs
+3. **Review Applicants** — Select ranked developers
+4. **Approve Work** — Review and accept completed submissions
+5. **Pay Adventurers** — Rewards are distributed on approval
+
+---
 
 ## Contributing
 
-We welcome contributions of all skill levels! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+We welcome contributions of all skill levels! NSoC 2026 participants — this is an active program running **April 15 – May 30, 2026**.
 
-Check out our [GitHub Issues](https://github.com/LarytheLord/adventurers-guild/issues) for tasks categorized by difficulty (F-Rank through S-Rank).
+Start here:
+1. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow
+2. Check [docs/contributor-onboarding.md](docs/contributor-onboarding.md) for local setup
+3. Pick an issue from [GitHub Issues](https://github.com/LarytheLord/adventurers-guild/issues) labeled by rank (F-rank = beginner-friendly)
+
+Issues are labeled `F-rank` through `S-rank` by complexity. Good first issues are labeled `good first issue`.
+
+---
 
 ## Documentation
 
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-- [docs/contributor-onboarding.md](docs/contributor-onboarding.md) - Contributor onboarding
-- [docs/ARCHITECTURE_DECISIONS.md](docs/ARCHITECTURE_DECISIONS.md) - Architecture decisions
-- [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md) - Revenue model
+| File | Purpose |
+|------|---------|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and code standards |
+| [docs/contributor-onboarding.md](docs/contributor-onboarding.md) | Local environment setup guide |
+| [docs/ARCHITECTURE_DECISIONS.md](docs/ARCHITECTURE_DECISIONS.md) | Why things are built the way they are |
+| [docs/IMPLEMENTATION_TASKS.md](docs/IMPLEMENTATION_TASKS.md) | Current task queue with specs |
+| [CLAUDE.md](CLAUDE.md) | Full project context (for AI agents) |
+
+---
 
 ## Connect
 
-- **Discord**: [Join our Community!](https://discord.gg/7hQYkEx5)
-- **Website**: [The Adventurers Guild](https://adventurersguild.vercel.app)
-- **GitHub**: [Adventurers Guild](https://github.com/LarytheLord/adventurers-guild)
+- **Discord**: [Join our Community](https://discord.gg/7hQYkEx5)
+- **Website**: [adventurersguild.vercel.app](https://adventurersguild.vercel.app)
+- **GitHub**: [LarytheLord/adventurers-guild](https://github.com/LarytheLord/adventurers-guild)
+
+---
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## What this does
Fixes critical CONTRIBUTING.md bug (`prisma migrate dev` → `npm run db:push`) that would break setup for every NSoC contributor. Also overhauls README to meet NSoC quality standards.

## Changes
- **README.md**: Added NSoC 2026 badge, Guild Card as top feature, quest-board screenshot, structured tech stack table, corrected DB setup command
- **CONTRIBUTING.md**: Fixed `prisma migrate dev` → `npm run db:push` (Neon serverless requirement), added NSoC welcome note for contributors

## Why urgent
NSoC email flagged our project for review. The `prisma migrate dev` bug in CONTRIBUTING.md would cause every contributor's setup to fail. NSoC's review criteria explicitly checks for "complete and clear README" and "functional project."

## Test plan
- [ ] README renders correctly on GitHub (badge row, screenshot, tables)
- [ ] Setup instructions are accurate: `npm run db:push` works, `prisma migrate dev` removed
- [ ] NSoC badge links to nsoc.in

🤖 Generated with [Claude Code](https://claude.com/claude-code)