### PR TITLE
refactor: Refactor quests api to service layer pattern

### DIFF
--- a/app/api/quests/route.ts
+++ b/app/api/quests/route.ts
@@ -1,11 +1,7 @@
 // app/api/quests/submissions/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
-import { AssignmentStatus } from '@prisma/client';
-import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 import { getAuthUser } from '@/lib/api-auth';
-import { logActivity } from '@/lib/activity-logger';
-import { processQuestPayment } from '@/lib/razorpay-payout';
+import { getQuests, createQuest, updateQuest } from '@/lib/services/quest-service';
 
 export async function GET(request: NextRequest) {
   // Check authentication
@@ -13,80 +9,14 @@ export async function GET(request: NextRequest) {
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
   }
+  // Parse query parameters
+  const { searchParams } = new URL(request.url);
 
-  try {
-    // Parse query parameters
-    const { searchParams } = new URL(request.url);
-    const assignmentId = searchParams.get('assignmentId');
-    const requestedUserId = searchParams.get('userId');
-    const status = searchParams.get('status');
-    const limit = searchParams.get('limit') || '10';
-    const offset = searchParams.get('offset') || '0';
-
-    const currentUserId = user.id;
-    const currentUserRole = user.role;
-
-    // Build where clause based on permissions
-    const where: Record<string, unknown> = {};
-
-    if (currentUserRole === 'adventurer') {
-      // Adventurers can only see their own submissions
-      where.userId = currentUserId;
-    } else if (currentUserRole === 'company') {
-      // Companies can see submissions for their quests
-      const companyQuests = await prisma.quest.findMany({
-        where: { companyId: currentUserId },
-        select: { id: true },
-      });
-
-      if (companyQuests.length === 0) {
-        return NextResponse.json({ submissions: [], success: true });
-      }
-
-      const questIds = companyQuests.map(q => q.id);
-      where.assignment = { questId: { in: questIds } };
-    } else if (currentUserRole === 'admin') {
-      // Admins can see all submissions - no additional filter needed
-    } else {
-      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 403 });
-    }
-
-    // Add filters if provided (respecting permissions)
-    if (assignmentId) {
-      where.assignmentId = assignmentId;
-    }
-    if (requestedUserId && currentUserRole === 'admin') {
-      where.userId = requestedUserId;
-    }
-    if (status) {
-      where.status = status;
-    }
-
-    const data = await prisma.questSubmission.findMany({
-      where,
-      include: {
-        assignment: {
-          select: {
-            questId: true,
-            status: true,
-          },
-        },
-        user: {
-          select: {
-            name: true,
-            email: true,
-          },
-        },
-      },
-      skip: parseInt(offset),
-      take: parseInt(limit),
-    });
-
-    return NextResponse.json({ submissions: data, success: true });
-  } catch (error) {
-    console.error('Error fetching quest submissions:', error);
-    return NextResponse.json({ error: 'Failed to fetch quest submissions', success: false }, { status: 500 });
+  const result = await getQuests(searchParams, user);
+  if (result.error) {
+    return NextResponse.json({ error: result.error, success: false }, { status: result.status });
   }
+  return NextResponse.json({ quests: result.data, success: true }, { status: 201 });
 }
 
 export async function POST(request: NextRequest) {
@@ -96,71 +26,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
   }
 
-  try {
-    const body = await request.json();
-    const { assignmentId, submissionContent, submissionNotes } = body;
-    const userId = user.id; // Use authenticated user's ID
+  const body = await request.json();
 
-    // Validate required fields
-    if (!assignmentId || !submissionContent) {
-      return NextResponse.json({ error: 'Missing required fields', success: false }, { status: 400 });
-    }
-
-    // Check if the assignment exists and belongs to the current user
-    const assignment = await prisma.questAssignment.findUnique({
-      where: { id: assignmentId },
-      select: { status: true, userId: true, questId: true, quest: { select: { track: true } } },
-    });
-
-    if (!assignment) {
-      return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
-    }
-
-    // Only the assigned user can submit
-    if (assignment.userId !== userId && user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized to submit for this assignment', success: false }, { status: 403 });
-    }
-
-    if (!['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status)) {
-      return NextResponse.json({ error: 'Invalid assignment state for submission', success: false }, { status: 400 });
-    }
-
-    // BOOTCAMP and INTERN quests go to pending_admin_review (Open Paws QA gate)
-    // OPEN track goes directly to submitted (client sees immediately)
-    const postSubmitStatus =
-      assignment.quest.track !== 'OPEN' ? 'pending_admin_review' : 'submitted';
-
-    const data = await prisma.$transaction(
-      async (tx) => {
-        const submission = await tx.questSubmission.create({
-          data: {
-            assignmentId: assignmentId,
-            userId,
-            submissionContent: submissionContent,
-            submissionNotes: submissionNotes || null,
-          },
-        });
-
-        await tx.questAssignment.update({
-          where: { id: assignmentId },
-          data: { status: postSubmitStatus },
-        });
-
-        await syncQuestLifecycleStatus(tx, assignment.questId);
-        
-        // Log activity
-        await logActivity(userId, 'quest_submit', { questId: assignment.questId }, tx);
-        
-        return submission;
-      },
-      { maxWait: 10_000, timeout: 20_000 }
-    );
-
-    return NextResponse.json({ submission: data, success: true }, { status: 201 });
-  } catch (error) {
-    console.error('Error creating quest submission:', error);
-    return NextResponse.json({ error: 'Failed to create quest submission', success: false }, { status: 500 });
+  const result = await createQuest(body, user);
+  if (result.error) {
+    return NextResponse.json({ error: result.error, success: false }, { status: result.status });
   }
+  return NextResponse.json({ quest: result.data, success: true }, { status: 201 });
 }
 
 export async function PUT(request: NextRequest) {
@@ -170,199 +42,11 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
   }
 
-  try {
-    const body = await request.json();
-    const { submissionId, status, review_notes, quality_score } = body;
-    const reviewerId = user.id; // Use authenticated user's ID
+  const body = await request.json();
 
-    // Validate required fields
-    if (!submissionId || !status) {
-      return NextResponse.json({ error: 'Missing required fields', success: false }, { status: 400 });
-    }
-
-    // Check if the user has permission to update this submission
-    // Only admins, or company users for their own quests can review submissions
-    // First get the submission
-    const submission = await prisma.questSubmission.findUnique({
-      where: { id: submissionId },
-      select: { id: true, assignmentId: true, status: true },
-    });
-
-    if (!submission) {
-      return NextResponse.json({ error: 'Submission not found', success: false }, { status: 404 });
-    }
-
-    // Then get the assignment to check quest details
-    const assignmentData = await prisma.questAssignment.findUnique({
-      where: { id: submission.assignmentId },
-      select: {
-        questId: true,
-        userId: true,
-        quest: {
-          select: {
-            companyId: true,
-            title: true,
-          },
-        },
-      },
-    });
-
-    if (!assignmentData) {
-      return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
-    }
-
-    // Check permissions
-    if (user.role !== 'admin' &&
-        (user.role !== 'company' || !assignmentData.quest || assignmentData.quest.companyId !== user.id)) {
-      return NextResponse.json({ error: 'Unauthorized to review this submission', success: false }, { status: 403 });
-    }
-
-    const wasAlreadyApproved = submission.status === 'approved';
-
-    const reviewResult = await prisma.$transaction(
-      async (tx) => {
-        const updatedSubmission = await tx.questSubmission.update({
-          where: { id: submissionId },
-          data: {
-            status,
-            reviewNotes: review_notes || undefined,
-            qualityScore: quality_score || undefined,
-            reviewerId,
-            reviewedAt: status !== 'pending' ? new Date() : undefined,
-          },
-        });
-
-        let newAssignmentStatus: AssignmentStatus | null = null;
-        if (status === 'approved') {
-          newAssignmentStatus = 'completed';
-        } else if (status === 'needs_rework' || status === 'rejected') {
-          newAssignmentStatus = 'in_progress';
-        }
-
-        if (newAssignmentStatus) {
-          await tx.questAssignment.update({
-            where: { id: submission.assignmentId },
-            data: {
-              status: newAssignmentStatus,
-              ...(newAssignmentStatus === 'completed' ? { completedAt: new Date() } : {}),
-            },
-          });
-        }
-
-        await syncQuestLifecycleStatus(tx, assignmentData.questId);
-
-        let rewardsPayload: { userId: string; xpReward: number; skillPointsReward: number; questTitle: string } | null = null;
-        let paymentInfo: { questId: string; userId: string; track: string; monetaryReward: number } | null = null;
-
-        if (status === 'approved' && !wasAlreadyApproved) {
-          const quest = await tx.quest.findUnique({
-            where: { id: assignmentData.questId },
-            select: { 
-              xpReward: true, 
-              skillPointsReward: true,
-              track: true,
-              monetaryReward: true,
-            },
-          });
-
-          if (!quest) throw new Error('Quest not found for completion recording');
-
-          await tx.questCompletion.upsert({
-            where: {
-              questId_userId: {
-                questId: assignmentData.questId,
-                userId: assignmentData.userId,
-              },
-            },
-            create: {
-              questId: assignmentData.questId,
-              userId: assignmentData.userId,
-              xpEarned: quest.xpReward,
-              skillPointsEarned: quest.skillPointsReward,
-              qualityScore: quality_score || null,
-            },
-            update: {
-              xpEarned: quest.xpReward,
-              skillPointsEarned: quest.skillPointsReward,
-              qualityScore: quality_score || null,
-            },
-          });
-
-          rewardsPayload = {
-            userId: assignmentData.userId,
-            xpReward: quest.xpReward,
-            skillPointsReward: quest.skillPointsReward,
-            questTitle: assignmentData.quest?.title ?? '',
-          };
-
-          // Prepare payment info for after transaction (only if monetary reward exists)
-          if (quest.monetaryReward && quest.track !== 'BOOTCAMP') {
-            paymentInfo = {
-              questId: assignmentData.questId,
-              userId: assignmentData.userId,
-              track: quest.track,
-              monetaryReward: Number(quest.monetaryReward),
-            };
-          }
-        }
-
-        return { submission: updatedSubmission, rewardsPayload, paymentInfo };
-      },
-      { maxWait: 10_000, timeout: 20_000 }
-    );
-
-    // Process XP and skill points (existing logic)
-    if (reviewResult.rewardsPayload) {
-      const { updateUserXpAndSkills } = await import('@/lib/xp-utils');
-      await updateUserXpAndSkills(
-        reviewResult.rewardsPayload.userId,
-        reviewResult.rewardsPayload.xpReward,
-        reviewResult.rewardsPayload.skillPointsReward,
-        assignmentData.questId
-      );
-
-      // Task 1.4: Tutorial quest completion tracking for bootcamp students
-      const { questTitle, userId: rewardUserId } = reviewResult.rewardsPayload;
-      if (questTitle.startsWith('Tutorial:')) {
-        const bootcampLink = await prisma.bootcampLink.findUnique({
-          where: { userId: rewardUserId },
-          select: { tutorialQuest1Complete: true, tutorialQuest2Complete: true },
-        });
-        if (bootcampLink) {
-          const updateData: { tutorialQuest1Complete?: boolean; tutorialQuest2Complete?: boolean; eligibleForRealQuests?: boolean } = {};
-          if (questTitle.startsWith('Tutorial: First Blood')) updateData.tutorialQuest1Complete = true;
-          if (questTitle.startsWith('Tutorial: Party Up')) updateData.tutorialQuest2Complete = true;
-          const tq1 = updateData.tutorialQuest1Complete ?? bootcampLink.tutorialQuest1Complete;
-          const tq2 = updateData.tutorialQuest2Complete ?? bootcampLink.tutorialQuest2Complete;
-          if (tq1 && tq2) updateData.eligibleForRealQuests = true;
-          if (Object.keys(updateData).length > 0) {
-            await prisma.bootcampLink.update({ where: { userId: rewardUserId }, data: updateData });
-          }
-        }
-      }
-    }
-
-    // Process payment (Razorpay or simulated)
-    if (reviewResult.paymentInfo && 
-        reviewResult.paymentInfo.track !== 'BOOTCAMP' && 
-        reviewResult.paymentInfo.monetaryReward > 0) {
-      const paymentResult = await processQuestPayment(
-        reviewResult.paymentInfo.questId,
-        reviewResult.paymentInfo.userId,
-        reviewResult.paymentInfo.monetaryReward,
-        'INR'
-      );
-      if (!paymentResult.success) {
-        console.error('Payment failed for quest', reviewResult.paymentInfo.questId, paymentResult.error);
-        // Optionally create a notification for admin
-      } else {
-        console.log('Payment successful', paymentResult);
-      }
-    }
-
-    return NextResponse.json({ submission: reviewResult.submission, success: true });
-  } catch (error) {
-    console.error('Error updating quest submission:', error);
-    return NextResponse.json({ error: 'Failed to update quest submission', success: false }, { status: 500 });
+  const result = await updateQuest(body, user);
+  if (result.error) {
+    return NextResponse.json({ error: result.error, success: false }, { status: result.status });
   }
+  return NextResponse.json({ submission: result.data, success: true }, { status: 201 });
 }

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -1,0 +1,369 @@
+import { ServiceResult, updateQuestBody, CreateQuestBody } from "./types";
+import { SessionUser } from "../api-auth";
+import { prisma } from "@/lib/db";
+import { Prisma, QuestStatus, QuestTrack, QuestCategory, Quest, UserRank, QuestSubmission } from '@prisma/client';
+import { processQuestPayment } from "../razorpay-payout";
+import { AssignmentStatus } from "@prisma/client";
+import { syncQuestLifecycleStatus } from "../quest-lifecycle";
+
+
+async function getQuests(searchParams: URLSearchParams, user: SessionUser | null): Promise<ServiceResult<Quest[]>> {
+  // Parse query parameters
+  const status = searchParams.get('status');
+  const category = searchParams.get('category');
+  const difficulty = searchParams.get('difficulty');
+  const track = searchParams.get('track');
+  const companyId = searchParams.get('company_id');
+  const limit = parseInt(searchParams.get('limit') || '10');
+  const offset = parseInt(searchParams.get('offset') || '0');
+  const sort = searchParams.get('sort') || 'createdAt_desc';
+  const search = searchParams.get('search');
+
+  // Check if user is a bootcamp student (has BootcampLink)
+  let bootcampLink: { eligibleForRealQuests: boolean } | null = null;
+  if (user && user.role === 'adventurer') {
+    bootcampLink = await prisma.bootcampLink.findUnique({
+      where: { userId: user.id },
+      select: { eligibleForRealQuests: true },
+    });
+  }
+
+  // Build where clause based on permissions
+  const where: Prisma.QuestWhereInput = {};
+
+  if (user) {
+    if (user.role === 'company') {
+      // Companies can see their own quests regardless of status
+      where.OR = [
+        { companyId: user.id },
+        { status: 'available' },
+      ];
+    } else if (user.role === 'admin') {
+      // Admins can see all quests - no additional filter needed
+    } else if (bootcampLink) {
+      // Bootcamp students: ONLY see BOOTCAMP track quests (API-enforced)
+      where.track = 'BOOTCAMP';
+      if (!bootcampLink.eligibleForRealQuests) {
+        // Ineligible bootcamp students: only see TUTORIAL source quests
+        where.source = 'TUTORIAL';
+      }
+      where.OR = [
+        { status: 'available' },
+        { assignments: { some: { userId: user.id } } },
+      ];
+    } else {
+      // Regular adventurers: see OPEN quests + their assigned quests
+      where.OR = [
+        { status: 'available', track: 'OPEN' },
+        { assignments: { some: { userId: user.id } } },
+      ];
+    }
+  } else {
+    // Unauthenticated users: only see OPEN track available quests
+    where.status = 'available';
+    where.track = 'OPEN';
+  }
+
+  // Add filters if provided (track filter overridden for bootcamp users above)
+  if (status && (!user || user.role !== 'company')) {
+    where.status = status as QuestStatus;
+  }
+
+  if (search) {
+    where.OR = [
+      ...(Array.isArray(where.OR) ? where.OR : []),
+      { title: { contains: search, mode: 'insensitive' } },
+      { description: { contains: search, mode: 'insensitive' } },
+    ];
+  }
+
+  if (category) {
+    where.questCategory = category as QuestCategory;
+  }
+  if (difficulty) {
+    where.difficulty = difficulty as UserRank;
+  }
+  // Only allow track filter override for admin/company — bootcamp students are locked
+  if (track && Object.values(QuestTrack).includes(track as QuestTrack) && !bootcampLink) {
+    where.track = track as QuestTrack;
+  }
+  if (companyId && user && (user.role === 'admin' || user.id === companyId)) {
+    where.companyId = companyId;
+  }
+
+  const orderBy: Prisma.QuestOrderByWithRelationInput =
+    sort === 'xp_desc'
+      ? { xpReward: 'desc' }
+      : sort === 'pay_desc'
+        ? { monetaryReward: 'desc' }
+        : sort === 'deadline_asc'
+          ? { deadline: { sort: 'asc', nulls: 'last' } }
+          : { createdAt: 'desc' };
+
+  const quests = await prisma.quest.findMany({
+    where,
+    include: {
+      company: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+    },
+    orderBy,
+    skip: offset,
+    take: limit,
+  });
+
+  return { data: quests, error: null, status: 200 };
+}
+
+async function createQuest(body: CreateQuestBody, user: SessionUser): Promise<ServiceResult<Quest>> {
+  const {
+    title,
+    description,
+    detailedDescription,
+    questType,
+    difficulty,
+    xpReward,
+    skillPointsReward,
+    monetaryReward,
+    requiredSkills,
+    requiredRank,
+    maxParticipants,
+    questCategory,
+    track,
+    source,
+    parentQuestId,
+    deadline,
+  } = body;
+
+  // Validate required fields
+  if (!title || !description || !questType || !difficulty || !xpReward) {
+    return { error: 'Missing required fields', data: null, status: 400 };
+  }
+
+  // Create the quest with the authenticated user as the company
+  const quest = await prisma.quest.create({
+    data: {
+      title,
+      description,
+      detailedDescription: detailedDescription,
+      questType: questType,
+      difficulty,
+      xpReward: xpReward,
+      skillPointsReward: skillPointsReward,
+      monetaryReward: monetaryReward,
+      requiredSkills: requiredSkills || [],
+      requiredRank: requiredRank,
+      maxParticipants: maxParticipants,
+      questCategory: questCategory,
+      track: track || undefined,
+      source: source || undefined,
+      parentQuestId: parentQuestId || null,
+      companyId: user.id,
+      deadline: deadline ? new Date(deadline) : null,
+    },
+  });
+
+  return { error: null, data: quest, status: 201 };
+}
+
+export async function updateQuest(body: updateQuestBody, user: SessionUser): Promise<ServiceResult<QuestSubmission>> {
+    const { submissionId, status, review_notes, quality_score } = body;
+    const reviewerId = user.id; // Use authenticated user's ID
+
+    // Validate required fields
+    if (!submissionId || !status) {
+      return { data: null, error: 'Missing required fields', status: 400 };
+    }
+
+    // Check if the user has permission to update this submission
+    // Only admins, or company users for their own quests can review submissions
+    // First get the submission
+    const submission = await prisma.questSubmission.findUnique({
+      where: { id: submissionId },
+      select: { id: true, assignmentId: true, status: true },
+    });
+
+    if (!submission) {
+      return { error: 'Submission not found', data: null, status: 404 };
+    }
+
+    // Then get the assignment to check quest details
+    const assignmentData = await prisma.questAssignment.findUnique({
+      where: { id: submission.assignmentId },
+      select: {
+        questId: true,
+        userId: true,
+        quest: {
+          select: {
+            companyId: true,
+            title: true,
+          },
+        },
+      },
+    });
+
+    if (!assignmentData) {
+      return { error: 'Assignment not found', data: null, status: 404 };
+    }
+
+    // Check permissions
+    if (user.role !== 'admin' &&
+      (user.role !== 'company' || !assignmentData.quest || assignmentData.quest.companyId !== user.id)) {
+      return { error: 'Unauthorized to review this submission', data: null, status: 403 };
+    }
+
+    const wasAlreadyApproved = submission.status === 'approved';
+
+    const reviewResult = await prisma.$transaction(
+      async (tx) => {
+        const updatedSubmission = await tx.questSubmission.update({
+          where: { id: submissionId },
+          data: {
+            status,
+            reviewNotes: review_notes || undefined,
+            qualityScore: quality_score || undefined,
+            reviewerId,
+            reviewedAt: status !== 'pending' ? new Date() : undefined,
+          },
+        });
+
+        let newAssignmentStatus: AssignmentStatus | null = null;
+        if (status === 'approved') {
+          newAssignmentStatus = 'completed';
+        } else if (status === 'needs_rework' || status === 'rejected') {
+          newAssignmentStatus = 'in_progress';
+        }
+
+        if (newAssignmentStatus) {
+          await tx.questAssignment.update({
+            where: { id: submission.assignmentId },
+            data: {
+              status: newAssignmentStatus,
+              ...(newAssignmentStatus === 'completed' ? { completedAt: new Date() } : {}),
+            },
+          });
+        }
+
+        await syncQuestLifecycleStatus(tx, assignmentData.questId);
+
+        let rewardsPayload: { userId: string; xpReward: number; skillPointsReward: number; questTitle: string } | null = null;
+        let paymentInfo: { questId: string; userId: string; track: string; monetaryReward: number } | null = null;
+
+        if (status === 'approved' && !wasAlreadyApproved) {
+          const quest = await tx.quest.findUnique({
+            where: { id: assignmentData.questId },
+            select: {
+              xpReward: true,
+              skillPointsReward: true,
+              track: true,
+              monetaryReward: true,
+            },
+          });
+
+          if (!quest) throw new Error('Quest not found for completion recording');
+
+          await tx.questCompletion.upsert({
+            where: {
+              questId_userId: {
+                questId: assignmentData.questId,
+                userId: assignmentData.userId,
+              },
+            },
+            create: {
+              questId: assignmentData.questId,
+              userId: assignmentData.userId,
+              xpEarned: quest.xpReward,
+              skillPointsEarned: quest.skillPointsReward,
+              qualityScore: quality_score || null,
+            },
+            update: {
+              xpEarned: quest.xpReward,
+              skillPointsEarned: quest.skillPointsReward,
+              qualityScore: quality_score || null,
+            },
+          });
+
+          rewardsPayload = {
+            userId: assignmentData.userId,
+            xpReward: quest.xpReward,
+            skillPointsReward: quest.skillPointsReward,
+            questTitle: assignmentData.quest?.title ?? '',
+          };
+
+          // Prepare payment info for after transaction (only if monetary reward exists)
+          if (quest.monetaryReward && quest.track !== 'BOOTCAMP') {
+            paymentInfo = {
+              questId: assignmentData.questId,
+              userId: assignmentData.userId,
+              track: quest.track,
+              monetaryReward: Number(quest.monetaryReward),
+            };
+          }
+        }
+
+        return { submission: updatedSubmission, rewardsPayload, paymentInfo };
+      },
+      { maxWait: 10_000, timeout: 20_000 }
+    );
+
+    // Process XP and skill points (existing logic)
+    if (reviewResult.rewardsPayload) {
+      const { updateUserXpAndSkills } = await import('@/lib/xp-utils');
+      await updateUserXpAndSkills(
+        reviewResult.rewardsPayload.userId,
+        reviewResult.rewardsPayload.xpReward,
+        reviewResult.rewardsPayload.skillPointsReward,
+        assignmentData.questId
+      );
+
+      // Task 1.4: Tutorial quest completion tracking for bootcamp students
+      const { questTitle, userId: rewardUserId } = reviewResult.rewardsPayload;
+      if (questTitle.startsWith('Tutorial:')) {
+        const bootcampLink = await prisma.bootcampLink.findUnique({
+          where: { userId: rewardUserId },
+          select: { tutorialQuest1Complete: true, tutorialQuest2Complete: true },
+        });
+        if (bootcampLink) {
+          const updateData: { tutorialQuest1Complete?: boolean; tutorialQuest2Complete?: boolean; eligibleForRealQuests?: boolean } = {};
+          if (questTitle.startsWith('Tutorial: First Blood')) updateData.tutorialQuest1Complete = true;
+          if (questTitle.startsWith('Tutorial: Party Up')) updateData.tutorialQuest2Complete = true;
+          const tq1 = updateData.tutorialQuest1Complete ?? bootcampLink.tutorialQuest1Complete;
+          const tq2 = updateData.tutorialQuest2Complete ?? bootcampLink.tutorialQuest2Complete;
+          if (tq1 && tq2) updateData.eligibleForRealQuests = true;
+          if (Object.keys(updateData).length > 0) {
+            await prisma.bootcampLink.update({ where: { userId: rewardUserId }, data: updateData });
+          }
+        }
+      }
+    }
+
+    // Process payment (Razorpay or simulated)
+    if (reviewResult.paymentInfo &&
+      reviewResult.paymentInfo.track !== 'BOOTCAMP' &&
+      reviewResult.paymentInfo.monetaryReward > 0) {
+      const paymentResult = await processQuestPayment(
+        reviewResult.paymentInfo.questId,
+        reviewResult.paymentInfo.userId,
+        reviewResult.paymentInfo.monetaryReward,
+        'INR'
+      );
+      if (!paymentResult.success) {
+        console.error('Payment failed for quest', reviewResult.paymentInfo.questId, paymentResult.error);
+        // Optionally create a notification for admin
+      } else {
+        console.log('Payment successful', paymentResult);
+      }
+    }
+
+    return { data: reviewResult.submission, error: null, status: 200 };
+}
+
+
+export {
+  getQuests,
+  createQuest,
+  // updateQuest
+}

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -16,7 +16,7 @@ async function getQuests(searchParams: URLSearchParams, user: SessionUser | null
   const companyId = searchParams.get('company_id');
   const limit = parseInt(searchParams.get('limit') || '10');
   const offset = parseInt(searchParams.get('offset') || '0');
-  const sort = searchParams.get('sort') || 'createdAt_desc';
+  const sort = searchParams.get('sort') || 'newest';
   const search = searchParams.get('search');
 
   // Check if user is a bootcamp student (has BootcampLink)

--- a/lib/services/types.ts
+++ b/lib/services/types.ts
@@ -1,4 +1,4 @@
-import { AssignmentStatus } from "@prisma/client";
+import { AssignmentStatus, QuestCategory, QuestSource, QuestTrack, QuestType, UserRank, SubmissionStatus  } from "@prisma/client";
 
 export type ServiceResult<T> = {
   data: T | null;
@@ -10,4 +10,30 @@ export type UpdateAssignmentBody = {
   assignmentId: string;
   status: AssignmentStatus;
   progress?: number;
+};
+
+export type CreateQuestBody = {
+  title: string;
+  description: string;
+  detailedDescription: string;
+  questType: QuestType;
+  difficulty: UserRank;
+  xpReward: number;
+  skillPointsReward: number;
+  monetaryReward: number;
+  requiredSkills: string[];
+  requiredRank: UserRank;
+  maxParticipants: number;
+  questCategory: QuestCategory;
+  track: QuestTrack;
+  source: QuestSource;
+  parentQuestId: string;
+  deadline: string;
+};
+
+export type updateQuestBody = {
+  submissionId: string;
+  status: SubmissionStatus;
+  review_notes: string;
+  quality_score: number;
 };


### PR DESCRIPTION
## "Stage 2 of 3: quest-service" (Stage 1 was assignment-service from PR https://github.com/LarytheLord/Adventurers-Guild/pull/159, Stage 3 will be submission-service).
added as a type
```
export type CreateQuestBody = {
  title: string;
  description: string;
  detailedDescription: string;
  questType: QuestType;
  difficulty: UserRank;
  xpReward: number;
  skillPointsReward: number;
  monetaryReward: number;
  requiredSkills: string[];
  requiredRank: UserRank;
  maxParticipants: number;
  questCategory: QuestCategory;
  track: QuestTrack;
  source: QuestSource;
  parentQuestId: string;
  deadline: string;
};
```

## Acceptance Criteria Checklist
- [x] API routes are thin wrappers calling services
- [x] All existing tests still pass


## Peer Review Checklist (for reviewer)
- [ ] All acceptance criteria met
- [ ] Follows existing code patterns
- [ ] No obvious bugs or edge cases
