### PR TITLE
fix: resolve login build error and quest data extraction issue

### DIFF
--- a/app/dashboard/quests/page.tsx
+++ b/app/dashboard/quests/page.tsx
@@ -151,10 +151,10 @@ export default function QuestsPage() {
     return `/api/quests?${params.toString()}`;
   }, [debouncedSearchTerm, difficulty, track, category, sort]);
 
-  const { data, loading, error, refetch } = useApiFetch<{ success: boolean; quests: Quest[]; error?: string }>(apiUrl, {
+  const { data, loading, error, refetch } = useApiFetch<Quest[]>(apiUrl, {
     skip: !shouldFetch,
   });
-  const quests = data?.quests ?? EMPTY_QUESTS;
+  const quests = (Array.isArray(data) ? data : []) ?? EMPTY_QUESTS;
 
   useEffect(() => {
     if (status === 'unauthenticated') {

--- a/components/ui/full-screen-signup.tsx
+++ b/components/ui/full-screen-signup.tsx
@@ -347,6 +347,14 @@ function RegisterForm() {
   );
 }
 
+function LoginFormWrapper() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
 /* ─── Main export ────────────────────────────────────────── */
 export interface FullScreenSignupProps {
   mode?: "login" | "register";
@@ -413,7 +421,7 @@ export const FullScreenSignup = ({ mode = "register" }: FullScreenSignupProps) =
             </p>
           </div>
 
-          {isLogin ? <LoginForm /> : <RegisterForm />}
+          {isLogin ? <LoginFormWrapper /> : <RegisterForm />}
         </div>
       </div>
       </div>


### PR DESCRIPTION
## Summary
Fixes two critical blocking issues that were introduced after merging PR #270 (Google Auth):

1. **Login page build failure** — `useSearchParams()` was not wrapped in Suspense boundary, causing build error: "useSearchParams() should be wrapped in a suspense boundary at page "/login""
2. **Quest visibility on authenticated pages** — Dashboard quests page was attempting double-extraction on API response data, causing empty quests list

## Changes
- Wrap `LoginForm` in a `LoginFormWrapper` component with `Suspense` boundary (matching existing `RegisterForm` pattern)
- Update `app/dashboard/quests/page.tsx` useApiFetch type from `{ success: boolean; quests: Quest[]; error?: string }` to `Quest[]` 
- Fix quest extraction logic from `data?.quests ?? []` to `(Array.isArray(data) ? data : []) ?? []`

## Test Plan
- [ ] Build succeeds with `npm run build`
- [ ] Login page renders without build errors
- [ ] Login page accepts credentials and authenticates
- [ ] Google OAuth sign-in works
- [ ] Dashboard quests display correctly for authenticated students (previously showing empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)