### PR TITLE
fix: platform audit — phantom route + QA approval questId

### DIFF
--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -198,7 +198,8 @@ export async function POST(request: NextRequest) {
       await updateUserXpAndSkills(
         existingSubmission.assignment.userId,
         quest.xpReward,
-        quest.skillPointsReward
+        quest.skillPointsReward,
+        existingSubmission.assignment.questId
       );
     }
     else if (status === 'needs_rework' || status === 'rejected') {

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,6 @@ const protectedRoutes: { [key: string]: UserRole[] } = {
   '/dashboard': ['adventurer', 'company', 'admin'],
   '/dashboard/quests': ['adventurer', 'company', 'admin'],
   '/dashboard/my-quests': ['adventurer'],
-  '/dashboard/completed-quests': ['adventurer'],
   '/dashboard/skill-tree': ['adventurer'],
   '/dashboard/teams': ['adventurer', 'company', 'admin'],
   '/dashboard/leaderboard': ['adventurer', 'company', 'admin'],


### PR DESCRIPTION
## What this does
Two small fixes found during a full platform audit:

1. **Middleware phantom route** — `middleware.ts` protected `/dashboard/completed-quests` but the page doesn't exist. Auth middleware was passing users through to a Next.js 404. Removed the route entry; an issue is being filed to build the actual page.

2. **QA approval missing questId** — `app/api/qa/reviews/route.ts` called `updateUserXpAndSkills()` without the `questId` parameter, so quest completion activity was never logged when QA approved a submission. The company approval path (`app/api/quests/submissions/route.ts`) already passed it correctly.

## Issue
Part of full platform audit — no single issue number.

## Changes
- `middleware.ts` — remove `/dashboard/completed-quests` from protected routes
- `app/api/qa/reviews/route.ts` — pass `existingSubmission.assignment.questId` to `updateUserXpAndSkills`

## Schema changes
None

## Test plan
- [ ] Navigate to `/dashboard/completed-quests` → should 404 (or redirect once page is built)
- [ ] Admin approves a QA submission → activity log should show quest_complete entry
- [ ] npm run type-check → 0 errors
- [ ] npm run lint → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)