### PR TITLE
feat: create public quest pages with stats, polish, and edge cases (#…

### DIFF
--- a/app/api/public/quests/[id]/route.ts
+++ b/app/api/public/quests/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/db';
+
+export async function GET(
+  _req: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  const { id } = await props.params;
+
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(id)) {
+    return Response.json({ error: 'Quest not found' }, { status: 404 });
+  }
+
+  try {
+    const quest = await prisma.quest.findUnique({
+      where: { id },
+      include: {
+        company: {
+          include: { companyProfile: true },
+        },
+        _count: {
+          select: { assignments: true },
+        },
+      },
+    });
+
+    if (!quest) {
+      return Response.json({ error: 'Quest not found' }, { status: 404 });
+    }
+
+    return Response.json({
+      quest: {
+        id: quest.id,
+        title: quest.title,
+        description: quest.description,
+        detailedDescription: quest.detailedDescription,
+        questType: quest.questType,
+        difficulty: quest.difficulty,
+        xpReward: quest.xpReward,
+        skillPointsReward: quest.skillPointsReward,
+        monetaryReward: quest.monetaryReward ? Number(quest.monetaryReward) : null,
+        requiredSkills: quest.requiredSkills,
+        requiredRank: quest.requiredRank,
+        maxParticipants: quest.maxParticipants,
+        questCategory: quest.questCategory,
+        track: quest.track,
+        status: quest.status,
+        deadline: quest.deadline?.toISOString() ?? null,
+        company: quest.company?.companyProfile?.companyName ?? quest.company?.name ?? 'Unknown Company',
+        companyId: quest.companyId,
+        applicants: quest._count.assignments,
+      },
+    });
+  } catch {
+    return Response.json({ error: 'Failed to fetch quest' }, { status: 500 });
+  }
+}

--- a/app/api/public/quests/route.ts
+++ b/app/api/public/quests/route.ts
@@ -1,13 +1,17 @@
+import { NextRequest } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
 import { QuestStatus } from '@prisma/client';
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
+    const url = new URL(req.url);
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') || '3', 10) || 3, 1), 60);
+
     const quests = await withDbRetry(() =>
       prisma.quest.findMany({
         where: { status: QuestStatus.available, track: 'OPEN' },
         orderBy: { createdAt: 'desc' },
-        take: 3,
+        take: limit,
         include: {
           company: {
             include: { companyProfile: true },

--- a/app/quests/[id]/page.tsx
+++ b/app/quests/[id]/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Zap, DollarSign, Clock, Users, Target, ChevronRight, AlertCircle, CalendarX } from 'lucide-react';
+import { RankBadge } from '@/components/ui/rank-badge';
+import type { Rank } from '@/components/ui/rank-badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type QuestDetail = {
+  id: string;
+  title: string;
+  description: string;
+  detailedDescription: string | null;
+  questType: string;
+  difficulty: Rank;
+  xpReward: number;
+  skillPointsReward: number;
+  monetaryReward: number | null;
+  requiredSkills: string[];
+  requiredRank: Rank | null;
+  maxParticipants: number | null;
+  questCategory: string;
+  track: string;
+  status: string;
+  deadline: string | null;
+  company: string;
+  companyId: string | null;
+  applicants: number;
+};
+
+export default function PublicQuestDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [quest, setQuest] = useState<QuestDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchQuest = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/public/quests/${id}`);
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        if (!res.ok) {
+          setFetchError(true);
+          return;
+        }
+        const data = await res.json();
+        setQuest(data.quest);
+      } catch {
+        setFetchError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void fetchQuest();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-slate-950">
+        <div className="container mx-auto max-w-4xl px-6 py-10">
+          <Skeleton className="mb-8 h-4 w-48" />
+          <Skeleton className="mb-4 h-10 w-3/4" />
+          <Skeleton className="mb-6 h-4 w-1/3" />
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Skeleton className="h-48" />
+            <Skeleton className="h-48" />
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="min-h-screen bg-slate-950">
+        <div className="container mx-auto max-w-4xl px-6 py-20 text-center">
+          <AlertCircle className="mx-auto h-12 w-12 text-slate-600" />
+          <h1 className="mt-4 text-2xl font-bold text-white">Quest not found</h1>
+          <p className="mt-2 text-sm text-slate-400">
+            This quest doesn&apos;t exist or has been removed.
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Button asChild variant="outline" className="border-slate-700 text-slate-400 hover:bg-slate-800 bg-transparent">
+              <Link href="/quests">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Browse Quests
+              </Link>
+            </Button>
+            <Button asChild className="bg-orange-500 hover:bg-orange-600 text-white">
+              <Link href="/">Back to Home</Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (fetchError || !quest) {
+    return (
+      <main className="min-h-screen bg-slate-950">
+        <div className="container mx-auto max-w-4xl px-6 py-20 text-center">
+          <p className="text-slate-400">Something went wrong. Please try again.</p>
+          <Button asChild variant="outline" className="mt-4 border-slate-700 text-slate-400 hover:bg-slate-800 bg-transparent">
+            <Link href="/quests">Back to Quest Board</Link>
+          </Button>
+        </div>
+      </main>
+    );
+  }
+
+  const isExpired = quest.status !== 'available';
+  const reward = quest.monetaryReward != null ? `$${quest.monetaryReward.toLocaleString()}` : null;
+
+  return (
+    <main className="min-h-screen bg-slate-950">
+      {/* Breadcrumb */}
+      <div className="border-b border-slate-800 bg-slate-900/50">
+        <div className="container mx-auto max-w-4xl px-6 py-3">
+          <nav className="flex items-center gap-2 text-xs text-slate-500">
+            <Link href="/" className="hover:text-slate-300 transition-colors">Home</Link>
+            <ChevronRight className="h-3 w-3" />
+            <Link href="/quests" className="hover:text-slate-300 transition-colors">Quests</Link>
+            <ChevronRight className="h-3 w-3" />
+            <span className="text-slate-400 truncate max-w-[200px]">{quest.title}</span>
+          </nav>
+        </div>
+      </div>
+
+      <div className="container mx-auto max-w-4xl px-6 py-10">
+        {isExpired && (
+          <div className="mb-6 flex items-center gap-3 rounded-xl border border-amber-800/50 bg-amber-950/30 p-4">
+            <CalendarX className="h-5 w-5 text-amber-400 shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-amber-300">This quest is no longer available</p>
+              <p className="text-xs text-amber-400/70">
+                This quest has been {quest.status === 'completed' ? 'completed' : 'closed'}.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          {/* Main content */}
+          <div className="lg:col-span-2 space-y-6">
+            <div>
+              <div className="flex items-center gap-3 mb-3">
+                <RankBadge rank={quest.difficulty} size="md" />
+                <span className="text-xs font-medium uppercase tracking-wider text-slate-500">{quest.questCategory}</span>
+              </div>
+              <h1 className="text-2xl font-bold text-white md:text-3xl">{quest.title}</h1>
+              <p className="mt-2 text-sm text-slate-400">
+                Posted by{' '}
+                {quest.companyId ? (
+                  <a href="#" className="text-orange-400 hover:text-orange-300 transition-colors">
+                    {quest.company}
+                  </a>
+                ) : (
+                  <span>{quest.company}</span>
+                )}
+              </p>
+            </div>
+
+            <p className="text-sm leading-relaxed text-slate-300">
+              {quest.detailedDescription || quest.description}
+            </p>
+
+            {quest.requiredSkills.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">Required Skills</p>
+                <div className="flex flex-wrap gap-2">
+                  {quest.requiredSkills.map((skill) => (
+                    <span
+                      key={skill}
+                      className="rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs font-medium text-slate-300"
+                    >
+                      {skill}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {quest.requiredRank && (
+              <div className="flex items-center gap-2 text-sm text-slate-400">
+                <Target className="h-4 w-4 text-slate-500" />
+                Minimum rank: <RankBadge rank={quest.requiredRank} size="sm" />
+              </div>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-4">
+            <div className="rounded-xl border border-slate-800 bg-slate-900 p-5">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-4">Details</h3>
+              <div className="space-y-3">
+                <DetailRow icon={<Zap className="h-4 w-4 text-orange-400" />} label="XP" value={`${quest.xpReward.toLocaleString()} XP`} />
+                <DetailRow icon={<Zap className="h-4 w-4 text-violet-400" />} label="SP" value={`${quest.skillPointsReward.toLocaleString()} SP`} />
+                {reward ? (
+                  <DetailRow icon={<DollarSign className="h-4 w-4 text-emerald-400" />} label="Reward" value={reward} />
+                ) : (
+                  <DetailRow icon={<DollarSign className="h-4 w-4 text-slate-600" />} label="Reward" value="XP Only" />
+                )}
+                <DetailRow icon={<Clock className="h-4 w-4 text-slate-500" />} label="Deadline" value={quest.deadline ? new Date(quest.deadline).toLocaleDateString() : 'None'} />
+                <DetailRow icon={<Users className="h-4 w-4 text-slate-500" />} label="Applicants" value={quest.applicants.toString()} />
+                {quest.maxParticipants && (
+                  <DetailRow icon={<Users className="h-4 w-4 text-slate-500" />} label="Max Team" value={quest.maxParticipants.toString()} />
+                )}
+              </div>
+            </div>
+
+            {!isExpired && (
+              <Button asChild className="w-full h-11 rounded-xl bg-orange-500 text-white hover:bg-orange-600">
+                <Link href="/register">
+                  <Target className="mr-2 h-4 w-4" />
+                  Claim This Quest
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function DetailRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="text-xs text-slate-500">{label}</span>
+      </div>
+      <span className="text-xs font-medium text-slate-300">{value}</span>
+    </div>
+  );
+}

--- a/app/quests/page.tsx
+++ b/app/quests/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { useInView, motion } from 'framer-motion';
+import { Sword, Users, Trophy, Zap, Clock, DollarSign, SearchX, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { RankBadge } from '@/components/ui/rank-badge';
+import type { Rank } from '@/components/ui/rank-badge';
+import { Button } from '@/components/ui/button';
+
+type PublicQuest = {
+  id: string;
+  title: string;
+  description: string;
+  company: string;
+  difficulty: Rank;
+  xpReward: number;
+  monetaryReward: number | null;
+  deadline: string | null;
+  requiredSkills: string[];
+  applicants: number;
+};
+
+type PublicStats = {
+  adventurers: number;
+  companies: number;
+  completedQuests: number;
+  openQuests: number;
+};
+
+function AnimatedCounter({ value, label, icon: Icon }: { value: number; label: string; icon: React.ComponentType<{ className?: string }> }) {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true });
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!isInView || value === 0) return;
+    const duration = 1200;
+    const steps = 30;
+    const stepTime = duration / steps;
+    const increment = value / steps;
+    let current = 0;
+    const timer = setInterval(() => {
+      current += increment;
+      if (current >= value) {
+        setCount(value);
+        clearInterval(timer);
+      } else {
+        setCount(Math.floor(current));
+      }
+    }, stepTime);
+    return () => clearInterval(timer);
+  }, [isInView, value]);
+
+  return (
+    <div ref={ref} className="flex items-center gap-3">
+      <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10 border border-orange-500/20">
+        <Icon className="h-5 w-5 text-orange-400" />
+      </div>
+      <div>
+        <p className="text-xl font-bold text-white tabular-nums">{isInView ? count.toLocaleString() : '0'}</p>
+        <p className="text-xs text-slate-500">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+function formatDeadline(iso: string | null): string {
+  if (!iso) return 'No deadline';
+  const diff = new Date(iso).getTime() - Date.now();
+  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  if (days < 0) return 'Expired';
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day left';
+  return `${days} days left`;
+}
+
+export default function PublicQuestsPage() {
+  const [quests, setQuests] = useState<PublicQuest[]>([]);
+  const [stats, setStats] = useState<PublicStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const [questsRes, statsRes] = await Promise.all([
+          fetch('/api/public/quests?limit=60'),
+          fetch('/api/public/stats'),
+        ]);
+        if (!questsRes.ok) throw new Error('Failed to load quests');
+        const questsData = await questsRes.json();
+        const statsData = await statsRes.json();
+        setQuests(questsData.quests ?? []);
+        setStats(statsData);
+      } catch {
+        setError('Something went wrong loading quests. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    void fetchData();
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-slate-950">
+      {/* Hero header */}
+      <div className="border-b border-slate-800 bg-slate-950">
+        <div className="container mx-auto max-w-6xl px-6 py-16">
+          <h1 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Quest Board
+          </h1>
+          <p className="mt-2 text-sm text-slate-400">
+            Browse open quests from partner companies. Real work, real pay, real XP.
+          </p>
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      <div className="border-b border-slate-800 bg-slate-900/50">
+        <div className="container mx-auto max-w-6xl px-6 py-5">
+          <div className="flex flex-wrap items-center justify-center gap-8 md:gap-12">
+            <AnimatedCounter value={stats?.openQuests ?? 0} label="Open Quests" icon={Sword} />
+            <AnimatedCounter value={stats?.adventurers ?? 0} label="Adventurers" icon={Users} />
+            <AnimatedCounter value={stats?.completedQuests ?? 0} label="Quests Completed" icon={Trophy} />
+          </div>
+        </div>
+      </div>
+
+      {/* Quest grid */}
+      <div className="container mx-auto max-w-6xl px-6 py-10">
+        {loading ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="rounded-xl border border-slate-800 bg-slate-900 p-5 animate-pulse">
+                <div className="mb-4 h-6 w-12 rounded bg-slate-800" />
+                <div className="mb-2 h-5 w-3/4 rounded bg-slate-800" />
+                <div className="mb-3 h-3 w-1/2 rounded bg-slate-800" />
+                <div className="mb-4 h-8 w-full rounded bg-slate-800" />
+                <div className="mb-5 flex gap-1.5">
+                  <div className="h-5 w-14 rounded bg-slate-800" />
+                  <div className="h-5 w-16 rounded bg-slate-800" />
+                </div>
+                <div className="mb-4 h-px bg-slate-800" />
+                <div className="grid grid-cols-2 gap-2.5">
+                  <div className="h-4 rounded bg-slate-800" />
+                  <div className="h-4 rounded bg-slate-800" />
+                  <div className="h-4 rounded bg-slate-800" />
+                  <div className="h-4 rounded bg-slate-800" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-12 text-center">
+            <p className="text-slate-400 text-sm">{error}</p>
+            <Button
+              variant="outline"
+              className="mt-4 border-slate-700 text-slate-400 hover:bg-slate-800 bg-transparent"
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </Button>
+          </div>
+        ) : quests.length === 0 ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-12 text-center">
+            <SearchX className="mx-auto h-10 w-10 text-slate-600" />
+            <h3 className="mt-4 text-lg font-semibold text-white">No quests found</h3>
+            <p className="mt-2 text-sm text-slate-400">No open quests right now — check back soon.</p>
+            <Button asChild variant="outline" className="mt-4 border-slate-700 text-slate-400 hover:bg-slate-800 bg-transparent">
+              <Link href="/">Back to Home</Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {quests.map((quest, index) => (
+              <Link key={quest.id} href={`/quests/${quest.id}`}>
+                <motion.div
+                  initial={{ opacity: 0, y: 12 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.35, delay: index * 0.05 }}
+                  className="rounded-xl border border-slate-800 bg-slate-900 p-5 hover:border-slate-600 transition-colors duration-200 h-full"
+                >
+                  <div className="flex items-center justify-between mb-4">
+                    <RankBadge rank={quest.difficulty} size="sm" />
+                  </div>
+                  <h3 className="text-base font-semibold text-white mb-1 leading-snug line-clamp-2">{quest.title}</h3>
+                  <p className="text-xs text-slate-500 mb-3">{quest.company}</p>
+                  <p className="text-sm text-slate-400 leading-relaxed mb-4 line-clamp-2">{quest.description}</p>
+
+                  {quest.requiredSkills.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mb-5">
+                      {quest.requiredSkills.slice(0, 3).map((tag) => (
+                        <span
+                          key={tag}
+                          className="text-[10px] px-2 py-0.5 bg-slate-800 border border-slate-700 rounded-md text-slate-400 font-medium"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="h-px bg-slate-800 mb-4" />
+
+                  <div className="grid grid-cols-2 gap-2.5">
+                    <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                      <Zap className="w-3.5 h-3.5 text-orange-400" />
+                      <span>{quest.xpReward.toLocaleString()} XP</span>
+                    </div>
+                    {quest.monetaryReward != null ? (
+                      <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                        <DollarSign className="w-3.5 h-3.5 text-emerald-400" />
+                        <span>${quest.monetaryReward}</span>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                        <DollarSign className="w-3.5 h-3.5 text-slate-600" />
+                        <span>Unpaid</span>
+                      </div>
+                    )}
+                    <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                      <Clock className="w-3.5 h-3.5 text-slate-500" />
+                      <span>{formatDeadline(quest.deadline)}</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                      <Users className="w-3.5 h-3.5 text-slate-500" />
+                      <span>{quest.applicants} applied</span>
+                    </div>
+                  </div>
+                </motion.div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
…237 #235 #233)

- Create app/quests/page.tsx — public quest board with animated stats bar, skeleton loading, error handling, empty state, and quest grid
- Create app/quests/[id]/page.tsx — public quest detail page with breadcrumb, 404 page, expired quest banner, company link stub, mobile-responsive layout
- Create app/api/public/quests/[id]/route.ts — public quest detail API
- Update app/api/public/quests/route.ts — support limit query parameter

## Quest Reference
- Quest ID/Link:
- Track: OPEN / INTERN / BOOTCAMP
- Rank: F / E / D / C / B+
- Source: BACKLOG / HACKATHON / CLIENT_PORTAL / INTERNAL / TUTORIAL

## Changes


## Acceptance Criteria Checklist
- [ ] Criteria 1
- [ ] Criteria 2

## Screenshots (if UI changes)


## Peer Review Checklist (for reviewer)
- [ ] Code does what the quest brief asks
- [ ] All acceptance criteria met
- [ ] Follows existing code patterns
- [ ] No obvious bugs or edge cases
- [ ] Comfortable sending to client
