### PR TITLE
fix: company auth signup and error messages

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -9,7 +9,7 @@ const registerSchema = z.object({
   password: z.string().min(8, 'Password must be at least 8 characters'),
   role: z.enum(['adventurer', 'company']).default('adventurer'),
   companyName: z.string().optional(),
-  username: z.string().min(3, 'Username must be at least 3 characters').max(20, 'Username must be at most 20 characters').regex(/^[a-z0-9]+$/, 'Username can only contain lowercase letters and numbers'),
+  username: z.string().min(3, 'Username must be at least 3 characters').max(20, 'Username must be at most 20 characters').regex(/^[a-z0-9]+$/, 'Username can only contain lowercase letters and numbers').optional(),
 });
 
 export async function POST(request: NextRequest) {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -35,7 +35,10 @@ export default function LoginPage() {
   }, [status, session, router]);
 
   async function handleLogin() {
-    if (!email || !password) return;
+    if (!email || !password) {
+      toast.error('Please enter email and password');
+      return;
+    }
     setIsLoading(true);
     try {
       const result = await signIn('credentials', {

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -50,8 +50,14 @@ function RegisterForm() {
     const password = role === 'company' ? cPassword : aPassword;
     const name = role === 'company' ? cName : aName;
 
-    if (!email || !password || !name) return;
-    if (role === 'adventurer' && !aUsername) return;
+    if (!email || !password || !name) {
+      toast.error(role === 'company' ? 'Please fill in all fields' : 'Please fill in all fields');
+      return;
+    }
+    if (role === 'adventurer' && !aUsername) {
+      toast.error('Username is required');
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -78,7 +84,13 @@ function RegisterForm() {
       }
 
       toast.success('Account created! Logging you in...');
-      await signIn('credentials', { email, password, callbackUrl: '/dashboard' });
+      const signInResult = await signIn('credentials', { email, password, callbackUrl: '/dashboard' });
+
+      if (!signInResult?.ok) {
+        toast.error(signInResult?.error || 'Login failed after registration');
+        setIsLoading(false);
+      }
+      // If signIn succeeds, the redirect will happen and component unmounts
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Registration failed');
       setIsLoading(false);


### PR DESCRIPTION
## Summary

Fixed three critical auth flow issues:

1. **Company signup failed** — schema incorrectly required username for all roles (companies don't need usernames)
2. **Silent field validation** — empty field submissions showed no error toast, leaving button stuck in loading state
3. **Stuck loading after registration** — if login failed after successful signup, loading state never reset

## Test Plan

- [ ] Company signup succeeds without username field
- [ ] Company signup fails with error if company name is missing
- [ ] Empty field submission shows error toast
- [ ] Error messages properly display to user
- [ ] Loading state resets on all error paths

🤖 Generated with Claude Code