### PR TITLE
[codex] admin hardening

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 import {
   Users,
   Target,
@@ -55,6 +56,7 @@ function AnimatedCounter({ value }: { value: number }) {
 }
 
 export default function AdminAnalyticsPage() {
+  const { data: session, status } = useSession();
   const router = useRouter();
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
@@ -65,13 +67,16 @@ export default function AdminAnalyticsPage() {
   );
 
   useEffect(() => {
+    if (status !== 'authenticated' || session?.user?.role !== 'admin') {
+      return;
+    }
     fetchAnalytics();
-  }, [dateRange]);
+  }, [dateRange, session?.user?.role, status]);
 
   const fetchAnalytics = async () => {
     try {
       setLoading(true);
-      const res = await fetch('/api/admin/analytics');
+      const res = await fetch(`/api/admin/analytics?range=${dateRange}`);
       if (res.status === 401) {
         router.push('/login');
         return;
@@ -90,6 +95,17 @@ export default function AdminAnalyticsPage() {
   const toggleSection = (section: string) => {
     setExpandedSection(expandedSection === section ? null : section);
   };
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+      return;
+    }
+
+    if (status === 'authenticated' && session?.user?.role !== 'admin') {
+      router.push('/dashboard');
+    }
+  }, [router, session?.user?.role, status]);
 
   const StatCard = ({
     title,
@@ -369,11 +385,11 @@ export default function AdminAnalyticsPage() {
 
                 {/* Quests by Track */}
                 <div>
-                  <p className="text-xs text-slate-500 uppercase tracking-wider mb-3">
-                    Quests by Track
-                  </p>
-                  <BarChart
-                    data={data.quests?.byTrack ?? []}
+                    <p className="text-xs text-slate-500 uppercase tracking-wider mb-3">
+                      Quests created by Track
+                    </p>
+                    <BarChart
+                      data={data.quests?.byTrack ?? []}
                     labelKey="track"
                     valueKey="count"
                     color="fill-sky-500"
@@ -427,7 +443,7 @@ export default function AdminAnalyticsPage() {
               {/* Activity Feed */}
               <Section
                 id="activity"
-                title="Activity Feed (Last 7 Days)"
+                title={`Activity Feed (${data.activity?.windowLabel ?? dateRange})`}
                 icon={<Activity className="w-4 h-4" />}
               >
                 <ActivityTimeline activities={data.activity?.last7Days ?? []} />

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -15,13 +15,15 @@ import {
   BarChart3,
   Shield,
   Activity,
-  DollarSign,
   Plus,
   ClipboardList,
   ArrowRight,
   Loader2,
   CheckCircle,
   Clock,
+  Layers,
+  Wallet,
+  Zap,
 } from 'lucide-react';
 
 interface AdminStats {
@@ -29,6 +31,7 @@ interface AdminStats {
   totalQuests: number;
   activeQuests: number;
   completedQuests: number;
+  pendingQaCount: number;
 }
 
 interface UserItem {
@@ -39,26 +42,29 @@ interface UserItem {
   rank: string;
   xp: number;
   level: number;
+  createdAt: string;
 }
 
-interface QuestItem {
-  status: string;
+interface ActivityItem {
+  id: string;
+  action: string;
+  createdAt: string;
+  user: {
+    name: string;
+    rank: string | null;
+  };
 }
 
-interface AdminUsersResponse {
+interface AdminOverviewResponse {
   success: boolean;
-  users: UserItem[];
-  error?: string;
-}
-
-interface AdminQuestsResponse {
-  success: boolean;
-  quests: QuestItem[];
+  stats: AdminStats;
+  recentUsers: UserItem[];
+  recentActivity: ActivityItem[];
   error?: string;
 }
 
 const EMPTY_USERS: UserItem[] = [];
-const EMPTY_QUESTS: QuestItem[] = [];
+const EMPTY_ACTIVITY: ActivityItem[] = [];
 
 const RANK_COLORS: Record<string, string> = {
   S: 'bg-amber-100 text-amber-800',
@@ -76,17 +82,10 @@ export default function AdminDashboard() {
   const shouldFetch = status === 'authenticated' && session?.user?.role === 'admin';
 
   const {
-    data: usersData,
-    loading: usersLoading,
-    error: usersError,
-  } = useApiFetch<AdminUsersResponse>('/api/admin/users', {
-    skip: !shouldFetch,
-  });
-  const {
-    data: questsData,
-    loading: questsLoading,
-    error: questsError,
-  } = useApiFetch<AdminQuestsResponse>('/api/admin/quests?limit=200', {
+    data: overviewData,
+    loading,
+    error: fetchError,
+  } = useApiFetch<AdminOverviewResponse>('/api/admin/overview', {
     skip: !shouldFetch,
   });
 
@@ -101,24 +100,17 @@ export default function AdminDashboard() {
     }
   }, [router, session, status]);
 
-  const allUsers = usersData?.users ?? EMPTY_USERS;
-  const users = allUsers.slice(0, 10);
-  const questList = questsData?.quests ?? EMPTY_QUESTS;
-  const fetchError = usersError ?? questsError;
+  const users = overviewData?.recentUsers ?? EMPTY_USERS;
+  const recentActivity = overviewData?.recentActivity ?? EMPTY_ACTIVITY;
+  const stats = overviewData?.stats ?? {
+    totalUsers: 0,
+    totalQuests: 0,
+    activeQuests: 0,
+    completedQuests: 0,
+    pendingQaCount: 0,
+  };
 
-  const stats = useMemo<AdminStats>(
-    () => ({
-      totalUsers: allUsers.length,
-      totalQuests: questList.length,
-      activeQuests: questList.filter(
-        (quest) => quest.status === 'available' || quest.status === 'in_progress'
-      ).length,
-      completedQuests: questList.filter((quest) => quest.status === 'completed').length,
-    }),
-    [allUsers, questList]
-  );
-
-  if (status === 'loading' || (shouldFetch && (usersLoading || questsLoading))) {
+  if (status === 'loading' || (shouldFetch && loading)) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -162,6 +154,13 @@ export default function AdminDashboard() {
               </Link>
             </Button>
             <Button variant="outline" asChild>
+              <Link href="/admin/analytics">
+                <BarChart3 className="h-4 w-4" />
+                Analytics
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button variant="outline" asChild>
               <Link href="/admin/quests">
                 <ClipboardList className="h-4 w-4" />
                 Manage Quests
@@ -171,7 +170,7 @@ export default function AdminDashboard() {
             <Button variant="outline" asChild className="border-orange-500/30 text-orange-400 hover:bg-orange-500/10">
               <Link href="/admin/qa-queue">
                 <Shield className="h-4 w-4" />
-                QA Queue
+                QA Queue ({stats.pendingQaCount})
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </Button>
@@ -189,12 +188,19 @@ export default function AdminDashboard() {
               </Link>
             </Button>
             <Button variant="outline" asChild>
-               <Link href="/admin/revenue">
-                 <BarChart3 className="h-4 w-4" />
-                 Revenue Dashboard
-                 <ArrowRight className="h-4 w-4" />
-               </Link>
-             </Button>
+              <Link href="/admin/api-budgets">
+                <Zap className="h-4 w-4" />
+                API Budgets
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/admin/revenue">
+                <Wallet className="h-4 w-4" />
+                Revenue Dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
           </CardContent>
         </Card>
 
@@ -235,6 +241,15 @@ export default function AdminDashboard() {
               <div className="text-2xl font-bold">{stats.completedQuests}</div>
             </CardContent>
           </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Pending QA</CardTitle>
+              <Shield className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.pendingQaCount}</div>
+            </CardContent>
+          </Card>
         </div>
 
         <Card>
@@ -258,8 +273,9 @@ export default function AdminDashboard() {
                 label: 'At least one quest is live and available',
                 link: '/admin/quests',
               },
+              { done: stats.pendingQaCount > 0, label: 'Run the QA mediation queue', link: '/admin/qa-queue' },
               { done: false, label: 'Walk interns through quest selection', link: '/dashboard/quests' },
-              { done: false, label: 'Add observation notes after first session', link: '/admin/quests' },
+              { done: false, label: 'Tune templates and criteria after first session', link: '/admin/quest-templates' },
             ].map((item, index) => (
               <div key={index} className="flex items-center gap-3 rounded-lg border bg-card p-3">
                 {item.done ? (
@@ -311,6 +327,37 @@ export default function AdminDashboard() {
                         Lv.{user.level} | {user.xp} XP
                       </span>
                     </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Activity</CardTitle>
+            <CardDescription>Latest platform actions recorded in the activity log</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {recentActivity.length === 0 ? (
+              <p className="py-8 text-center text-muted-foreground">No recent activity recorded</p>
+            ) : (
+              <div className="space-y-3">
+                {recentActivity.map((entry) => (
+                  <div key={entry.id} className="flex items-center justify-between rounded-lg border p-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium capitalize">
+                        {entry.action.replace(/_/g, ' ')}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {entry.user.name}
+                        {entry.user.rank ? ` • ${entry.user.rank}-Rank` : ''}
+                      </div>
+                    </div>
+                    <Badge variant="outline">
+                      {new Date(entry.createdAt).toLocaleDateString()}
+                    </Badge>
                   </div>
                 ))}
               </div>

--- a/app/admin/qa-queue/[assignmentId]/page.tsx
+++ b/app/admin/qa-queue/[assignmentId]/page.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { formatDistanceToNow } from 'date-fns';
+import { ArrowLeft, CheckCircle, Loader2, Shield, XCircle } from 'lucide-react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { FieldDisplay } from '@/components/quest/field-display';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
+import {
+  asFieldDefs,
+  asFieldValues,
+  type CriteriaResult,
+} from '@/lib/quest-field-templates';
+
+type QueueAssignment = {
+  id: string;
+  status: string;
+  assignedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  progress: string | number;
+  quest: {
+    id: string;
+    title: string;
+    track: string;
+    difficulty: string;
+    xpReward: number;
+    monetaryReward: string | null;
+    detailedDescription: string | null;
+    acceptanceCriteria: string[];
+    briefData: unknown;
+    fieldTemplate: { briefFields: unknown; submissionFields: unknown } | null;
+  };
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    rank: string;
+    bootcampLink: { cohort: string | null; bootcampTrack: string; bootcampWeek: number } | null;
+  };
+  submissions: Array<{
+    id: string;
+    submissionContent: string;
+    submissionNotes: string | null;
+    submissionData: unknown;
+    submittedAt: string;
+    reviewNotes: unknown;
+    criteriaResults: unknown;
+  }>;
+};
+
+const TRACK_COLORS: Record<string, string> = {
+  BOOTCAMP: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  INTERN: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  OPEN: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+};
+
+function parseReviewNotes(value: unknown) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value as Array<{ id: string; author: string; timestamp: string; note: string }>;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export default function QAQueueDetailPage() {
+  const params = useParams<{ assignmentId: string }>();
+  const assignmentId = params?.assignmentId;
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  const [assignment, setAssignment] = useState<QueueAssignment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [rejectNotes, setRejectNotes] = useState('');
+  const [criteriaState, setCriteriaState] = useState<boolean[]>([]);
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+      return;
+    }
+
+    if (status === 'authenticated' && session?.user?.role !== 'admin') {
+      router.push('/dashboard');
+      return;
+    }
+  }, [router, session, status]);
+
+  useEffect(() => {
+    if (!assignmentId || status !== 'authenticated' || session?.user?.role !== 'admin') return;
+
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetchWithAuth(`/api/admin/qa-queue/${assignmentId}`);
+        const payload = await response.json();
+
+        if (!response.ok || !payload.success) {
+          throw new Error(payload.error || 'Failed to load QA item');
+        }
+
+        const nextAssignment = payload.assignment as QueueAssignment;
+        setAssignment(nextAssignment);
+
+        const submission = nextAssignment.submissions[0];
+        if (
+          submission?.criteriaResults &&
+          Array.isArray(submission.criteriaResults)
+        ) {
+          const initialState = (submission.criteriaResults as CriteriaResult[]).map(
+            (result) => result.met === true
+          );
+          setCriteriaState(initialState);
+        } else {
+          setCriteriaState(
+            (nextAssignment.quest.acceptanceCriteria ?? []).map(() => false)
+          );
+        }
+      } catch (nextError) {
+        console.error(nextError);
+        setError(nextError instanceof Error ? nextError.message : 'Failed to load QA item');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [assignmentId, session?.user?.role, status]);
+
+  const latestSubmission = assignment?.submissions[0] ?? null;
+  const reviewNotes = useMemo(
+    () => parseReviewNotes(latestSubmission?.reviewNotes),
+    [latestSubmission?.reviewNotes]
+  );
+
+  const criteriaResults = useMemo<CriteriaResult[]>(
+    () =>
+      (assignment?.quest.acceptanceCriteria ?? []).map((criterion, index) => ({
+        criterion,
+        met: criteriaState[index] === true,
+      })),
+    [assignment?.quest.acceptanceCriteria, criteriaState]
+  );
+
+  const toggleCriterion = (index: number) =>
+    setCriteriaState((current) => {
+      const next = [...current];
+      next[index] = !next[index];
+      return next;
+    });
+
+  const handleAction = async (action: 'approve' | 'reject') => {
+    if (!assignment) return;
+    if (action === 'reject' && !rejectNotes.trim()) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetchWithAuth(`/api/admin/qa-queue/${assignment.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          notes: action === 'reject' ? rejectNotes.trim() : undefined,
+          criteriaResults,
+        }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || 'Failed to update QA item');
+      }
+
+      router.push('/admin/qa-queue');
+    } catch (nextError) {
+      console.error(nextError);
+      setError(nextError instanceof Error ? nextError.message : 'Failed to update QA item');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (status === 'loading' || loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950">
+        <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
+      </div>
+    );
+  }
+
+  if (status !== 'authenticated' || session?.user?.role !== 'admin') {
+    return null;
+  }
+
+  if (!assignment) {
+    return (
+      <div className="min-h-screen bg-slate-950 p-6 text-slate-100">
+        <div className="mx-auto max-w-4xl">
+          <Link href="/admin/qa-queue" className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200">
+            <ArrowLeft className="h-4 w-4" />
+            Back to QA queue
+          </Link>
+          <Card className="mt-6 border-slate-800 bg-slate-900">
+            <CardContent className="p-6 text-sm text-red-300">
+              {error || 'QA item not found.'}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 p-6 text-slate-100">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/admin/qa-queue" className="text-slate-400 transition-colors hover:text-slate-200">
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <Shield className="h-6 w-6 text-orange-500" />
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100">QA Review Detail</h1>
+            <p className="text-sm text-slate-400">Review submission quality before it reaches the client.</p>
+          </div>
+        </div>
+
+        {error && (
+          <Card className="border-red-800 bg-red-950/20">
+            <CardContent className="p-4 text-sm text-red-300">{error}</CardContent>
+          </Card>
+        )}
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge className={`border text-xs ${TRACK_COLORS[assignment.quest.track] ?? ''}`}>
+                {assignment.quest.track}
+              </Badge>
+              <Badge variant="outline" className="border-slate-700 text-slate-300">
+                {assignment.quest.difficulty}-rank
+              </Badge>
+              <Badge variant="outline" className="border-slate-700 text-slate-300">
+                {assignment.status}
+              </Badge>
+            </div>
+            <CardTitle className="text-xl text-slate-100">{assignment.quest.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg bg-slate-950/70 p-4">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Student</p>
+              <p className="mt-2 font-medium text-slate-100">{assignment.user.name}</p>
+              <p className="text-sm text-slate-400">{assignment.user.email}</p>
+              <p className="mt-2 text-sm text-slate-300">{assignment.user.rank}-Rank</p>
+              {assignment.user.bootcampLink && (
+                <p className="mt-1 text-xs text-slate-500">
+                  {assignment.user.bootcampLink.bootcampTrack} · Week {assignment.user.bootcampLink.bootcampWeek}
+                </p>
+              )}
+            </div>
+            <div className="rounded-lg bg-slate-950/70 p-4">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Reward</p>
+              <p className="mt-2 font-medium text-slate-100">{assignment.quest.xpReward} XP</p>
+              <p className="text-sm text-slate-400">
+                {assignment.quest.monetaryReward ? `${assignment.quest.monetaryReward} payout` : 'No cash payout'}
+              </p>
+            </div>
+            <div className="rounded-lg bg-slate-950/70 p-4">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Submitted</p>
+              <p className="mt-2 font-medium text-slate-100">
+                {latestSubmission
+                  ? formatDistanceToNow(new Date(latestSubmission.submittedAt), { addSuffix: true })
+                  : 'No submission'}
+              </p>
+              <p className="text-sm text-slate-400">Progress: {String(assignment.progress)}</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {(assignment.quest.detailedDescription ||
+          asFieldDefs(assignment.quest.fieldTemplate?.briefFields).length > 0) && (
+          <Card className="border-slate-800 bg-slate-900">
+            <CardHeader>
+              <CardTitle className="text-base text-slate-100">Quest Brief</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-slate-300">
+              {assignment.quest.detailedDescription && (
+                <p className="whitespace-pre-wrap">{assignment.quest.detailedDescription}</p>
+              )}
+              <div className="[&_a]:text-orange-400 [&_dd]:text-slate-200 [&_dl]:divide-slate-800 [&_dt]:text-slate-400">
+                <FieldDisplay
+                  fields={asFieldDefs(assignment.quest.fieldTemplate?.briefFields)}
+                  values={asFieldValues(assignment.quest.briefData)}
+                  hideEmpty
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-100">Submission</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {latestSubmission ? (
+              <>
+                {asFieldDefs(assignment.quest.fieldTemplate?.submissionFields).length > 0 &&
+                latestSubmission.submissionData ? (
+                  <div className="[&_a]:text-orange-400 [&_dd]:text-slate-200 [&_dl]:divide-slate-800 [&_dt]:text-slate-400">
+                    <FieldDisplay
+                      fields={asFieldDefs(assignment.quest.fieldTemplate?.submissionFields)}
+                      values={asFieldValues(latestSubmission.submissionData)}
+                      hideEmpty
+                    />
+                  </div>
+                ) : (
+                  <p className="rounded-lg bg-slate-950/70 p-4 whitespace-pre-wrap text-sm text-slate-300">
+                    {latestSubmission.submissionContent}
+                  </p>
+                )}
+                {latestSubmission.submissionNotes && (
+                  <p className="rounded-lg bg-slate-950/50 p-3 text-sm text-slate-400">
+                    <span className="font-medium text-slate-300">Notes: </span>
+                    {latestSubmission.submissionNotes}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="text-sm text-slate-400">No submission found.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-100">Acceptance Criteria</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {(assignment.quest.acceptanceCriteria ?? []).length === 0 ? (
+              <p className="text-sm text-slate-400">No acceptance criteria configured for this quest.</p>
+            ) : (
+              assignment.quest.acceptanceCriteria.map((criterion, index) => (
+                <label key={criterion + index} className="flex items-start gap-3 rounded-lg bg-slate-950/60 p-3 text-sm text-slate-300">
+                  <Checkbox
+                    checked={criteriaState[index] === true}
+                    onCheckedChange={() => toggleCriterion(index)}
+                    className="mt-0.5 border-slate-600"
+                  />
+                  <span>{criterion}</span>
+                </label>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-100">Revision Notes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {reviewNotes.length === 0 ? (
+              <p className="text-sm text-slate-400">No prior QA notes recorded.</p>
+            ) : (
+              reviewNotes.map((note) => (
+                <div key={note.id} className="rounded-lg bg-slate-950/60 p-3">
+                  <div className="text-sm font-medium text-slate-200">{note.author}</div>
+                  <div className="text-xs text-slate-500">{new Date(note.timestamp).toLocaleString()}</div>
+                  <p className="mt-2 text-sm text-slate-300 whitespace-pre-wrap">{note.note}</p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-100">Decision</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Textarea
+              value={rejectNotes}
+              onChange={(event) => setRejectNotes(event.target.value)}
+              className="min-h-[120px] border-slate-700 bg-slate-950 text-slate-200 placeholder:text-slate-600"
+              placeholder="Required if you reject. Explain exactly what the student needs to fix."
+            />
+            <div className="flex flex-wrap gap-3">
+              <Button
+                className="bg-emerald-600 text-white hover:bg-emerald-500"
+                disabled={submitting}
+                onClick={() => void handleAction('approve')}
+              >
+                {submitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle className="mr-2 h-4 w-4" />}
+                Approve and forward to client
+              </Button>
+              <Button
+                variant="outline"
+                className="border-red-800 text-red-400 hover:bg-red-950/40"
+                disabled={submitting || !rejectNotes.trim()}
+                onClick={() => void handleAction('reject')}
+              >
+                {submitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <XCircle className="mr-2 h-4 w-4" />}
+                Reject and return to student
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,8 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma, withDbRetry } from '@/lib/db';
+import { AssignmentStatus, UserRole } from '@prisma/client';
+
 import { requireAuth } from '@/lib/api-auth';
-import { QuestStatus, AssignmentStatus, UserRole } from '@prisma/client';
+import { prisma, withDbRetry } from '@/lib/db';
+
+function parseRangeDays(raw: string | null) {
+  if (raw === '30d') return 30;
+  if (raw === '90d') return 90;
+  return 7;
+}
 
 /**
  * GET /api/admin/analytics
@@ -15,10 +22,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const { searchParams } = new URL(request.url);
+    const rangeDays = parseRangeDays(searchParams.get('range'));
     const now = new Date();
     const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const rangeStart = new Date(now.getTime() - rangeDays * 24 * 60 * 60 * 1000);
 
     const [
       dau,
@@ -34,39 +44,35 @@ export async function GET(request: NextRequest) {
       rankDistribution,
       questByCategory,
       questByTrack,
-      activityLast7Days,
-      avgCompletionTime,
+      activityByRange,
+      completionDurations,
       topAdventurers,
     ] = await withDbRetry(() =>
       Promise.all([
-        // DAU - unique users with activity in last 24h
-        prisma.activityLog.count({
+        prisma.activityLog.groupBy({
+          by: ['userId'],
           where: { createdAt: { gte: dayAgo } },
-          select: { userId: true },
         }),
-        // WAU - unique users with activity in last 7 days
-        prisma.activityLog.count({
+        prisma.activityLog.groupBy({
+          by: ['userId'],
           where: { createdAt: { gte: weekAgo } },
-          select: { userId: true },
         }),
-        // MAU - unique users with activity in last 30 days
-        prisma.activityLog.count({
+        prisma.activityLog.groupBy({
+          by: ['userId'],
           where: { createdAt: { gte: monthAgo } },
-          select: { userId: true },
         }),
-        // Total adventurers
         prisma.user.count({ where: { role: UserRole.adventurer } }),
-        // Total companies
         prisma.user.count({ where: { role: UserRole.company } }),
-        // Total quests ever created
         prisma.quest.count(),
-        // Active (available) quests
-        prisma.quest.count({ where: { status: QuestStatus.available } }),
-        // Completed assignments
-        prisma.questAssignment.count({
-          where: { status: AssignmentStatus.completed },
+        prisma.quest.count({
+          where: { status: { in: ['available', 'in_progress', 'review'] } },
         }),
-        // Pending assignments (submitted, under review)
+        prisma.questAssignment.count({
+          where: {
+            status: AssignmentStatus.completed,
+            completedAt: { gte: rangeStart },
+          },
+        }),
         prisma.questAssignment.count({
           where: {
             status: {
@@ -76,66 +82,81 @@ export async function GET(request: NextRequest) {
                 AssignmentStatus.review,
               ],
             },
+            assignedAt: { gte: rangeStart },
           },
         }),
-        // Rejected/needs rework assignments
         prisma.questAssignment.count({
           where: {
             status: {
-              in: [
-                AssignmentStatus.needs_rework,
-                AssignmentStatus.cancelled,
-              ],
+              in: [AssignmentStatus.needs_rework, AssignmentStatus.cancelled],
             },
+            assignedAt: { gte: rangeStart },
           },
         }),
-        // Rank distribution
         prisma.user.groupBy({
           by: ['rank'],
           _count: { id: true },
           where: { role: UserRole.adventurer },
           orderBy: { rank: 'desc' },
         }),
-        // Quests by category
         prisma.quest.groupBy({
           by: ['questCategory'],
           _count: { id: true },
-          where: { status: QuestStatus.available },
+          where: { createdAt: { gte: rangeStart } },
         }),
-        // Quests by track
         prisma.quest.groupBy({
           by: ['track'],
           _count: { id: true },
-          where: { status: QuestStatus.available },
+          where: { createdAt: { gte: rangeStart } },
         }),
-        // Activity logs (last 7 days) - daily breakdown
         prisma.activityLog.groupBy({
           by: ['action'],
           _count: { id: true },
-          where: { createdAt: { gte: weekAgo } },
+          where: { createdAt: { gte: rangeStart } },
           orderBy: { _count: { id: 'desc' } },
           take: 20,
         }),
-        // Average completion time (completed quests only) — calculate from DB
-        prisma.questCompletion.findMany({
-          select: {
-            id: true,
-            completionDate: true,
+        prisma.questAssignment.findMany({
+          where: {
+            status: AssignmentStatus.completed,
+            completedAt: { gte: rangeStart },
+            startedAt: { not: null },
           },
-          orderBy: { completionDate: 'desc' },
-          take: 100,
+          select: {
+            startedAt: true,
+            completedAt: true,
+          },
         }),
-        // Top 10 adventurers by completions
         prisma.questCompletion.groupBy({
           by: ['userId'],
           _count: { questId: true },
+          where: { completionDate: { gte: rangeStart } },
           orderBy: { _count: { questId: 'desc' } },
           take: 10,
         }),
       ])
     );
 
-    // Fetch adventurer names for top adventurers
+    const completionDurationsInDays = completionDurations
+      .map((assignment) => {
+        if (!assignment.startedAt || !assignment.completedAt) return null;
+        return (
+          (assignment.completedAt.getTime() - assignment.startedAt.getTime()) /
+          (1000 * 60 * 60 * 24)
+        );
+      })
+      .filter((duration): duration is number => duration !== null && duration >= 0);
+
+    const avgCompletionTimeDays =
+      completionDurationsInDays.length > 0
+        ? Number(
+            (
+              completionDurationsInDays.reduce((sum, duration) => sum + duration, 0) /
+              completionDurationsInDays.length
+            ).toFixed(1)
+          )
+        : null;
+
     const topAdventurerIds = topAdventurers.map((a) => a.userId);
     const topAdventurerUsers = await withDbRetry(() =>
       prisma.user.findMany({
@@ -145,11 +166,11 @@ export async function GET(request: NextRequest) {
     );
 
     const topAdventurersWithNames = topAdventurers.map((a) => {
-      const user = topAdventurerUsers.find((u) => u.id === a.userId);
+      const topUser = topAdventurerUsers.find((candidate) => candidate.id === a.userId);
       return {
         id: a.userId,
-        name: user?.name || user?.username || 'Unknown',
-        rank: user?.rank || 'F',
+        name: topUser?.name || topUser?.username || 'Unknown',
+        rank: topUser?.rank || 'F',
         completions: a._count.questId,
       };
     });
@@ -158,9 +179,9 @@ export async function GET(request: NextRequest) {
       success: true,
       analytics: {
         overview: {
-          dau: Array.isArray(dau) ? dau.length : dau,
-          wau: Array.isArray(wau) ? wau.length : wau,
-          mau: Array.isArray(mau) ? mau.length : mau,
+          dau: dau.length,
+          wau: wau.length,
+          mau: mau.length,
           totalUsers: totalAdventurers + totalCompanies,
           totalAdventurers,
           totalCompanies,
@@ -188,19 +209,25 @@ export async function GET(request: NextRequest) {
           topAdventurers: topAdventurersWithNames,
         },
         activity: {
-          last7Days: activityLast7Days.map((a: any) => ({
+          windowLabel: `${rangeDays}d`,
+          last7Days: activityByRange.map((a: any) => ({
             action: a.action,
             count: a._count.id,
           })),
         },
         completionMetrics: {
-          avgCompletionTimeDays: null as number | null,
+          avgCompletionTimeDays,
           completionRate:
-            completedAssignments > 0
-              ? ((completedAssignments / (completedAssignments + rejectedAssignments + pendingAssignments)) * 100).toFixed(1)
+            completedAssignments + rejectedAssignments + pendingAssignments > 0
+              ? (
+                  (completedAssignments /
+                    (completedAssignments + rejectedAssignments + pendingAssignments)) *
+                  100
+                ).toFixed(1)
               : '0.0',
         },
         generatedAt: now.toISOString(),
+        selectedRange: `${rangeDays}d`,
       },
     });
   } catch (error) {

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireAuth } from '@/lib/api-auth';
+import { prisma, withDbRetry } from '@/lib/db';
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request, 'admin');
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+    }
+
+    const [
+      totalUsers,
+      totalQuests,
+      activeQuests,
+      completedQuests,
+      pendingQaCount,
+      recentUsers,
+      recentActivity,
+    ] = await withDbRetry(() =>
+      Promise.all([
+        prisma.user.count(),
+        prisma.quest.count(),
+        prisma.quest.count({
+          where: { status: { in: ['available', 'in_progress', 'review'] } },
+        }),
+        prisma.questAssignment.count({
+          where: { status: 'completed' },
+        }),
+        prisma.questAssignment.count({
+          where: { status: 'pending_admin_review' },
+        }),
+        prisma.user.findMany({
+          take: 10,
+          orderBy: { createdAt: 'desc' },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            role: true,
+            rank: true,
+            xp: true,
+            level: true,
+            createdAt: true,
+          },
+        }),
+        prisma.activityLog.findMany({
+          take: 8,
+          orderBy: { createdAt: 'desc' },
+          include: {
+            user: {
+              select: {
+                name: true,
+                email: true,
+                rank: true,
+              },
+            },
+          },
+        }),
+      ])
+    );
+
+    return NextResponse.json({
+      success: true,
+      stats: {
+        totalUsers,
+        totalQuests,
+        activeQuests,
+        completedQuests,
+        pendingQaCount,
+      },
+      recentUsers,
+      recentActivity: recentActivity.map((entry) => ({
+        id: entry.id,
+        action: entry.action,
+        createdAt: entry.createdAt.toISOString(),
+        user: {
+          name: entry.user?.name || entry.user?.email || 'Unknown',
+          rank: entry.user?.rank || null,
+        },
+      })),
+    });
+  } catch (error) {
+    console.error('Error fetching admin overview:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch admin overview', success: false },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -4,6 +4,73 @@ import { requireAuth } from '@/lib/api-auth';
 import { Prisma } from '@prisma/client';
 import crypto from 'crypto';
 
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ assignmentId: string }> }
+) {
+  const user = await requireAuth(request, 'admin');
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  const { assignmentId } = await params;
+
+  const assignment = await prisma.questAssignment.findUnique({
+    where: { id: assignmentId },
+    select: {
+      id: true,
+      status: true,
+      assignedAt: true,
+      startedAt: true,
+      completedAt: true,
+      progress: true,
+      quest: {
+        select: {
+          id: true,
+          title: true,
+          track: true,
+          difficulty: true,
+          xpReward: true,
+          monetaryReward: true,
+          detailedDescription: true,
+          acceptanceCriteria: true,
+          briefData: true,
+          fieldTemplate: { select: { briefFields: true, submissionFields: true } },
+        },
+      },
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          rank: true,
+          bootcampLink: {
+            select: { cohort: true, bootcampTrack: true, bootcampWeek: true },
+          },
+        },
+      },
+      submissions: {
+        orderBy: { submittedAt: 'desc' },
+        select: {
+          id: true,
+          submissionContent: true,
+          submissionNotes: true,
+          submissionData: true,
+          submittedAt: true,
+          reviewNotes: true,
+          criteriaResults: true,
+        },
+      },
+    },
+  });
+
+  if (!assignment) {
+    return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
+  }
+
+  return NextResponse.json({ assignment, success: true });
+}
+
 // PATCH /api/admin/qa-queue/[assignmentId] — approve or reject submission
 export async function PATCH(
   request: NextRequest,

--- a/app/api/admin/qa-queue/route.ts
+++ b/app/api/admin/qa-queue/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
           name: true,
           email: true,
           rank: true,
-          bootcampLink: { select: { bootcampTrack: true, bootcampWeek: true } },
+          bootcampLink: { select: { cohort: true, bootcampTrack: true, bootcampWeek: true } },
         },
       },
       submissions: {

--- a/components/admin/AdminRail.tsx
+++ b/components/admin/AdminRail.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { BarChart3, ClipboardList, LayoutDashboard, Shield } from 'lucide-react';
+import {
+  BarChart3,
+  ClipboardList,
+  LayoutDashboard,
+  Layers,
+  Shield,
+  Wallet,
+  Zap,
+} from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -20,10 +28,34 @@ const adminLinks = [
     icon: ClipboardList,
   },
   {
+    href: '/admin/qa-queue',
+    label: 'QA Queue',
+    description: 'Review submissions before client handoff',
+    icon: Shield,
+  },
+  {
+    href: '/admin/analytics',
+    label: 'Analytics',
+    description: 'Platform health, ranks, and activity',
+    icon: BarChart3,
+  },
+  {
     href: '/admin/revenue',
     label: 'Revenue',
     description: 'GMV, take rate, and payout health',
-    icon: BarChart3,
+    icon: Wallet,
+  },
+  {
+    href: '/admin/quest-templates',
+    label: 'Templates',
+    description: 'Manage quest brief and submission schemas',
+    icon: Layers,
+  },
+  {
+    href: '/admin/api-budgets',
+    label: 'API Budgets',
+    description: 'Track internal model spend and caps',
+    icon: Zap,
   },
 ] as const;
 


### PR DESCRIPTION
## What changed
- replaced the admin overview with a real aggregate-backed endpoint for trustworthy counts and recent activity
- fixed admin analytics so the range selector actually affects backend queries and active-user metrics use distinct users
- added the missing QA detail page and GET route so the queue's Full View link works end to end
- expanded the admin rail so QA queue, analytics, templates, revenue, and API budgets are reachable from the main console

## Why
The admin surface had several disconnected or misleading pieces: overview totals were derived from paginated lists, analytics had broken filter behavior, and the QA queue linked to a missing detail page.

## Impact
Admins now have a more coherent operations console with more trustworthy overview metrics, working analytics filters, and a complete QA review path.

## Validation
- `npx tsc --noEmit`