### PR TITLE
fix: password reset token validation and logging

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
     // Generate token
     const token = randomBytes(32).toString('hex');
     const tokenHash = createHash('sha256').update(token).digest('hex');
-    const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
     console.log('[forgot-password] Generated reset token for user:', user.id);
 
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
           <a href="${resetLink}" style="display:inline-block;margin:20px 0;padding:12px 24px;background:#f97316;color:#fff;font-weight:700;font-size:14px;border-radius:8px;text-decoration:none">
             Reset password
           </a>
-          <p style="color:#94a3b8;font-size:12px">This link expires in 1 hour. If you didn't request a reset, ignore this email.</p>
+          <p style="color:#94a3b8;font-size:12px">This link expires in 24 hours. If you didn't request a reset, ignore this email.</p>
           <p style="color:#94a3b8;font-size:11px;word-break:break-all">Or copy this link: ${resetLink}</p>
         </div>
       `,

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -7,15 +7,21 @@ export async function POST(request: NextRequest) {
   try {
     const { token, password } = await request.json();
 
+    console.log('[reset-password] Request received');
+
     if (!token || !password) {
+      console.log('[reset-password] Missing token or password');
       return NextResponse.json({ error: 'Token and password are required' }, { status: 400 });
     }
 
     if (password.length < 8) {
+      console.log('[reset-password] Password too short');
       return NextResponse.json({ error: 'Password must be at least 8 characters' }, { status: 400 });
     }
 
+    console.log('[reset-password] Token received (length:', token.length, ')');
     const tokenHash = createHash('sha256').update(token).digest('hex');
+    console.log('[reset-password] Token hash:', tokenHash.substring(0, 16) + '...');
 
     // Find the token
     const resetToken = await prisma.passwordResetToken.findUnique({
@@ -23,15 +29,29 @@ export async function POST(request: NextRequest) {
       include: { user: true },
     });
 
+    console.log('[reset-password] Token lookup result:', !!resetToken);
+
     if (!resetToken) {
+      console.log('[reset-password] Token not found in database');
       return NextResponse.json({ error: 'Invalid or expired reset token' }, { status: 400 });
     }
 
+    console.log('[reset-password] Token found, checking validity...');
+
     if (resetToken.usedAt) {
+      console.log('[reset-password] Token already used');
       return NextResponse.json({ error: 'This reset token has already been used' }, { status: 400 });
     }
 
-    if (new Date() > resetToken.expiresAt) {
+    const now = new Date();
+    console.log('[reset-password] Expiration check:', {
+      now: now.toISOString(),
+      expiresAt: resetToken.expiresAt.toISOString(),
+      isExpired: now > resetToken.expiresAt,
+    });
+
+    if (now > resetToken.expiresAt) {
+      console.log('[reset-password] Token expired');
       return NextResponse.json({ error: 'Reset token has expired' }, { status: 400 });
     }
 
@@ -49,9 +69,10 @@ export async function POST(request: NextRequest) {
       }),
     ]);
 
+    console.log('[reset-password] Password reset successful for user:', resetToken.userId);
     return NextResponse.json({ message: 'Password reset successful' });
   } catch (error) {
-    console.error('Reset password error:', error);
+    console.error('[reset-password] Error:', error);
     return NextResponse.json({ error: 'Something went wrong' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Problem
Users received password reset emails but got 'invalid or expired token' error when trying to use the link.

## Root Cause
- Token expiration was only 1 hour, possibly causing timeouts
- No logging to debug token lookup/validation issues

## Solution
- **Extended token expiration** from 1 hour → 24 hours (more realistic for email delivery + user action)
- **Added comprehensive logging** to debug:
  - Token lookup in database
  - Token validity checks (used, expired)
  - Timestamps for debugging
- **Updated email** to reflect new 24-hour expiration window

## How to Test
1. Go to `/forgot-password`
2. Enter your email
3. Check inbox for reset link
4. Click the link and reset password
5. Check Vercel logs for `[reset-password]` messages showing token validation flow

## Testing Checklist
- [ ] Email arrives within 1 minute
- [ ] Reset link works when clicked immediately
- [ ] Reset link works after 1 hour wait
- [ ] Check Vercel logs for token validation messages
- [ ] Try with invalid token - should see error