### PR TITLE
feat: premium UI components (FinalCTA, SocialProof, GlassCard, GlowButton, category pages)

### DIFF
--- a/app/quests/category/[slug]/client.tsx
+++ b/app/quests/category/[slug]/client.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Search, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { RankBadge } from '@/components/ui/rank-badge';
+import type { UserRank } from '@prisma/client';
+
+interface PublicQuest {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: string;
+  xpReward: number;
+  paymentAmount: number | null;
+  category: string | null;
+  skills: string[];
+  company: { name: string } | null;
+}
+
+interface CategoryQuestsClientProps {
+  slug: string;
+  title: string;
+  description: string;
+  dbCategory: string;
+}
+
+export default function CategoryQuestsClient({
+  title,
+  description,
+  dbCategory,
+}: CategoryQuestsClientProps) {
+  const [quests, setQuests] = useState<PublicQuest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    async function fetchQuests() {
+      try {
+        const res = await fetch(`/api/public/quests?category=${dbCategory}`);
+        if (res.ok) {
+          const data = await res.json();
+          setQuests(data.quests ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchQuests();
+  }, [dbCategory]);
+
+  const filtered = quests.filter(
+    (q) =>
+      q.title.toLowerCase().includes(search.toLowerCase()) ||
+      q.description.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-950 py-12">
+      <div className="mx-auto max-w-5xl px-6">
+        {/* Header */}
+        <div className="mb-10">
+          <Link
+            href="/quests"
+            className="mb-4 inline-flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            ← All Quests
+          </Link>
+          <h1 className="text-3xl font-bold text-white md:text-4xl">{title}</h1>
+          <p className="mt-2 text-slate-400">{description}</p>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-8">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <Input
+            placeholder="Search quests..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 bg-slate-900 border-slate-800 text-slate-200 placeholder:text-slate-600 focus-visible:ring-orange-500/30"
+          />
+        </div>
+
+        {/* Quest grid */}
+        {loading ? (
+          <div className="flex items-center justify-center py-24">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-600" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="py-24 text-center">
+            <p className="text-slate-500">
+              {search ? 'No quests match your search.' : 'No quests in this category yet.'}
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {filtered.map((quest) => (
+              <Link key={quest.id} href={`/quests/${quest.id}`} className="group block">
+                <div className="h-full rounded-2xl border border-slate-800 bg-slate-900 p-5 transition-all duration-200 group-hover:border-slate-700 group-hover:bg-slate-800/80">
+                  <div className="mb-3 flex items-start justify-between gap-3">
+                    <h3 className="font-semibold text-white group-hover:text-orange-400 transition-colors line-clamp-2">
+                      {quest.title}
+                    </h3>
+                    <RankBadge rank={quest.difficulty as UserRank} size="sm" />
+                  </div>
+                  <p className="text-xs text-slate-400 line-clamp-2 mb-4">{quest.description}</p>
+                  <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap gap-1.5">
+                      {quest.skills.slice(0, 3).map((skill) => (
+                        <Badge
+                          key={skill}
+                          variant="outline"
+                          className="text-[10px] border-slate-700 text-slate-400"
+                        >
+                          {skill}
+                        </Badge>
+                      ))}
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="text-xs font-bold text-orange-400">+{quest.xpReward} XP</p>
+                      {quest.paymentAmount && quest.paymentAmount > 0 ? (
+                        <p className="text-[10px] text-slate-500">
+                          ₹{quest.paymentAmount.toLocaleString()}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/quests/category/[slug]/page.tsx
+++ b/app/quests/category/[slug]/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import CategoryQuestsClient from './client';
+
+const categoryMeta: Record<string, { title: string; description: string; dbValue: string }> = {
+  'web-development': {
+    title: 'Web Development Quests',
+    description: 'Full-stack, frontend, and backend web development quests.',
+    dbValue: 'web_development',
+  },
+  'mobile-development': {
+    title: 'Mobile Development Quests',
+    description: 'iOS, Android, and cross-platform mobile development quests.',
+    dbValue: 'mobile_development',
+  },
+  'ai-ml': {
+    title: 'AI & ML Quests',
+    description: 'Machine learning, NLP, computer vision, and AI integration quests.',
+    dbValue: 'ai_ml',
+  },
+  'devops': {
+    title: 'DevOps & Infrastructure Quests',
+    description: 'CI/CD, cloud infrastructure, Kubernetes, and SRE quests.',
+    dbValue: 'devops',
+  },
+  'data-engineering': {
+    title: 'Data Engineering Quests',
+    description: 'Data pipelines, ETL, analytics engineering, and warehouse quests.',
+    dbValue: 'data_engineering',
+  },
+  'security': {
+    title: 'Security Quests',
+    description: 'Penetration testing, code audits, and security hardening quests.',
+    dbValue: 'security',
+  },
+  'blockchain': {
+    title: 'Blockchain & Web3 Quests',
+    description: 'Smart contracts, DeFi protocols, and Web3 integration quests.',
+    dbValue: 'blockchain',
+  },
+  'open-source': {
+    title: 'Open Source Quests',
+    description: 'Contribute to real open source projects and build your public portfolio.',
+    dbValue: 'open_source',
+  },
+  'design-systems': {
+    title: 'Design Systems Quests',
+    description: 'Component libraries, design tokens, and UI engineering quests.',
+    dbValue: 'design_systems',
+  },
+  'api-integration': {
+    title: 'API Integration Quests',
+    description: 'Third-party API integrations, webhooks, and platform connectors.',
+    dbValue: 'api_integration',
+  },
+};
+
+export async function generateStaticParams() {
+  return Object.keys(categoryMeta).map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const meta = categoryMeta[slug];
+  if (!meta) return {};
+  return {
+    title: `${meta.title} — Adventurers Guild`,
+    description: meta.description,
+  };
+}
+
+export default async function CategoryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const meta = categoryMeta[slug];
+  if (!meta) notFound();
+
+  return (
+    <CategoryQuestsClient
+      slug={slug}
+      title={meta.title}
+      description={meta.description}
+      dbCategory={meta.dbValue}
+    />
+  );
+}

--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ArrowRight, Check, Zap } from 'lucide-react';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { GlowButton } from '@/components/ui/glow-button';
+
+function Counter({ target, label }: { target: number; label: string }) {
+  const [count, setCount] = useState(0);
+  const ref = useRef<HTMLDivElement>(null);
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAnimated.current) {
+          hasAnimated.current = true;
+          const duration = 2000;
+          const steps = 60;
+          const increment = target / steps;
+          let current = 0;
+          const timer = setInterval(() => {
+            current += increment;
+            if (current >= target) {
+              setCount(target);
+              clearInterval(timer);
+            } else {
+              setCount(Math.floor(current));
+            }
+          }, duration / steps);
+        }
+      },
+      { threshold: 0.3 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [target]);
+
+  return (
+    <div ref={ref} className="text-center">
+      <p className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+        {count.toLocaleString()}+
+      </p>
+      <p className="mt-1 text-xs text-slate-500">{label}</p>
+    </div>
+  );
+}
+
+const stats = [
+  { target: 500, label: 'Quests completed' },
+  { target: 200, label: 'Active developers' },
+  { target: 50, label: 'Partner companies' },
+  { target: 94, label: '% Satisfaction rate' },
+];
+
+const features = [
+  'No equity required — you keep 100% of what you earn',
+  'Real production tasks from actual companies',
+  'Hand-reviewed submissions with detailed feedback',
+  'Rank-based progression from F to S-Rank',
+  'Built-in portfolio of completed work',
+];
+
+export default function FinalCTA() {
+  return (
+    <section className="relative overflow-hidden border-t border-slate-800/60 bg-slate-950 py-24 md:py-32">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'radial-gradient(ellipse 70% 40% at 30% 0%, rgba(99,102,241,0.08), transparent), radial-gradient(ellipse 60% 35% at 70% 100%, rgba(249,115,22,0.05), transparent)',
+        }}
+      />
+
+      {/* Dot grid */}
+      <div
+        className="absolute inset-0 pointer-events-none opacity-[0.03]"
+        style={{
+          backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.8) 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+        }}
+      />
+
+      <div className="relative container mx-auto max-w-6xl px-6">
+        {/* Stats */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="mb-20 grid grid-cols-2 gap-8 md:grid-cols-4"
+        >
+          {stats.map((s) => (
+            <Counter key={s.label} target={s.target} label={s.label} />
+          ))}
+        </motion.div>
+
+        {/* Main CTA */}
+        <div className="mx-auto max-w-3xl text-center">
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4 }}
+            className="mb-3 inline-flex items-center gap-2 rounded-full border border-indigo-800/30 bg-indigo-950/30 px-3.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-indigo-400"
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-indigo-400 animate-pulse" />
+            Now accepting adventurers
+          </motion.p>
+
+          <motion.h2
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: 0.1 }}
+            className="text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl"
+          >
+            Ship code.{' '}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400">
+              Level up.
+            </span>{' '}
+            Get paid.
+          </motion.h2>
+
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: 0.2 }}
+            className="mx-auto mt-5 max-w-xl text-sm leading-relaxed text-slate-400"
+          >
+            Join a growing community of developers earning real income through quest-based work.
+            No applications, no interviews — just code that ships.
+          </motion.p>
+
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: 0.3 }}
+            className="mt-8 flex flex-wrap items-center justify-center gap-3"
+          >
+            <Link href="/register">
+              <GlowButton size="lg">
+                Create Free Account <Zap className="h-4 w-4" />
+              </GlowButton>
+            </Link>
+            <Link href="/quests">
+              <GlowButton variant="secondary" size="lg">
+                Browse Quests <ArrowRight className="h-4 w-4" />
+              </GlowButton>
+            </Link>
+          </motion.div>
+
+          {/* Feature list */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+            className="mt-10 grid gap-2 text-left sm:grid-cols-2 sm:gap-x-8"
+          >
+            {features.map((f) => (
+              <div key={f} className="flex items-start gap-2.5">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                <span className="text-xs text-slate-400">{f}</span>
+              </div>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/SocialProof.tsx
+++ b/components/landing/SocialProof.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const companies = [
+  { name: 'Stripe', symbol: 'S' },
+  { name: 'Vercel', symbol: 'V' },
+  { name: 'Linear', symbol: 'L' },
+  { name: 'Supabase', symbol: 'S' },
+  { name: 'Railway', symbol: 'R' },
+  { name: 'Cal.com', symbol: 'C' },
+  { name: 'Figma', symbol: 'F' },
+  { name: 'Notion', symbol: 'N' },
+];
+
+export default function SocialProof() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isPaused, setIsPaused] = useState(false);
+
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+    let animationId: number;
+
+    function animate() {
+      if (!scrollEl || isPaused) {
+        animationId = requestAnimationFrame(animate);
+        return;
+      }
+      scrollEl.scrollLeft += 0.5;
+      if (scrollEl.scrollLeft >= scrollEl.scrollWidth / 2) {
+        scrollEl.scrollLeft = 0;
+      }
+      animationId = requestAnimationFrame(animate);
+    }
+    animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [isPaused]);
+
+  const items = [...companies, ...companies];
+
+  return (
+    <section className="border-t border-slate-800/60 bg-slate-900/50 py-12">
+      <div className="mx-auto mb-6 max-w-6xl px-6 text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.15em] text-slate-600">
+          Trusted by developers building for
+        </p>
+      </div>
+
+      <div
+        ref={scrollRef}
+        onMouseEnter={() => setIsPaused(true)}
+        onMouseLeave={() => setIsPaused(false)}
+        className="flex overflow-x-hidden scrollbar-none"
+      >
+        <div className="flex items-center gap-8 px-8">
+          {items.map((company, i) => (
+            <div
+              key={`${company.name}-${i}`}
+              className="flex shrink-0 items-center gap-2.5 rounded-xl border border-slate-800/60 bg-slate-900/80 px-4 py-2.5"
+            >
+              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-gradient-to-br from-slate-700 to-slate-800 text-[10px] font-bold text-slate-300">
+                {company.symbol}
+              </div>
+              <span className="whitespace-nowrap text-xs font-medium text-slate-400">
+                {company.name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/glass-card.tsx
+++ b/components/ui/glass-card.tsx
@@ -1,0 +1,37 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+interface GlassCardProps extends HTMLAttributes<HTMLDivElement> {
+  hover?: boolean;
+  glow?: 'indigo' | 'emerald' | 'amber' | 'none';
+}
+
+const glowStyles = {
+  indigo: 'hover:border-indigo-800/40 hover:shadow-[0_0_30px_-8px_rgba(99,102,241,0.12)]',
+  emerald: 'hover:border-emerald-800/40 hover:shadow-[0_0_30px_-8px_rgba(16,185,129,0.12)]',
+  amber: 'hover:border-amber-800/40 hover:shadow-[0_0_30px_-8px_rgba(245,158,11,0.12)]',
+  none: '',
+};
+
+const GlassCard = forwardRef<HTMLDivElement, GlassCardProps>(
+  ({ className, hover = true, glow = 'indigo', children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'relative rounded-2xl border border-slate-800/60 bg-gradient-to-b from-slate-900/80 to-slate-900/40 backdrop-blur-sm transition-all duration-300',
+          hover && glowStyles[glow],
+          hover && 'hover:bg-slate-900',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+GlassCard.displayName = 'GlassCard';
+
+export { GlassCard };

--- a/components/ui/glow-button.tsx
+++ b/components/ui/glow-button.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+interface GlowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const GlowButton = forwardRef<HTMLButtonElement, GlowButtonProps>(
+  ({ className, variant = 'primary', size = 'md', children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'relative inline-flex items-center justify-center font-semibold transition-all duration-300 rounded-xl overflow-hidden group',
+          size === 'sm' && 'h-9 px-4 text-xs',
+          size === 'md' && 'h-11 px-6 text-sm',
+          size === 'lg' && 'h-12 px-8 text-base',
+          variant === 'primary' && [
+            'bg-indigo-600 text-white',
+            'hover:bg-indigo-500',
+            'shadow-[0_0_20px_-6px_rgba(99,102,241,0.3)]',
+            'hover:shadow-[0_0_30px_-4px_rgba(99,102,241,0.5)]',
+          ],
+          variant === 'secondary' && [
+            'border border-slate-700 bg-slate-900 text-slate-300',
+            'hover:border-indigo-700/40 hover:bg-slate-800 hover:text-white',
+          ],
+          variant === 'ghost' && [
+            'text-slate-400 hover:text-white hover:bg-slate-800/50',
+          ],
+          className
+        )}
+        {...props}
+      >
+        {variant === 'primary' && (
+          <>
+            <span
+              className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+              style={{
+                background:
+                  'linear-gradient(135deg, rgba(99,102,241,0.15) 0%, rgba(139,92,246,0.15) 50%, rgba(99,102,241,0) 100%)',
+              }}
+            />
+            <span
+              className="absolute -inset-[2px] rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-700"
+              style={{
+                background:
+                  'conic-gradient(from 0deg at 50% 50%, transparent 0%, rgba(99,102,241,0.3) 25%, transparent 50%, rgba(139,92,246,0.3) 75%, transparent 100%)',
+                animation: 'glow-rotate 3s linear infinite',
+              }}
+            />
+          </>
+        )}
+        <span className="relative flex items-center gap-2 z-10">{children}</span>
+      </button>
+    );
+  }
+);
+
+GlowButton.displayName = 'GlowButton';
+
+export { GlowButton };


### PR DESCRIPTION
## Summary

Cherry-picks the genuinely unique and valuable components from PR #253 (`feat/premium-landing-quests`) which was closed due to irreconcilable conflicts with main after the editorial landing redesign in PR #262.

- **`FinalCTA.tsx`** — Animated count-up stats section with intersection observer, editorial headline "Ship code. Level up. Get paid.", framer-motion scroll-reveal, feature checklist
- **`SocialProof.tsx`** — Auto-scrolling company logo carousel (Stripe, Vercel, Linear, Supabase, etc.) that pauses on hover
- **`GlassCard`** — Glassmorphism card with configurable glow variants (indigo/emerald/amber/none), `forwardRef` composition
- **`GlowButton`** — Premium CTA button system with conic-gradient hover animation, 3 variants (primary/secondary/ghost), 3 sizes
- **`app/quests/category/[slug]/`** — SEO-optimized category pages (10 categories: web-dev, mobile, AI/ML, DevOps, etc.) with `generateStaticParams`, per-category metadata, dynamic quest fetching via existing `/api/public/quests?category=` filter

## What was NOT cherry-picked

- Admin analytics changes (already superseded on main)
- CTASection changes (already replaced by main's editorial version)
- Reddit automation (intentionally deprioritized)
- OG image route (already exists on main via PR #236)

## Test plan

- [ ] `npm run type-check` — passes (verified)
- [ ] `npm run lint` — passes (verified, no new errors)
- [ ] Visit `/quests/category/web-development` — should load quest grid
- [ ] `FinalCTA` and `SocialProof` can be imported in `app/home/page.tsx` to use
- [ ] `GlowButton` and `GlassCard` available as design primitives for any new landing sections

## Co-authorship

Original implementation credit: @Adil2009700 (PR #253)

🤖 Generated with [Claude Code](https://claude.com/claude-code)