### PR TITLE
chore: add MAINTAINERS.md and CODEOWNERS — Adil joins as co-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS — automatically request review from maintainers on PRs
+# Both maintainers can review/approve any part of the codebase.
+
+# Default: both maintainers
+*                              @LarytheLord @Adil2009700
+
+# Frontend / landing / dashboard UX (Adil's area of focus)
+/app/home/                     @Adil2009700 @LarytheLord
+/app/dashboard/                @Adil2009700 @LarytheLord
+/components/landing/           @Adil2009700 @LarytheLord
+/components/ui/                @Adil2009700 @LarytheLord
+
+# Architecture / infra / data / payments / auth (Abi's area of focus)
+/lib/                          @LarytheLord @Adil2009700
+/prisma/                       @LarytheLord
+/middleware.ts                 @LarytheLord
+/app/api/                      @LarytheLord @Adil2009700
+/.github/workflows/            @LarytheLord

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,49 @@
+# Maintainers
+
+This document lists the people responsible for the Adventurers Guild project. Maintainers have merge authority, set direction, and are accountable for the project's technical health.
+
+## Current Maintainers
+
+| Name | GitHub | Focus |
+|------|--------|-------|
+| Abi | [@LarytheLord](https://github.com/LarytheLord) | Architecture, infrastructure, payments, bootcamp pipeline, partnerships |
+| Adil | [@Adil2009700](https://github.com/Adil2009700) | Frontend, dashboard UX, landing page, contributor coordination, day-to-day PR triage |
+
+Both maintainers have full merge and review authority on every part of the codebase. Either can approve and merge PRs without waiting on the other.
+
+## What Maintainers Do
+
+- Review and merge pull requests
+- Triage issues and assign owners
+- Set technical direction and resolve architectural disagreements
+- Coordinate with contributors (NSoC 2026 cohort, external collaborators)
+- Keep the documentation map in sync with reality
+- Decide when to cut releases and what goes into them
+
+## What Maintainers Escalate to Each Other
+
+A maintainer should consult the other before:
+
+- Reverting another maintainer's merge
+- Adding or removing a contributor's repo permissions
+- Changing the project's strategic direction (e.g. payment provider, target market, monetization model)
+- Major schema migrations affecting more than one feature area
+- Decisions that would conflict with documented [Architecture Decisions](docs/ARCHITECTURE_DECISIONS.md)
+
+## How Decisions Are Made
+
+For day-to-day technical decisions: the maintainer touching the code decides.
+
+For decisions affecting both maintainers' areas: brief written discussion in the relevant GitHub issue or PR comments. Default to async over meetings.
+
+For strategic decisions: the [Architecture Decisions](docs/ARCHITECTURE_DECISIONS.md) doc is authoritative. New ADRs require both maintainers to agree before being added.
+
+## Becoming a Maintainer
+
+We add maintainers when the project's pace requires it, not on a schedule. Strong signals: sustained merged contributions, demonstrated judgment in code review, ability to coordinate with other contributors, alignment with the project's direction.
+
+## Contact
+
+- Open a GitHub issue for anything project-related
+- Tag both maintainers (`@LarytheLord` `@Adil2009700`) on items that need shared input
+- For sensitive matters: reach maintainers directly via email or Discord


### PR DESCRIPTION
## What

- Adds `MAINTAINERS.md` formalizing the maintainer team
- Adds `.github/CODEOWNERS` to route review requests automatically

## Why

@Adil2009700 is joining @LarytheLord as a co-maintainer. With NSoC 2026 ramping up (~1500 contributors over Apr 15–May 30), a steady stream of feature PRs, and the bootcamp launch in May, the project needs two people with merge authority and decision power so PRs don't pile up waiting on a single bottleneck.

Adil has consistently shipped quality work on the frontend (PRs #120, #121, #131, #153, #156, #158 all merged) and has the strongest mental model of the landing/dashboard UX side of the codebase. Making this official so they can review and merge directly without ceremony.

## How

Both maintainers have full authority across the whole codebase. CODEOWNERS routes review requests by file area as a default, but either can review and merge anything.

## Test plan

- [x] MAINTAINERS.md renders cleanly on GitHub
- [x] CODEOWNERS syntax valid (no parse errors in PR review tab)
- [ ] After merge: grant @Adil2009700 `maintain` permission via Settings → Collaborators (currently has `push` + `triage`)
- [ ] After merge: pin the announcement issue

## Notes

This is announcement-companion infra. The actual welcome / context dump for Adil is in a separate issue (link will be added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)