### PR TITLE
fix: quest board auth, middleware gaps, and dashboard metrics

### DIFF
--- a/app/api/admin/activity/route.ts
+++ b/app/api/admin/activity/route.ts
@@ -1,5 +1,5 @@
 // app/api/admin/activity/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
 
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     // Parse query parameters
@@ -59,7 +59,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    return Response.json({
+    return NextResponse.json({
       recentActivity,
       dailyActiveUsers: dailyActiveUsers.length,
       activityBreakdown: activityBreakdown.map(item => ({
@@ -71,6 +71,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error fetching activity data:', error);
-    return Response.json({ error: 'Failed to fetch activity data', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch activity data', success: false }, { status: 500 });
   }
 }

--- a/app/api/admin/quests/route.ts
+++ b/app/api/admin/quests/route.ts
@@ -1,5 +1,5 @@
 // app/api/admin/quests/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
 import { Prisma, QuestStatus, QuestType, UserRank, QuestCategory, QuestTrack, QuestSource } from '@prisma/client';
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -98,10 +98,10 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return Response.json({ quests: data, success: true });
+    return NextResponse.json({ quests: data, success: true });
   } catch (error) {
     console.error('Error fetching quests:', error);
-    return Response.json({ error: 'Failed to fetch quests', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch quests', success: false }, { status: 500 });
   }
 }
 
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -117,24 +117,24 @@ export async function POST(request: NextRequest) {
     const requiredFields = ['title', 'description', 'questType', 'difficulty', 'xpReward', 'questCategory'];
     for (const field of requiredFields) {
       if (body[field] == null || String(body[field]).trim() === '') {
-        return Response.json({ error: `${field} is required`, success: false }, { status: 400 });
+        return NextResponse.json({ error: `${field} is required`, success: false }, { status: 400 });
       }
     }
 
     if (!Object.values(QuestType).includes(body.questType as QuestType)) {
-      return Response.json({ error: 'Invalid questType value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid questType value', success: false }, { status: 400 });
     }
     if (!Object.values(UserRank).includes(body.difficulty as UserRank)) {
-      return Response.json({ error: 'Invalid difficulty value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid difficulty value', success: false }, { status: 400 });
     }
     if (!Object.values(QuestCategory).includes(body.questCategory as QuestCategory)) {
-      return Response.json({ error: 'Invalid questCategory value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid questCategory value', success: false }, { status: 400 });
     }
     if (body.track && !Object.values(QuestTrack).includes(body.track as QuestTrack)) {
-      return Response.json({ error: 'Invalid track value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid track value', success: false }, { status: 400 });
     }
     if (body.source && !Object.values(QuestSource).includes(body.source as QuestSource)) {
-      return Response.json({ error: 'Invalid source value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid source value', success: false }, { status: 400 });
     }
 
     const data = await prisma.quest.create({
@@ -162,10 +162,10 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return Response.json({ quest: data, success: true }, { status: 201 });
+    return NextResponse.json({ quest: data, success: true }, { status: 201 });
   } catch (error) {
     console.error('Error creating quest:', error);
-    return Response.json({ error: 'Failed to create quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to create quest', success: false }, { status: 500 });
   }
 }
 
@@ -173,17 +173,17 @@ export async function PUT(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
     const { questId, addNote, ...updateFields } = body;
 
     if (!questId) {
-      return Response.json({ error: 'Quest ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
     if (!UUID_REGEX.test(questId)) {
-      return Response.json({ error: 'Invalid quest ID format', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid quest ID format', success: false }, { status: 400 });
     }
 
     const updateData: Prisma.QuestUpdateInput = {};
@@ -208,7 +208,7 @@ export async function PUT(request: NextRequest) {
     const validStatuses = Object.values(QuestStatus);
     if (updateFields.status !== undefined) {
       if (!validStatuses.includes(updateFields.status as QuestStatus)) {
-        return Response.json({ error: 'Invalid status value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid status value', success: false }, { status: 400 });
       }
       updateData.status = updateFields.status as QuestStatus;
     }
@@ -216,7 +216,7 @@ export async function PUT(request: NextRequest) {
     if (updateFields.description !== undefined) updateData.description = updateFields.description;
     if (updateFields.requiredRank !== undefined) {
       if (updateFields.requiredRank !== null && !Object.values(UserRank).includes(updateFields.requiredRank as UserRank)) {
-        return Response.json({ error: 'Invalid requiredRank value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid requiredRank value', success: false }, { status: 400 });
       }
       updateData.requiredRank = updateFields.requiredRank as UserRank | null;
     }
@@ -224,13 +224,13 @@ export async function PUT(request: NextRequest) {
     if (updateFields.xpReward !== undefined) updateData.xpReward = updateFields.xpReward;
     if (updateFields.track !== undefined) {
       if (!Object.values(QuestTrack).includes(updateFields.track as QuestTrack)) {
-        return Response.json({ error: 'Invalid track value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid track value', success: false }, { status: 400 });
       }
       updateData.track = updateFields.track as QuestTrack;
     }
     if (updateFields.source !== undefined) {
       if (!Object.values(QuestSource).includes(updateFields.source as QuestSource)) {
-        return Response.json({ error: 'Invalid source value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid source value', success: false }, { status: 400 });
       }
       updateData.source = updateFields.source as QuestSource;
     }
@@ -250,10 +250,10 @@ export async function PUT(request: NextRequest) {
       data: updateData,
     });
 
-    return Response.json({ quest: data, success: true });
+    return NextResponse.json({ quest: data, success: true });
   } catch (error) {
     console.error('Error updating quest:', error);
-    return Response.json({ error: 'Failed to update quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update quest', success: false }, { status: 500 });
   }
 }
 
@@ -261,17 +261,17 @@ export async function DELETE(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
     const { questId } = body;
 
     if (!questId) {
-      return Response.json({ error: 'Quest ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
     if (!UUID_REGEX.test(questId)) {
-      return Response.json({ error: 'Invalid quest ID format', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid quest ID format', success: false }, { status: 400 });
     }
 
     await prisma.quest.update({
@@ -279,9 +279,9 @@ export async function DELETE(request: NextRequest) {
       data: { status: 'cancelled' },
     });
 
-    return Response.json({ message: 'Quest cancelled successfully', success: true });
+    return NextResponse.json({ message: 'Quest cancelled successfully', success: true });
   } catch (error) {
     console.error('Error cancelling quest:', error);
-    return Response.json({ error: 'Failed to cancel quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to cancel quest', success: false }, { status: 500 });
   }
 }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,5 +1,5 @@
 // app/api/admin/users/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
 import { Prisma, UserRole } from '@prisma/client';
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request, 'admin');
     if (!user) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     // Parse query parameters
@@ -79,10 +79,10 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return Response.json({ users: data, success: true });
+    return NextResponse.json({ users: data, success: true });
   } catch (error) {
     console.error('Error fetching users:', error);
-    return Response.json({ error: 'Failed to fetch users', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch users', success: false }, { status: 500 });
   }
 }
 
@@ -90,7 +90,7 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -98,19 +98,19 @@ export async function PUT(request: NextRequest) {
 
     // Validate required fields
     if (!userId) {
-      return Response.json({ error: 'User ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'User ID is required', success: false }, { status: 400 });
     }
 
     // Validate role if provided
     if (role !== undefined) {
       if (!Object.values(UserRole).includes(role as UserRole)) {
-        return Response.json({ error: 'Invalid role value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid role value', success: false }, { status: 400 });
       }
       // Prevent demoting admin users
       if (role !== 'admin') {
         const target = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
         if (target?.role === 'admin') {
-          return Response.json({ error: 'Cannot change role of an admin user', success: false }, { status: 400 });
+          return NextResponse.json({ error: 'Cannot change role of an admin user', success: false }, { status: 400 });
         }
       }
     }
@@ -126,10 +126,10 @@ export async function PUT(request: NextRequest) {
       data: updateData,
     });
 
-    return Response.json({ user: data, success: true });
+    return NextResponse.json({ user: data, success: true });
   } catch (error) {
     console.error('Error updating user:', error);
-    return Response.json({ error: 'Failed to update user', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update user', success: false }, { status: 500 });
   }
 }
 
@@ -137,7 +137,7 @@ export async function DELETE(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -145,12 +145,12 @@ export async function DELETE(request: NextRequest) {
 
     // Validate required field
     if (!userId) {
-      return Response.json({ error: 'User ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'User ID is required', success: false }, { status: 400 });
     }
 
     // Prevent self-deactivation
     if (userId === authUser.id) {
-      return Response.json({ error: 'Cannot deactivate your own account', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Cannot deactivate your own account', success: false }, { status: 400 });
     }
 
     // Delete the user (in reality, you'd want to de-activate rather than hard delete)
@@ -159,9 +159,9 @@ export async function DELETE(request: NextRequest) {
       data: { isActive: false },
     });
 
-    return Response.json({ message: 'User deactivated successfully', success: true });
+    return NextResponse.json({ message: 'User deactivated successfully', success: true });
   } catch (error) {
     console.error('Error deactivating user:', error);
-    return Response.json({ error: 'Failed to deactivate user', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to deactivate user', success: false }, { status: 500 });
   }
 }

--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -1,5 +1,5 @@
 // app/api/company/quests/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 import { Prisma, QuestStatus, QuestType, UserRank, QuestTrack, QuestSource } from '@prisma/client';
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     // Parse query parameters
@@ -26,19 +26,19 @@ export async function GET(request: NextRequest) {
 
     if (status) {
       if (!Object.values(QuestStatus).includes(status as QuestStatus)) {
-        return Response.json({ error: 'Invalid status value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid status value', success: false }, { status: 400 });
       }
       where.status = status as QuestStatus;
     }
     if (questType) {
       if (!Object.values(QuestType).includes(questType as QuestType)) {
-        return Response.json({ error: 'Invalid questType value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid questType value', success: false }, { status: 400 });
       }
       where.questType = questType as QuestType;
     }
     if (difficulty) {
       if (!Object.values(UserRank).includes(difficulty as UserRank)) {
-        return Response.json({ error: 'Invalid difficulty value', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid difficulty value', success: false }, { status: 400 });
       }
       where.difficulty = difficulty as UserRank;
     }
@@ -69,10 +69,10 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return Response.json({ quests: data, success: true });
+    return NextResponse.json({ quests: data, success: true });
   } catch (error) {
     console.error('Error fetching company quests:', error);
-    return Response.json({ error: 'Failed to fetch company quests', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch company quests', success: false }, { status: 500 });
   }
 }
 
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -90,16 +90,16 @@ export async function POST(request: NextRequest) {
     const requiredFields = ['title', 'description', 'questType', 'difficulty', 'xpReward', 'questCategory'];
     for (const field of requiredFields) {
       if (body[field] == null || String(body[field]).trim() === '') {
-        return Response.json({ error: `${field} is required`, success: false }, { status: 400 });
+        return NextResponse.json({ error: `${field} is required`, success: false }, { status: 400 });
       }
     }
 
     // Validate optional enums
     if (body.track && !Object.values(QuestTrack).includes(body.track as QuestTrack)) {
-      return Response.json({ error: 'Invalid track value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid track value', success: false }, { status: 400 });
     }
     if (body.source && !Object.values(QuestSource).includes(body.source as QuestSource)) {
-      return Response.json({ error: 'Invalid source value', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid source value', success: false }, { status: 400 });
     }
 
     // Create the quest
@@ -133,10 +133,10 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    return Response.json({ quest: data, success: true }, { status: 201 });
+    return NextResponse.json({ quest: data, success: true }, { status: 201 });
   } catch (error) {
     console.error('Error creating quest:', error);
-    return Response.json({ error: 'Failed to create quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to create quest', success: false }, { status: 500 });
   }
 }
 
@@ -144,7 +144,7 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -155,7 +155,7 @@ export async function PUT(request: NextRequest) {
 
     // Validate required fields
     if (!questId || !companyId) {
-      return Response.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
     }
 
     // Verify the company owns this quest
@@ -165,7 +165,7 @@ export async function PUT(request: NextRequest) {
     });
 
     if (!quest || quest.companyId !== companyId) {
-      return Response.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 
     // Convert snake_case keys to camelCase for Prisma
@@ -193,10 +193,10 @@ export async function PUT(request: NextRequest) {
       data: prismaUpdateFields,
     });
 
-    return Response.json({ quest: data, success: true });
+    return NextResponse.json({ quest: data, success: true });
   } catch (error) {
     console.error('Error updating quest:', error);
-    return Response.json({ error: 'Failed to update quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update quest', success: false }, { status: 500 });
   }
 }
 
@@ -204,7 +204,7 @@ export async function DELETE(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -213,7 +213,7 @@ export async function DELETE(request: NextRequest) {
 
     // Validate required fields
     if (!questId || !companyId) {
-      return Response.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
     }
 
     // Verify the company owns this quest
@@ -223,7 +223,7 @@ export async function DELETE(request: NextRequest) {
     });
 
     if (!quest || quest.companyId !== companyId) {
-      return Response.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 
     // Update the quest status to cancelled instead of hard deleting
@@ -232,9 +232,9 @@ export async function DELETE(request: NextRequest) {
       data: { status: 'cancelled' },
     });
 
-    return Response.json({ message: 'Quest cancelled successfully', success: true });
+    return NextResponse.json({ message: 'Quest cancelled successfully', success: true });
   } catch (error) {
     console.error('Error cancelling quest:', error);
-    return Response.json({ error: 'Failed to cancel quest', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to cancel quest', success: false }, { status: 500 });
   }
 }

--- a/app/api/matching/route.ts
+++ b/app/api/matching/route.ts
@@ -1,5 +1,5 @@
 // app/api/matching/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await getAuthUser(request);
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     // Parse query parameters
@@ -17,10 +17,10 @@ export async function GET(request: NextRequest) {
 
     // Validate user ID is provided
     if (!userId) {
-      return Response.json({ error: 'User ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'User ID is required', success: false }, { status: 400 });
     }
     if (authUser.role !== 'admin' && userId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     // Get user's profile information including skills and rank
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
     });
 
     if (!user) {
-      return Response.json({ error: 'User not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'User not found', success: false }, { status: 404 });
     }
 
     // Get available quests
@@ -86,7 +86,7 @@ export async function GET(request: NextRequest) {
 
     // If user is not an adventurer, return empty list
     if (user.role !== 'adventurer') {
-      return Response.json({ matches: [], success: true });
+      return NextResponse.json({ matches: [], success: true });
     }
 
     // Perform matching algorithm
@@ -176,10 +176,10 @@ export async function GET(request: NextRequest) {
     // Take top matches
     .slice(0, parseInt(limit));
 
-    return Response.json({ matches: matchedQuests, success: true });
+    return NextResponse.json({ matches: matchedQuests, success: true });
   } catch (error) {
     console.error('Error in quest matching:', error);
-    return Response.json({ error: 'Failed to match quests', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to match quests', success: false }, { status: 500 });
   }
 }
 
@@ -188,7 +188,7 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await getAuthUser(request);
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -196,10 +196,10 @@ export async function POST(request: NextRequest) {
 
     // Validate required fields
     if (!userId) {
-      return Response.json({ error: 'User ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'User ID is required', success: false }, { status: 400 });
     }
     if (authUser.role !== 'admin' && userId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     // Get user's profile
@@ -224,7 +224,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!user) {
-      return Response.json({ error: 'User not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'User not found', success: false }, { status: 404 });
     }
 
     // Get user's completed quests to understand their preferences
@@ -341,9 +341,9 @@ export async function POST(request: NextRequest) {
     .sort((a, b) => b.recommendationScore - a.recommendationScore)
     .slice(0, num_recommendations);
 
-    return Response.json({ recommendations: recommendedQuests, success: true });
+    return NextResponse.json({ recommendations: recommendedQuests, success: true });
   } catch (error) {
     console.error('Error in quest recommendation:', error);
-    return Response.json({ error: 'Failed to generate recommendations', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to generate recommendations', success: false }, { status: 500 });
   }
 }

--- a/app/api/mentorship/route.ts
+++ b/app/api/mentorship/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -44,15 +44,15 @@ export async function GET(request: NextRequest) {
     const offset = toSafeInt(searchParams.get('offset'), 0, 0, 10000);
 
     if (requestedUserId && authUser.role !== 'admin' && requestedUserId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     if (role && role !== 'mentor' && role !== 'mentee') {
-      return Response.json({ error: 'Invalid role filter', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid role filter', success: false }, { status: 400 });
     }
 
     if (status && !VALID_STATUSES.includes(status as MentorshipStatus)) {
-      return Response.json({ error: 'Invalid status filter', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid status filter', success: false }, { status: 400 });
     }
 
     const targetUserId =
@@ -111,10 +111,10 @@ export async function GET(request: NextRequest) {
       take: limit,
     });
 
-    return Response.json({ mentorships: data, success: true });
+    return NextResponse.json({ mentorships: data, success: true });
   } catch (error) {
     console.error('Error fetching mentorships:', error);
-    return Response.json({ error: 'Failed to fetch mentorships', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch mentorships', success: false }, { status: 500 });
   }
 }
 
@@ -122,7 +122,7 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
@@ -131,22 +131,22 @@ export async function POST(request: NextRequest) {
     const goals = parseGoals(body.goals);
 
     if (!mentorId || !menteeId) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'mentorId and menteeId are required', success: false },
         { status: 400 }
       );
     }
     if (mentorId === menteeId) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Mentor and mentee must be different users', success: false },
         { status: 400 }
       );
     }
     if (goals.length === 0) {
-      return Response.json({ error: 'At least one goal is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'At least one goal is required', success: false }, { status: 400 });
     }
     if (authUser.role !== 'admin' && authUser.id !== mentorId && authUser.id !== menteeId) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     const mentor = await prisma.user.findUnique({
@@ -154,7 +154,7 @@ export async function POST(request: NextRequest) {
       select: { id: true, name: true, role: true },
     });
     if (!mentor || mentor.role !== 'adventurer') {
-      return Response.json({ error: 'Invalid mentor user', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid mentor user', success: false }, { status: 400 });
     }
 
     const mentee = await prisma.user.findUnique({
@@ -162,7 +162,7 @@ export async function POST(request: NextRequest) {
       select: { id: true, role: true },
     });
     if (!mentee || mentee.role !== 'adventurer') {
-      return Response.json({ error: 'Invalid mentee user', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid mentee user', success: false }, { status: 400 });
     }
 
     const existingMentorship = await prisma.mentorship.findMany({
@@ -177,7 +177,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingMentorship.length > 0) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'A mentorship already exists between these users', success: false },
         { status: 400 }
       );
@@ -186,7 +186,7 @@ export async function POST(request: NextRequest) {
     const startDate = parseDate(body.startDate) ?? new Date();
     const endDate = body.endDate === null ? null : parseDate(body.endDate);
     if (body.endDate && !endDate) {
-      return Response.json({ error: 'Invalid endDate', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid endDate', success: false }, { status: 400 });
     }
 
     const data = await prisma.mentorship.create({
@@ -219,10 +219,10 @@ export async function POST(request: NextRequest) {
       console.error('Error sending mentorship request notification:', notificationError);
     }
 
-    return Response.json({ mentorship: data, success: true }, { status: 201 });
+    return NextResponse.json({ mentorship: data, success: true }, { status: 201 });
   } catch (error) {
     console.error('Error creating mentorship:', error);
-    return Response.json({ error: 'Failed to create mentorship', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to create mentorship', success: false }, { status: 500 });
   }
 }
 
@@ -230,7 +230,7 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
@@ -241,7 +241,7 @@ export async function PUT(request: NextRequest) {
         : null;
 
     if (!mentorshipId) {
-      return Response.json({ error: 'Mentorship ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Mentorship ID is required', success: false }, { status: 400 });
     }
 
     const mentorship = await prisma.mentorship.findUnique({
@@ -250,7 +250,7 @@ export async function PUT(request: NextRequest) {
     });
 
     if (!mentorship) {
-      return Response.json({ error: 'Mentorship not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Mentorship not found', success: false }, { status: 404 });
     }
 
     const currentUserId = authUser.id;
@@ -268,7 +268,7 @@ export async function PUT(request: NextRequest) {
     }
 
     if (!canUpdate) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Unauthorized to perform this action', success: false },
         { status: 403 }
       );
@@ -301,14 +301,14 @@ export async function PUT(request: NextRequest) {
       } else if (body.endDate !== undefined) {
         const parsedEndDate = parseDate(body.endDate);
         if (!parsedEndDate) {
-          return Response.json({ error: 'Invalid endDate', success: false }, { status: 400 });
+          return NextResponse.json({ error: 'Invalid endDate', success: false }, { status: 400 });
         }
         updateData.endDate = parsedEndDate;
       }
     }
 
     if (Object.keys(updateData).length === 0) {
-      return Response.json({ error: 'No valid fields to update', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });
     }
 
     const data = await prisma.mentorship.update({
@@ -341,10 +341,10 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    return Response.json({ mentorship: data, success: true });
+    return NextResponse.json({ mentorship: data, success: true });
   } catch (error) {
     console.error('Error updating mentorship:', error);
-    return Response.json({ error: 'Failed to update mentorship', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update mentorship', success: false }, { status: 500 });
   }
 }
 
@@ -352,13 +352,13 @@ export async function DELETE(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const mentorshipId = typeof body.mentorshipId === 'string' ? body.mentorshipId : '';
     if (!mentorshipId) {
-      return Response.json({ error: 'Mentorship ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Mentorship ID is required', success: false }, { status: 400 });
     }
 
     const mentorship = await prisma.mentorship.findUnique({
@@ -367,12 +367,12 @@ export async function DELETE(request: NextRequest) {
     });
 
     if (!mentorship) {
-      return Response.json({ error: 'Mentorship not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Mentorship not found', success: false }, { status: 404 });
     }
 
     const isParticipant = authUser.id === mentorship.mentorId || authUser.id === mentorship.menteeId;
     if (authUser.role !== 'admin' && !isParticipant) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 403 });
     }
 
     if (
@@ -380,7 +380,7 @@ export async function DELETE(request: NextRequest) {
       mentorship.status !== 'cancelled' &&
       mentorship.status !== 'completed'
     ) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Can only delete cancelled or completed mentorships', success: false },
         { status: 400 }
       );
@@ -390,9 +390,9 @@ export async function DELETE(request: NextRequest) {
       where: { id: mentorshipId },
     });
 
-    return Response.json({ message: 'Mentorship deleted successfully', success: true });
+    return NextResponse.json({ message: 'Mentorship deleted successfully', success: true });
   } catch (error) {
     console.error('Error deleting mentorship:', error);
-    return Response.json({ error: 'Failed to delete mentorship', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to delete mentorship', success: false }, { status: 500 });
   }
 }

--- a/app/api/onboard/route.ts
+++ b/app/api/onboard/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
@@ -31,12 +31,12 @@ export async function POST(request: NextRequest) {
     const expectedSecret = process.env.BOOTCAMP_WEBHOOK_SECRET;
     const providedSecret = readBearerToken(request) ?? body.webhookSecret ?? null;
     if (!expectedSecret || !providedSecret || providedSecret !== expectedSecret) {
-      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // 2. Validate required fields
     if (!body.bootcampStudentId || !body.name || !body.email || !body.bootcampTrack) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Missing required fields: bootcampStudentId, name, email, bootcampTrack' },
         { status: 400 }
       );
@@ -46,13 +46,13 @@ export async function POST(request: NextRequest) {
 
     // Validate bootcamp track
     if (!VALID_BOOTCAMP_TRACKS.includes(body.bootcampTrack)) {
-      return Response.json({ error: `Invalid bootcampTrack. Must be one of: ${VALID_BOOTCAMP_TRACKS.join(', ')}` }, { status: 400 });
+      return NextResponse.json({ error: `Invalid bootcampTrack. Must be one of: ${VALID_BOOTCAMP_TRACKS.join(', ')}` }, { status: 400 });
     }
 
     // Validate bootcamp week
     const bootcampWeek = body.bootcampWeek ?? 1;
     if (bootcampWeek < 1 || bootcampWeek > 10) {
-      return Response.json({ error: 'bootcampWeek must be between 1 and 10' }, { status: 400 });
+      return NextResponse.json({ error: 'bootcampWeek must be between 1 and 10' }, { status: 400 });
     }
 
     // 3. Check for existing BootcampLink — idempotent update if same student
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
     if (existingLink) {
       // Same student re-enrolling: update bootcampWeek (idempotent)
       if (existingLink.user.email !== normalizedEmail) {
-        return Response.json(
+        return NextResponse.json(
           { error: 'Student ID already linked to a different email' },
           { status: 409 }
         );
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest) {
         })
       );
 
-      return Response.json({
+      return NextResponse.json({
         success: true,
         adventurerId: existingLink.userId,
         rank: 'F',
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     );
 
     if (existingUser) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Email already registered. Contact support to link bootcamp enrollment.' },
         { status: 409 }
       );
@@ -139,7 +139,7 @@ export async function POST(request: NextRequest) {
 
     const shouldReturnPassword = process.env.BOOTCAMP_ONBOARD_RETURN_PASSWORD === 'true';
 
-    return Response.json(
+    return NextResponse.json(
       {
         success: true,
         adventurerId: user.id,
@@ -150,6 +150,6 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     console.error('Onboard webhook error:', error);
-    return Response.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -1,5 +1,5 @@
 // app/api/payments/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { validatePaymentInfo } from '@/lib/payment-utils';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     // Parse query parameters
@@ -21,14 +21,14 @@ export async function GET(request: NextRequest) {
     const offsetParam = searchParams.get('offset');
 
     if (!userId) {
-      return Response.json({ error: 'User ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'User ID is required', success: false }, { status: 400 });
     }
 
     let limit: number | null = null;
     if (limitParam !== null) {
       limit = Number.parseInt(limitParam, 10);
       if (!Number.isFinite(limit) || limit <= 0) {
-        return Response.json({ error: 'limit must be a positive integer', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'limit must be a positive integer', success: false }, { status: 400 });
       }
     }
 
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
     if (offsetParam !== null) {
       offset = Number.parseInt(offsetParam, 10);
       if (!Number.isFinite(offset) || offset < 0) {
-        return Response.json({ error: 'offset must be a non-negative integer', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'offset must be a non-negative integer', success: false }, { status: 400 });
       }
     }
 
@@ -84,10 +84,10 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return Response.json({ transactions: data, success: true });
+    return NextResponse.json({ transactions: data, success: true });
   } catch (error) {
     console.error('Error fetching transactions:', error);
-    return Response.json({ error: 'Failed to fetch transactions', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch transactions', success: false }, { status: 500 });
   }
 }
 
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -104,7 +104,7 @@ export async function POST(request: NextRequest) {
     const requiredFields = ['fromUserId', 'toUserId', 'questId', 'amount', 'currency'];
     for (const field of requiredFields) {
       if (body[field] === undefined) {
-        return Response.json({ error: `${field} is required`, success: false }, { status: 400 });
+        return NextResponse.json({ error: `${field} is required`, success: false }, { status: 400 });
       }
     }
 
@@ -116,20 +116,20 @@ export async function POST(request: NextRequest) {
       !body.toUserId.trim() ||
       !body.questId.trim()
     ) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'fromUserId, toUserId, and questId must be non-empty strings', success: false },
         { status: 400 }
       );
     }
 
     if (authUser.role !== 'admin' && body.fromUserId !== authUser.id) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'You can only initiate payments from your own account', success: false },
         { status: 403 }
       );
     }
     if (body.fromUserId === body.toUserId) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Sender and receiver cannot be the same user', success: false },
         { status: 400 }
       );
@@ -144,7 +144,7 @@ export async function POST(request: NextRequest) {
       );
 
       if (!validation.isValid) {
-        return Response.json({ error: validation.error, success: false }, { status: 400 });
+        return NextResponse.json({ error: validation.error, success: false }, { status: 400 });
       }
     }
 
@@ -155,26 +155,26 @@ export async function POST(request: NextRequest) {
     });
 
     if (!quest) {
-      return Response.json({ error: 'Quest not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
     }
 
     if (quest.status !== 'completed') {
-      return Response.json({ error: 'Quest must be completed before payment', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest must be completed before payment', success: false }, { status: 400 });
     }
 
     if (!quest.companyId) {
-      return Response.json({ error: 'Quest is not linked to a company', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Quest is not linked to a company', success: false }, { status: 400 });
     }
 
     if (authUser.role !== 'admin' && quest.companyId !== authUser.id) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'You can only pay for your own quests', success: false },
         { status: 403 }
       );
     }
 
     if (authUser.role !== 'admin' && body.fromUserId !== quest.companyId) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'fromUserId must match the quest owner', success: false },
         { status: 403 }
       );
@@ -186,7 +186,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!recipient || !recipient.isActive || recipient.role !== 'adventurer') {
-      return Response.json({ error: 'Invalid adventurer account', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid adventurer account', success: false }, { status: 400 });
     }
 
     const completionRecord = await prisma.questCompletion.findUnique({
@@ -200,7 +200,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!completionRecord) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Selected adventurer has not completed this quest', success: false },
         { status: 400 }
       );
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingPayment) {
-      return Response.json({ error: 'Payment already exists for this quest', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Payment already exists for this quest', success: false }, { status: 400 });
     }
 
     // In a real implementation, you would integrate with a payment processor like Stripe
@@ -269,13 +269,13 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return Response.json({
+    return NextResponse.json({
       transaction: completedTransaction,
       success: true,
       message: 'Payment processed successfully'
     });
   } catch (error) {
     console.error('Error processing payment:', error);
-    return Response.json({ error: 'Failed to process payment', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to process payment', success: false }, { status: 500 });
   }
 }

--- a/app/api/payments/webhooks/razorpay/route.ts
+++ b/app/api/payments/webhooks/razorpay/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { notifyDiscord } from '@/lib/discord-notify';
 import crypto from 'crypto';
@@ -56,13 +56,13 @@ export async function POST(request: NextRequest) {
 
   if (!signature) {
     console.error('Missing Razorpay signature header');
-    return Response.json({ error: 'Missing signature' }, { status: 403 });
+    return NextResponse.json({ error: 'Missing signature' }, { status: 403 });
   }
 
   const secret = process.env.RAZORPAY_KEY_SECRET;
   if (!secret) {
     console.error('RAZORPAY_KEY_SECRET not configured');
-    return Response.json({ error: 'Server configuration error' }, { status: 500 });
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
   }
 
   const hash = crypto
@@ -72,14 +72,14 @@ export async function POST(request: NextRequest) {
 
   if (hash !== signature) {
     console.error('Invalid webhook signature');
-    return Response.json({ error: 'Invalid signature' }, { status: 403 });
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 403 });
   }
 
   let payload: RazorpayWebhookPayload;
   try {
     payload = JSON.parse(rawBody);
   } catch {
-    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
   try {
@@ -187,9 +187,9 @@ export async function POST(request: NextRequest) {
         break;
     }
 
-    return Response.json({ received: true });
+    return NextResponse.json({ received: true });
   } catch (error) {
     console.error('Razorpay webhook processing error:', error);
-    return Response.json({ error: 'Webhook processing failed' }, { status: 500 });
+    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
   }
 }

--- a/app/api/payments/webhooks/stripe/route.ts
+++ b/app/api/payments/webhooks/stripe/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { verifyStripeWebhook } from '@/lib/stripe';
 import { notifyDiscord } from '@/lib/discord-notify';
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
   const signature = request.headers.get('stripe-signature');
 
   if (!signature) {
-    return Response.json({ error: 'Missing stripe-signature header' }, { status: 400 });
+    return NextResponse.json({ error: 'Missing stripe-signature header' }, { status: 400 });
   }
 
   let event;
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     event = verifyStripeWebhook(body, signature);
   } catch (err) {
     console.error('Stripe webhook signature verification failed:', err);
-    return Response.json({ error: 'Invalid signature' }, { status: 401 });
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
   try {
@@ -74,9 +74,9 @@ export async function POST(request: NextRequest) {
         break;
     }
 
-    return Response.json({ received: true });
+    return NextResponse.json({ received: true });
   } catch (error) {
     console.error('Stripe webhook processing error:', error);
-    return Response.json({ error: 'Webhook processing failed' }, { status: 500 });
+    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
   }
 }

--- a/app/api/public/stats/route.ts
+++ b/app/api/public/stats/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
 import { AssignmentStatus, UserRole, QuestStatus } from '@prisma/client';
 
@@ -12,13 +13,13 @@ export async function GET() {
       ])
     );
 
-    return Response.json({
+    return NextResponse.json({
       adventurers: adventurerCount,
       companies: companyCount,
       completedQuests: completedCount,
       openQuests: openCount,
     });
   } catch {
-    return Response.json({ error: 'Failed to fetch stats' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
   }
 }

--- a/app/api/qa/reviews/route.ts
+++ b/app/api/qa/reviews/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     const offset = Number.parseInt(searchParams.get('offset') ?? '0', 10) || 0;
 
     if (reviewerId && authUser.role !== 'admin' && reviewerId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     const whereClause: Record<string, unknown> = {};
@@ -83,10 +83,10 @@ export async function GET(request: NextRequest) {
       take: Math.min(limit, 50),
     });
 
-    return Response.json({ submissions: data, success: true });
+    return NextResponse.json({ submissions: data, success: true });
   } catch (error) {
     console.error('Error fetching submissions for review:', error);
-    return Response.json({ error: 'Failed to fetch submissions', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch submissions', success: false }, { status: 500 });
   }
 }
 
@@ -94,14 +94,14 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const requiredFields = ['submissionId', 'quality_score', 'status'];
     for (const field of requiredFields) {
       if (body[field] === undefined) {
-        return Response.json({ error: `${field} is required`, success: false }, { status: 400 });
+        return NextResponse.json({ error: `${field} is required`, success: false }, { status: 400 });
       }
     }
 
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
         : null;
 
     if (!submissionId || !status || qualityScore === null) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'submissionId, status and quality_score are required', success: false },
         { status: 400 }
       );
@@ -143,11 +143,11 @@ export async function POST(request: NextRequest) {
     });
 
     if (!existingSubmission) {
-      return Response.json({ error: 'Submission not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Submission not found', success: false }, { status: 404 });
     }
 
     if (authUser.role !== 'admin' && existingSubmission.assignment.quest?.companyId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     const data = await prisma.questSubmission.update({
@@ -241,10 +241,10 @@ export async function POST(request: NextRequest) {
 
     await syncQuestLifecycleStatus(prisma, existingSubmission.assignment.questId);
 
-    return Response.json({ submission: data, success: true });
+    return NextResponse.json({ submission: data, success: true });
   } catch (error) {
     console.error('Error reviewing submission:', error);
-    return Response.json({ error: 'Failed to review submission', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to review submission', success: false }, { status: 500 });
   }
 }
 
@@ -253,14 +253,14 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     await request.json();
 
-    return Response.json({ success: true });
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error in QA PUT:', error);
-    return Response.json({ error: 'Failed to process request', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to process request', success: false }, { status: 500 });
   }
 }

--- a/app/api/teams/members/route.ts
+++ b/app/api/teams/members/route.ts
@@ -1,5 +1,5 @@
 import { TeamRole } from '@prisma/client';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -49,26 +49,26 @@ export async function GET(request: NextRequest) {
     const offset = toSafeInt(searchParams.get('offset'), 0, 0, 10000);
 
     if (!teamId && !userId) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Either Team ID or User ID is required', success: false },
         { status: 400 }
       );
     }
 
     if (userId && authUser.role !== 'admin' && userId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     if (teamId && authUser.role !== 'admin') {
       const requesterRole = await getRequesterTeamRole(teamId, authUser.id);
       if (!requesterRole) {
-        return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+        return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
       }
     }
 
     const parsedRole = role ? parseTeamRole(role) : null;
     if (role && !parsedRole) {
-      return Response.json({ error: 'Invalid role filter', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid role filter', success: false }, { status: 400 });
     }
 
     const where: Record<string, unknown> = {
@@ -110,10 +110,10 @@ export async function GET(request: NextRequest) {
       orderBy: { joinedAt: 'desc' },
     });
 
-    return Response.json({ members: data, success: true });
+    return NextResponse.json({ members: data, success: true });
   } catch (error) {
     console.error('Error fetching team members:', error);
-    return Response.json({ error: 'Failed to fetch team members', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch team members', success: false }, { status: 500 });
   }
 }
 
@@ -121,7 +121,7 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
@@ -131,16 +131,16 @@ export async function POST(request: NextRequest) {
     const requestedRole = parseTeamRole(body.role) ?? 'member';
 
     if (!teamId) {
-      return Response.json({ error: 'teamId is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'teamId is required', success: false }, { status: 400 });
     }
     if (!requestedUserId && !inviteEmail) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Either userId or email is required', success: false },
         { status: 400 }
       );
     }
     if (requestedRole === 'owner') {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Assigning owner role is not supported via this endpoint', success: false },
         { status: 400 }
       );
@@ -152,13 +152,13 @@ export async function POST(request: NextRequest) {
     });
 
     if (!team || !team.isActive) {
-      return Response.json({ error: 'Team not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found', success: false }, { status: 404 });
     }
 
     if (authUser.role !== 'admin') {
       const requesterRole = await getRequesterTeamRole(teamId, authUser.id, team.ownerUserId);
       if (!requesterRole || (requesterRole !== 'owner' && requesterRole !== 'admin')) {
-        return Response.json(
+        return NextResponse.json(
           { error: 'Only team owners and admins can invite members', success: false },
           { status: 403 }
         );
@@ -172,7 +172,7 @@ export async function POST(request: NextRequest) {
         select: { id: true },
       });
       if (!invitedUser) {
-        return Response.json({ error: 'No user found with this email', success: false }, { status: 404 });
+        return NextResponse.json({ error: 'No user found with this email', success: false }, { status: 404 });
       }
       targetUserId = invitedUser.id;
     }
@@ -185,7 +185,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (team.maxMembers && activeMemberCount >= team.maxMembers) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Team has reached maximum members', success: false },
         { status: 400 }
       );
@@ -200,7 +200,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingMembership?.isActive) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'User is already a member of this team', success: false },
         { status: 400 }
       );
@@ -219,10 +219,10 @@ export async function POST(request: NextRequest) {
           },
         });
 
-    return Response.json({ member: data, success: true }, { status: 201 });
+    return NextResponse.json({ member: data, success: true }, { status: 201 });
   } catch (error) {
     console.error('Error adding team member:', error);
-    return Response.json({ error: 'Failed to add team member', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to add team member', success: false }, { status: 500 });
   }
 }
 
@@ -230,7 +230,7 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
@@ -238,13 +238,13 @@ export async function PUT(request: NextRequest) {
     const role = parseTeamRole(body.role);
 
     if (!memberId || !role) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Member ID and valid role are required', success: false },
         { status: 400 }
       );
     }
     if (role === 'owner') {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Use ownership transfer flow to assign owner role', success: false },
         { status: 400 }
       );
@@ -256,7 +256,7 @@ export async function PUT(request: NextRequest) {
     });
 
     if (!currentMember || !currentMember.isActive) {
-      return Response.json({ error: 'Team member not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team member not found', success: false }, { status: 404 });
     }
 
     const team = await prisma.team.findUnique({
@@ -264,13 +264,13 @@ export async function PUT(request: NextRequest) {
       select: { ownerUserId: true },
     });
     if (!team) {
-      return Response.json({ error: 'Team not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found', success: false }, { status: 404 });
     }
 
     if (authUser.role !== 'admin') {
       const requesterRole = await getRequesterTeamRole(currentMember.teamId, authUser.id, team.ownerUserId);
       if (!requesterRole || (requesterRole !== 'owner' && requesterRole !== 'admin')) {
-        return Response.json(
+        return NextResponse.json(
           { error: 'Only team owners and admins can update member roles', success: false },
           { status: 403 }
         );
@@ -278,7 +278,7 @@ export async function PUT(request: NextRequest) {
     }
 
     if (currentMember.role === 'owner') {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Cannot change role of team owner', success: false },
         { status: 400 }
       );
@@ -289,10 +289,10 @@ export async function PUT(request: NextRequest) {
       data: { role },
     });
 
-    return Response.json({ member: data, success: true });
+    return NextResponse.json({ member: data, success: true });
   } catch (error) {
     console.error('Error updating team member:', error);
-    return Response.json({ error: 'Failed to update team member', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update team member', success: false }, { status: 500 });
   }
 }
 
@@ -300,14 +300,14 @@ export async function DELETE(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const memberId = typeof body.member_id === 'string' ? body.member_id : '';
 
     if (!memberId) {
-      return Response.json({ error: 'Member ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Member ID is required', success: false }, { status: 400 });
     }
 
     const currentMember = await prisma.teamMember.findUnique({
@@ -316,7 +316,7 @@ export async function DELETE(request: NextRequest) {
     });
 
     if (!currentMember || !currentMember.isActive) {
-      return Response.json({ error: 'Team member not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team member not found', success: false }, { status: 404 });
     }
 
     const team = await prisma.team.findUnique({
@@ -324,7 +324,7 @@ export async function DELETE(request: NextRequest) {
       select: { ownerUserId: true },
     });
     if (!team) {
-      return Response.json({ error: 'Team not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found', success: false }, { status: 404 });
     }
 
     const isSelfRemoval = authUser.id === currentMember.userId;
@@ -334,12 +334,12 @@ export async function DELETE(request: NextRequest) {
         : await getRequesterTeamRole(currentMember.teamId, authUser.id, team.ownerUserId);
 
     if (!requesterRole) {
-      return Response.json({ error: 'Requester not found in team', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Requester not found in team', success: false }, { status: 404 });
     }
 
     if (isSelfRemoval) {
       if (currentMember.role === 'owner') {
-        return Response.json(
+        return NextResponse.json(
           {
             error: 'Team owner cannot leave the team. Transfer ownership or delete the team.',
             success: false,
@@ -348,7 +348,7 @@ export async function DELETE(request: NextRequest) {
         );
       }
     } else if (requesterRole !== 'owner' && requesterRole !== 'admin') {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Only team owners and admins can remove other members', success: false },
         { status: 403 }
       );
@@ -359,9 +359,9 @@ export async function DELETE(request: NextRequest) {
       data: { isActive: false },
     });
 
-    return Response.json({ message: 'Team member removed successfully', success: true });
+    return NextResponse.json({ message: 'Team member removed successfully', success: true });
   } catch (error) {
     console.error('Error removing team member:', error);
-    return Response.json({ error: 'Failed to remove team member', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to remove team member', success: false }, { status: 500 });
   }
 }

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     const offset = toSafeInt(searchParams.get('offset'), 0, 0, 10000);
 
     if (requestedUserId && authUser.role !== 'admin' && requestedUserId !== authUser.id) {
-      return Response.json({ error: 'Forbidden', success: false }, { status: 403 });
+      return NextResponse.json({ error: 'Forbidden', success: false }, { status: 403 });
     }
 
     const targetUserId =
@@ -110,10 +110,10 @@ export async function GET(request: NextRequest) {
       })),
     }));
 
-    return Response.json({ teams, success: true });
+    return NextResponse.json({ teams, success: true });
   } catch (error) {
     console.error('Error fetching teams:', error);
-    return Response.json({ error: 'Failed to fetch teams', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch teams', success: false }, { status: 500 });
   }
 }
 
@@ -121,14 +121,14 @@ export async function POST(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const name = typeof body.name === 'string' ? body.name.trim() : '';
 
     if (!name) {
-      return Response.json({ error: 'name is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'name is required', success: false }, { status: 400 });
     }
 
     const ownerUserId =
@@ -179,10 +179,10 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return Response.json({ team: fullTeam ?? team, success: true }, { status: 201 });
+    return NextResponse.json({ team: fullTeam ?? team, success: true }, { status: 201 });
   } catch (error) {
     console.error('Error creating team:', error);
-    return Response.json({ error: 'Failed to create team', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to create team', success: false }, { status: 500 });
   }
 }
 
@@ -190,13 +190,13 @@ export async function PUT(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const teamId = typeof body.teamId === 'string' ? body.teamId : '';
     if (!teamId) {
-      return Response.json({ error: 'Team ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Team ID is required', success: false }, { status: 400 });
     }
 
     const team = await prisma.team.findUnique({
@@ -205,11 +205,11 @@ export async function PUT(request: NextRequest) {
     });
 
     if (!team || !team.isActive) {
-      return Response.json({ error: 'Team not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found', success: false }, { status: 404 });
     }
 
     if (authUser.role !== 'admin' && team.ownerUserId !== authUser.id) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Only team owners can update team details', success: false },
         { status: 403 }
       );
@@ -230,7 +230,7 @@ export async function PUT(request: NextRequest) {
     }
 
     if (Object.keys(updateData).length === 0) {
-      return Response.json({ error: 'No valid fields to update', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });
     }
 
     const data = await prisma.team.update({
@@ -238,10 +238,10 @@ export async function PUT(request: NextRequest) {
       data: updateData,
     });
 
-    return Response.json({ team: data, success: true });
+    return NextResponse.json({ team: data, success: true });
   } catch (error) {
     console.error('Error updating team:', error);
-    return Response.json({ error: 'Failed to update team', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update team', success: false }, { status: 500 });
   }
 }
 
@@ -249,13 +249,13 @@ export async function DELETE(request: NextRequest) {
   try {
     const authUser = await getAuthUser();
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = (await request.json()) as Record<string, unknown>;
     const teamId = typeof body.teamId === 'string' ? body.teamId : '';
     if (!teamId) {
-      return Response.json({ error: 'Team ID is required', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'Team ID is required', success: false }, { status: 400 });
     }
 
     const team = await prisma.team.findUnique({
@@ -264,11 +264,11 @@ export async function DELETE(request: NextRequest) {
     });
 
     if (!team || !team.isActive) {
-      return Response.json({ error: 'Team not found', success: false }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found', success: false }, { status: 404 });
     }
 
     if (authUser.role !== 'admin' && team.ownerUserId !== authUser.id) {
-      return Response.json(
+      return NextResponse.json(
         { error: 'Only team owners can delete teams', success: false },
         { status: 403 }
       );
@@ -279,9 +279,9 @@ export async function DELETE(request: NextRequest) {
       data: { isActive: false },
     });
 
-    return Response.json({ message: 'Team deleted successfully', success: true });
+    return NextResponse.json({ message: 'Team deleted successfully', success: true });
   } catch (error) {
     console.error('Error deleting team:', error);
-    return Response.json({ error: 'Failed to delete team', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to delete team', success: false }, { status: 500 });
   }
 }

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -1,5 +1,5 @@
 // app/api/users/me/route.ts
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
@@ -7,7 +7,7 @@ export async function PATCH(request: NextRequest) {
   try {
     const authUser = await getAuthUser(request);
     if (!authUser) {
-      return Response.json({ error: 'Unauthorized', success: false }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
     }
 
     const body = await request.json();
@@ -18,11 +18,11 @@ export async function PATCH(request: NextRequest) {
     if (typeof body.username === 'string') {
       const username = body.username.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
       if (username.length < 3 || username.length > 30) {
-        return Response.json({ error: 'Username must be 3-30 characters (letters, numbers, - _)', success: false }, { status: 400 });
+        return NextResponse.json({ error: 'Username must be 3-30 characters (letters, numbers, - _)', success: false }, { status: 400 });
       }
       const taken = await prisma.user.findUnique({ where: { username }, select: { id: true } });
       if (taken && taken.id !== authUser.id) {
-        return Response.json({ error: 'Username already taken', success: false }, { status: 409 });
+        return NextResponse.json({ error: 'Username already taken', success: false }, { status: 409 });
       }
       userUpdate.username = username;
     }
@@ -34,7 +34,7 @@ export async function PATCH(request: NextRequest) {
     if (typeof body.discord === 'string') userUpdate.discord = body.discord.trim() || null;
 
     if (Object.keys(userUpdate).length === 0) {
-      return Response.json({ error: 'No valid fields to update', success: false }, { status: 400 });
+      return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });
     }
 
     const updated = await prisma.user.update({
@@ -58,9 +58,9 @@ export async function PATCH(request: NextRequest) {
       }
     }
 
-    return Response.json({ user: updated, success: true });
+    return NextResponse.json({ user: updated, success: true });
   } catch (error) {
     console.error('Error updating user profile:', error);
-    return Response.json({ error: 'Failed to update profile', success: false }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update profile', success: false }, { status: 500 });
   }
 }

--- a/app/dashboard/quests/page.tsx
+++ b/app/dashboard/quests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
@@ -104,6 +104,23 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 
 const EMPTY_QUESTS: Quest[] = [];
 
+// Debounce utility
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
 export default function QuestsPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -118,18 +135,21 @@ export default function QuestsPage() {
   const [joiningPartyId, setJoiningPartyId] = useState<string | null>(null);
   const [isBootcamp, setIsBootcamp] = useState(false);
 
+  // Debounce search term to avoid excessive API calls
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
+
   const isAdmin = session?.user?.role === 'admin';
   const shouldFetch = status === 'authenticated' && session?.user?.role !== 'company';
 
   const apiUrl = useMemo(() => {
     const params = new URLSearchParams({ status: 'available', limit: '60' });
-    if (searchTerm) params.set('search', searchTerm);
+    if (debouncedSearchTerm) params.set('search', debouncedSearchTerm);
     if (difficulty !== 'all') params.set('difficulty', difficulty);
     if (track !== 'all') params.set('track', track);
     if (category !== 'all') params.set('category', category);
     if (sort !== 'newest') params.set('sort', sort);
     return `/api/quests?${params.toString()}`;
-  }, [searchTerm, difficulty, track, category, sort]);
+  }, [debouncedSearchTerm, difficulty, track, category, sort]);
 
   const { data, loading, error, refetch } = useApiFetch<{ success: boolean; quests: Quest[]; error?: string }>(apiUrl, {
     skip: !shouldFetch,

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 // Types
 interface Notification {
@@ -54,7 +55,7 @@ export default function NotificationBell({ userId }: NotificationBellProps) {
       
       try {
         setLoading(true);
-        const response = await fetch(`/api/notifications?userId=${userId}&limit=10`);
+        const response = await fetchWithAuth(`/api/notifications?userId=${userId}&limit=10`);
         const data = await response.json();
         
         if (data.success) {
@@ -88,7 +89,7 @@ export default function NotificationBell({ userId }: NotificationBellProps) {
 
   const markAsRead = async (notificationId: string) => {
     try {
-      const response = await fetch('/api/notifications', {
+      const response = await fetchWithAuth('/api/notifications', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -121,7 +122,7 @@ export default function NotificationBell({ userId }: NotificationBellProps) {
 
   const markAllAsRead = async () => {
     try {
-      const response = await fetch('/api/notifications', {
+      const response = await fetchWithAuth('/api/notifications', {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -151,7 +152,7 @@ export default function NotificationBell({ userId }: NotificationBellProps) {
 
   const deleteNotification = async (notificationId: string) => {
     try {
-      const response = await fetch('/api/notifications', {
+      const response = await fetchWithAuth('/api/notifications', {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/components/QualityAssuranceDashboard.tsx
+++ b/components/QualityAssuranceDashboard.tsx
@@ -24,6 +24,7 @@ import {
   Target,
   TrendingUp
 } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 import { toast } from 'sonner';
 
 // Types
@@ -132,14 +133,30 @@ export default function QualityAssuranceDashboard({ userId, userRole }: QualityA
   // Fetch quality metrics
   useEffect(() => {
     const fetchMetrics = async () => {
-      // In a real implementation, this would call an API to get metrics
-      // For now, we'll simulate the data
-      setMetrics({
-        totalSubmissions: 128,
-        reviewedSubmissions: 95,
-        averageQualityScore: 7.8,
-        approvalRate: 78
-      });
+      try {
+        const response = await fetchWithAuth('/api/quests/submissions?status=all');
+        const data = await response.json();
+
+        if (data.success && data.submissions) {
+          const subs = data.submissions;
+          const reviewed = subs.filter((s: Submission) => s.qualityScore != null).length;
+          const qualityScores = subs.filter((s: Submission) => s.qualityScore != null).map((s: Submission) => s.qualityScore as number);
+          const avgScore = qualityScores.length > 0
+            ? Number((qualityScores.reduce((a: number, b: number) => a + b, 0) / qualityScores.length).toFixed(1))
+            : 0;
+          const approved = subs.filter((s: Submission) => s.status === 'approved' || s.status === 'completed').length;
+          const approvalRate = reviewed > 0 ? Math.round((approved / reviewed) * 100) : 0;
+
+          setMetrics({
+            totalSubmissions: subs.length,
+            reviewedSubmissions: reviewed,
+            averageQualityScore: avgScore,
+            approvalRate: approvalRate,
+          });
+        }
+      } catch (error) {
+        console.error('Error fetching metrics:', error);
+      }
     };
 
     fetchMetrics();

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -6,13 +6,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableHead, 
-  TableHeader, 
-  TableRow 
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -25,6 +25,7 @@ import {
   AlertTriangle
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 // Types
 interface User {
@@ -86,7 +87,7 @@ export default function AdminDashboard() {
     const fetchUsers = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`/api/admin/users?search=${userSearch}`);
+        const response = await fetchWithAuth(`/api/admin/users?search=${userSearch}`);
         const data = await response.json();
         
         if (data.success) {
@@ -112,7 +113,7 @@ export default function AdminDashboard() {
     const fetchQuests = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`/api/admin/quests?search=${questSearch}`);
+        const response = await fetchWithAuth(`/api/admin/quests?search=${questSearch}`);
         const data = await response.json();
         
         if (data.success) {
@@ -135,7 +136,7 @@ export default function AdminDashboard() {
 
   const handleUserAction = async (userId: string, action: 'verify' | 'deactivate' | 'setRole', role?: string) => {
     try {
-      const response = await fetch('/api/admin/users', {
+      const response = await fetchWithAuth('/api/admin/users', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -153,7 +154,7 @@ export default function AdminDashboard() {
       if (data.success) {
         toast.success('User updated successfully');
         // Refresh the user list
-        const updatedUsersResponse = await fetch(`/api/admin/users?search=${userSearch}`);
+        const updatedUsersResponse = await fetchWithAuth(`/api/admin/users?search=${userSearch}`);
         const updatedUsersData = await updatedUsersResponse.json();
         
         if (updatedUsersData.success) {
@@ -170,7 +171,7 @@ export default function AdminDashboard() {
 
   const handleQuestAction = async (questId: string, action: 'activate' | 'deactivate' | 'cancel') => {
     try {
-      const response = await fetch('/api/admin/quests', {
+      const response = await fetchWithAuth('/api/admin/quests', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -186,7 +187,7 @@ export default function AdminDashboard() {
       if (data.success) {
         toast.success('Quest updated successfully');
         // Refresh the quest list
-        const updatedQuestsResponse = await fetch(`/api/admin/quests?search=${questSearch}`);
+        const updatedQuestsResponse = await fetchWithAuth(`/api/admin/quests?search=${questSearch}`);
         const updatedQuestsData = await updatedQuestsResponse.json();
         
         if (updatedQuestsData.success) {
@@ -478,6 +479,12 @@ export default function AdminDashboard() {
         </TabsContent>
 
         <TabsContent value="analytics" className="space-y-6">
+          {(() => {
+            const totalQuests = quests.length;
+            const completedCount = quests.filter(q => q.status === 'completed').length;
+            const avgCompletionRate = totalQuests > 0 ? Math.round((completedCount / totalQuests) * 100) : 0;
+            return (
+          <>
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -486,7 +493,7 @@ export default function AdminDashboard() {
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">{users.length}</div>
-                <p className="text-xs text-muted-foreground">+12% from last month</p>
+                <p className="text-xs text-muted-foreground">{users.length} registered users</p>
               </CardContent>
             </Card>
             <Card>
@@ -498,7 +505,7 @@ export default function AdminDashboard() {
                 <div className="text-2xl font-bold">
                   {quests.filter(q => q.status === 'available' || q.status === 'in_progress').length}
                 </div>
-                <p className="text-xs text-muted-foreground">+3 from last week</p>
+                <p className="text-xs text-muted-foreground">Currently open or in progress</p>
               </CardContent>
             </Card>
             <Card>
@@ -510,7 +517,7 @@ export default function AdminDashboard() {
                 <div className="text-2xl font-bold">
                   {quests.filter(q => q.status === 'completed').length}
                 </div>
-                <p className="text-xs text-muted-foreground">+8% from last month</p>
+                <p className="text-xs text-muted-foreground">Total completed quests</p>
               </CardContent>
             </Card>
             <Card>
@@ -519,8 +526,9 @@ export default function AdminDashboard() {
                 <AlertTriangle className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">76%</div>
-                <p className="text-xs text-muted-foreground">+5% from last month</p>
+                  {totalQuests > 0 ? Math.round((quests.filter(q => q.status === 'completed').length / totalQuests) * 100) : 0}%
+                </div>
+                <p className="text-xs text-muted-foreground">Quest completion rate</p>
               </CardContent>
             </Card>
           </div>
@@ -534,34 +542,28 @@ export default function AdminDashboard() {
               <div className="space-y-4">
                 <div className="flex items-center">
                   <div className="ml-4 space-y-1">
-                    <p className="text-sm font-medium">New user registration</p>
-                    <p className="text-sm text-muted-foreground">John Doe joined as an Adventurer</p>
-                  </div>
-                  <div className="ml-auto text-xs text-muted-foreground">
-                    2 hours ago
+                    <p className="text-sm font-medium">Users</p>
+                    <p className="text-sm text-muted-foreground">{users.length} registered on platform</p>
                   </div>
                 </div>
                 <div className="flex items-center">
                   <div className="ml-4 space-y-1">
-                    <p className="text-sm font-medium">Quest completed</p>
-                    <p className="text-sm text-muted-foreground">&quot;API Integration&quot; completed by Jane Smith</p>
-                  </div>
-                  <div className="ml-auto text-xs text-muted-foreground">
-                    4 hours ago
+                    <p className="text-sm font-medium">Quests</p>
+                    <p className="text-sm text-muted-foreground">{totalQuests} total quests on platform</p>
                   </div>
                 </div>
                 <div className="flex items-center">
                   <div className="ml-4 space-y-1">
-                    <p className="text-sm font-medium">Company verified</p>
-                    <p className="text-sm text-muted-foreground">TechCorp verified their account</p>
-                  </div>
-                  <div className="ml-auto text-xs text-muted-foreground">
-                    1 day ago
+                    <p className="text-sm font-medium">Quest Completion</p>
+                    <p className="text-sm text-muted-foreground">{completedCount} completed out of {totalQuests} total</p>
                   </div>
                 </div>
               </div>
             </CardContent>
           </Card>
+          </>
+            );
+          })()}
         </TabsContent>
       </Tabs>
 

--- a/components/company/CompanyStats.tsx
+++ b/components/company/CompanyStats.tsx
@@ -33,7 +33,7 @@ export function CompanyStats({ companyQuests }: CompanyStatsProps) {
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{totalQuests}</div>
-          <p className="text-xs text-muted-foreground">+{totalQuests} this month</p>
+          <p className="text-xs text-muted-foreground">Total quests posted</p>
         </CardContent>
       </Card>
       <Card>

--- a/lib/hooks/useApiFetch.ts
+++ b/lib/hooks/useApiFetch.ts
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface ApiState<T> {
   data: T | null;
@@ -85,12 +86,23 @@ export function useApiFetch<T = unknown>(
         fetchOptions.body = JSON.stringify(body);
       }
 
-      const response = await fetch(endpoint, fetchOptions);
-      const data = await response.json();
+      // Use fetchWithAuth to handle 401s and include credentials
+      const response = await fetchWithAuth(endpoint, fetchOptions);
+      let data: Record<string, unknown>;
 
+      // Try to parse JSON, handle non-JSON responses gracefully
+      try {
+        data = await response.json();
+      } catch {
+        setState(prev => ({ ...prev, error: 'Invalid response from server', loading: false }));
+        return null;
+      }
+
+      // Handle HTTP errors
       if (!response.ok) {
-        const errorMsg = errorMessage || data.error || `Failed to ${method.toLowerCase()} data`;
-        if (showToast) {
+        // Don't show toast for 401 - fetchWithAuth already redirects
+        const errorMsg = errorMessage || (data.error as string) || `Failed to ${method.toLowerCase()} data`;
+        if (showToast && response.status !== 401) {
           toast.error(errorMsg);
         }
         setState(prev => ({ ...prev, error: errorMsg, loading: false }));
@@ -101,13 +113,43 @@ export function useApiFetch<T = unknown>(
         toast.success(successMessage);
       }
 
+      // Normalize response: handle various API response shapes
+      // The API returns { success: boolean; quests/data/error: ... }
+      // We need to extract the actual data regardless of shape
+      let extractedData: unknown;
+
+      if (data && typeof data === 'object') {
+        // Direct data field
+        if ('data' in data && data.data !== undefined) {
+          extractedData = data.data;
+        }
+        // Wrapped in success object (e.g., { success: true, quests: [...] })
+        else if ('success' in data && data.success) {
+          // Try common payload keys
+          extractedData = (data.quests as unknown)
+            ?? (data.users as unknown)
+            ?? (data.quest as unknown)
+            ?? (data.user as unknown)
+            ?? (data.assignments as unknown)
+            ?? (data.submissions as unknown)
+            ?? (data.stats as unknown)
+            ?? data;
+        }
+        // Already unwrapped data
+        else {
+          extractedData = data;
+        }
+      } else {
+        extractedData = data;
+      }
+
       setState({
-        data: data.data || data,
+        data: extractedData as T,
         loading: false,
         error: null,
       });
 
-      return data.data || data;
+      return extractedData as T;
     } catch (error) {
       const errorMsg = errorMessage || (error instanceof Error ? error.message : 'Network error occurred');
       if (showToast) {

--- a/lib/quest-constants.ts
+++ b/lib/quest-constants.ts
@@ -54,5 +54,7 @@ export const RANK_COLORS: Record<string, string> = {
 
 /** Returns the quest list path for a given user role. */
 export function getQuestListPath(role: string): string {
-  return role === 'admin' ? '/admin/quests' : '/dashboard/company/quests';
+  if (role === 'admin') return '/admin/quests';
+  if (role === 'company') return '/dashboard/company/quests';
+  return '/dashboard/quests';
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,8 +17,18 @@ const protectedRoutes: { [key: string]: UserRole[] } = {
   '/dashboard/company/create-quest': ['company', 'admin'],
   '/dashboard/company/analytics': ['company', 'admin'],
   '/dashboard/company/profile': ['company', 'admin'],
+  '/dashboard/company/payments': ['company', 'admin'],
+  '/dashboard/company/quests/[id]': ['company', 'admin'],
+  '/dashboard/company/quests/[id]/edit': ['company', 'admin'],
+  '/dashboard/earnings': ['adventurer'],
+  '/dashboard/completed-quests': ['adventurer'],
+  '/dashboard/my-payments': ['adventurer'],
+  '/dashboard/settings': ['adventurer', 'company', 'admin'],
+  '/dashboard/[id]': ['adventurer', 'company', 'admin'],
   '/admin': ['admin'],
   '/admin/quests': ['admin'],
+  '/admin/qa-queue': ['admin'],
+  '/admin/api-budgets': ['admin'],
 };
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
Cleaned version of PR #228 — drops the superseded landing redesign commit. Fixes:\n- useApiFetch now uses fetchWithAuth (credentials) + handles multiple response shapes\n- NotificationBell: all 4 fetch calls use fetchWithAuth\n- getQuestListPath: returns /dashboard/quests for adventurer (was company path)\n- middleware: 10 missing protected routes added\n- dashboard: replaces hardcoded metrics with real API data\n- 15 API route files: Response.json → NextResponse.json