### PR TITLE
fix: backend security and reliability — audit findings

### DIFF
--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -151,14 +151,11 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { questId, ...rawUpdateFields } = body;
-    const updateFields: Record<string, unknown> = { ...rawUpdateFields };
-    delete updateFields.company_id;
+    const { questId } = body;
     const companyId = authUser.id;
 
-    // Validate required fields
-    if (!questId || !companyId) {
-      return NextResponse.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
+    if (!questId) {
+      return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
 
     // Verify the company owns this quest
@@ -171,23 +168,19 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 
-    // Convert snake_case keys to camelCase for Prisma
-    const prismaUpdateFields: Record<string, unknown> = {};
-    const fieldMapping: Record<string, string> = {
-      detailedDescription: 'detailedDescription',
-      questType: 'questType',
-      xpReward: 'xpReward',
-      skillPointsReward: 'skillPointsReward',
-      monetaryReward: 'monetaryReward',
-      requiredSkills: 'requiredSkills',
-      requiredRank: 'requiredRank',
-      maxParticipants: 'maxParticipants',
-      questCategory: 'questCategory',
-    };
+    // Explicit allowlist — never spread raw body into Prisma to prevent field injection
+    const ALLOWED_FIELDS = [
+      'title', 'description', 'detailedDescription', 'questType', 'difficulty',
+      'xpReward', 'skillPointsReward', 'monetaryReward', 'requiredSkills',
+      'requiredRank', 'maxParticipants', 'questCategory', 'track', 'deadline',
+      'submissionInstructions', 'expectedDeliverables',
+    ] as const;
 
-    for (const [key, value] of Object.entries(updateFields)) {
-      const camelKey = fieldMapping[key] || key;
-      prismaUpdateFields[camelKey] = value;
+    const prismaUpdateFields: Record<string, unknown> = {};
+    for (const field of ALLOWED_FIELDS) {
+      if (field in body && body[field] !== undefined) {
+        prismaUpdateFields[field] = body[field];
+      }
     }
 
     // Update the quest

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getAuthUser } from '@/lib/api-auth';
+import { markAllNotificationsAsRead, deleteNotification } from '@/lib/notification-utils';
 
 export async function GET(req: NextRequest) {
   const authUser = await getAuthUser(req);
@@ -40,12 +41,41 @@ export async function PUT(req: NextRequest) {
     if (userId !== authUser.id) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
 
     await prisma.notification.update({
-      where: { id: notification_id },
+      where: { id: notification_id, userId: authUser.id },
       data: { readAt: is_read ? new Date() : null },
     });
 
     return NextResponse.json({ success: true });
   } catch {
     return NextResponse.json({ success: false, error: 'Failed to update notification' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const authUser = await getAuthUser(req);
+  if (!authUser) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    await markAllNotificationsAsRead(authUser.id);
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Failed to mark notifications as read' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const authUser = await getAuthUser(req);
+  if (!authUser) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const notificationId = searchParams.get('id');
+    if (!notificationId) {
+      return NextResponse.json({ success: false, error: 'Notification ID required' }, { status: 400 });
+    }
+    await deleteNotification(notificationId, authUser.id);
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Failed to delete notification' }, { status: 500 });
   }
 }

--- a/app/api/public/quests/[id]/route.ts
+++ b/app/api/public/quests/[id]/route.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
-import { QuestStatus, QuestTrack } from '@prisma/client';
+import { QuestTrack } from '@prisma/client';
 
 interface QuestParams {
   id: string;
@@ -22,7 +22,6 @@ export async function GET(
             select: {
               id: true,
               name: true,
-              email: true,
               avatar: true,
               companyProfile: {
                 select: { companyName: true },
@@ -114,7 +113,6 @@ export async function GET(
       detailedDescription: q.detailedDescription,
       company: q.company?.companyProfile?.companyName || q.company?.name || 'Unknown Company',
       companyAvatar: q.company?.avatar || null,
-      companyEmail: q.company?.email || null,
       difficulty: q.difficulty,
       xpReward: q.xpReward,
       skillPointsReward: q.skillPointsReward,

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -36,10 +36,17 @@ function isValidEmail(email: string) {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
 }
 
+function escHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 export async function POST(request: NextRequest) {
     try {
         const { name, email } = await request.json()
         const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : ''
+
+        const safeName = typeof name === 'string' ? escHtml(name.slice(0, 200)) : 'Not provided';
+        const safeEmail = escHtml(normalizedEmail);
 
         if (!normalizedEmail || !isValidEmail(normalizedEmail)) {
             return NextResponse.json({
@@ -182,8 +189,8 @@ export async function POST(request: NextRequest) {
     <div style="font-family: Arial, sans-serif; max-width: 500px; margin: 0 auto; padding: 20px; border: 2px solid #667eea; border-radius: 8px;">
       <h2 style="color: #667eea;">⚔️ New Adventurer Joined The Guild!</h2>
       <div style="background: #f8f9fa; padding: 15px; border-radius: 5px; margin: 15px 0;">
-        <p><strong>Name:</strong> ${name || 'Not provided'}</p>
-        <p><strong>Email:</strong> ${email}</p>
+        <p><strong>Name:</strong> ${safeName}</p>
+        <p><strong>Email:</strong> ${safeEmail}</p>
         <p><strong>Joined:</strong> ${new Date().toLocaleString()}</p>
       </div>
       <div style="background: #e3f2fd; padding: 15px; border-radius: 5px; margin: 15px 0;">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,7 +3,7 @@ import type { Session, User } from 'next-auth';
 import type { JWT } from 'next-auth/jwt';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
-import { prisma } from './db';
+import { prisma, withDbRetry } from './db';
 import { env } from '@/lib/env';
 import { UserRole, UserRank } from '@prisma/client';
 
@@ -19,39 +19,40 @@ export const authOptions: AuthOptions = {
         if (!credentials?.email || !credentials?.password) {
           return null;
         }
-        const normalizedEmail = credentials.email.trim().toLowerCase();
+        try {
+          const normalizedEmail = credentials.email.trim().toLowerCase();
 
-        // Find user by email
-        const user = await prisma.user.findUnique({
-          where: { email: normalizedEmail },
-        });
+          const user = await withDbRetry(() =>
+            prisma.user.findUnique({ where: { email: normalizedEmail } })
+          );
 
-        if (!user) {
-          if (process.env.NODE_ENV === 'development') console.log('[Auth] User not found:', normalizedEmail);
+          if (!user) {
+            if (process.env.NODE_ENV === 'development') console.log('[Auth] User not found:', normalizedEmail);
+            return null;
+          }
+
+          const isValidPassword = await bcrypt.compare(credentials.password, user.passwordHash);
+          if (!isValidPassword) {
+            if (process.env.NODE_ENV === 'development') console.log('[Auth] Invalid password for:', credentials.email);
+            return null;
+          }
+
+          // Non-blocking — a cold-start failure here must not block a valid login
+          prisma.user.update({ where: { id: user.id }, data: { lastLoginAt: new Date() } })
+            .catch(e => console.warn('[Auth] lastLoginAt update failed:', e));
+
+          return {
+            id: user.id,
+            email: user.email,
+            name: user.name ?? '',
+            role: user.role as UserRole,
+            rank: user.rank as UserRank,
+            xp: user.xp,
+          };
+        } catch (error) {
+          console.error('[Auth] authorize error:', error);
           return null;
         }
-
-        // Verify password
-        const isValidPassword = await bcrypt.compare(credentials.password, user.passwordHash);
-        if (!isValidPassword) {
-          if (process.env.NODE_ENV === 'development') console.log('[Auth] Invalid password for:', credentials.email);
-          return null;
-        }
-
-        // Update last login
-        await prisma.user.update({
-          where: { id: user.id },
-          data: { lastLoginAt: new Date() },
-        });
-
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name ?? '',
-          role: user.role as UserRole,
-          rank: user.rank as UserRank,
-          xp: user.xp,
-        };
       }
     })
   ],

--- a/middleware.ts
+++ b/middleware.ts
@@ -130,12 +130,9 @@ async function checkAuthAndRole(request: NextRequest, requiredRoles: UserRole[])
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - api (API routes)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * Match all request paths except static assets.
+     * /api/* is intentionally included so rate limiting applies to all API routes.
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
## Summary

Fixed 7 critical/high backend security and reliability issues from codebase audit:

1. **Rate limiting was dead code** — `/api/*` routes excluded from middleware matcher, completely unprotected
2. **Company PII leak** — unauthenticated callers could fetch company email from quest detail endpoint  
3. **Broken notification UI** — PATCH/DELETE handlers missing, "Mark All Read" and delete buttons non-functional
4. **IDOR on notifications** — any user could mark any notification as read via PUT
5. **Field injection in quest updates** — companies could inject arbitrary fields including `status` and `companyId`
6. **XSS in admin email** — user-controlled name/email not HTML-escaped before template interpolation
7. **Neon cold-start breaks login** — unauthorized failure + blocking lastLoginAt update could crash auth

## Changes

### `middleware.ts`
- Remove `api` from matcher negative lookahead so rate limiting runs on `/api/*` routes
- Was completely ineffective; now `strictRateLimit` protects `/api/auth` endpoints

### `app/api/public/quests/[id]/route.ts`
- Remove `email: true` from company select and `companyEmail` from response shape
- Stops leaking login emails to unauthenticated visitors

### `app/api/notifications/route.ts`
- Fix IDOR on PUT: add `userId` scope to where clause (was trusting body userId)
- Add PATCH handler: calls `markAllNotificationsAsRead()` from lib
- Add DELETE handler: calls `deleteNotification()` from lib
- Restores "Mark All Read" and delete functionality

### `app/api/company/quests/route.ts`  
- Replace raw body field-spread (`{ ...rawUpdateFields }`) with explicit allowlist
- Only `title`, `description`, `questType`, `difficulty`, `xpReward`, etc. can be updated
- Prevents injection of `status`, `companyId`, `adminNotes`, `revisionCount`

### `app/api/send-email/route.ts`
- Add `escHtml()` function to escape `<>&"` characters
- HTML-escape `name` (max 200 chars) and `email` before interpolating into admin email template
- Prevents script injection via user-controlled fields

### `lib/auth.ts`
- Wrap entire `authorize` callback in try/catch  
- Use `withDbRetry` for user lookup (handles Neon cold-start)
- Fire `lastLoginAt` update non-blocking with `.catch()` so DB failures don't block login
- Valid login is never blocked by cold-start or logging failures

## Test Plan

- [ ] Rate limiting on `/api/auth/register` and `/api/auth/forgot-password` blocks spam
- [ ] Public quest endpoint no longer returns company email
- [ ] "Mark All Read" button (PATCH) and delete button (DELETE) work in NotificationBell
- [ ] Company cannot update quest `status` or change `companyId` via PUT
- [ ] HTML with `<script>` tags in name field doesn't break admin email
- [ ] Login succeeds even if Neon is cold-starting (concurrent login doesn't see DB failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)