### PR TITLE
fix(auth): align auth pages below navbar

### DIFF
--- a/components/ui/full-screen-signup.tsx
+++ b/components/ui/full-screen-signup.tsx
@@ -377,8 +377,8 @@ export const FullScreenSignup = ({ mode = "register" }: FullScreenSignupProps) =
   const isLogin = mode === "login";
 
   return (
-    <div
-      className="min-h-[calc(100vh-4rem)] flex flex-col overflow-hidden relative bg-background"
+    <main
+      className="min-h-screen flex flex-col overflow-hidden relative bg-background pt-20"
     >
       {/* Subtle ink-spread from the card's bottom-left corner */}
       <div
@@ -394,7 +394,7 @@ export const FullScreenSignup = ({ mode = "register" }: FullScreenSignupProps) =
       />
 
       {/* Card */}
-      <div className="flex-1 flex items-center justify-center p-4 pb-12">
+      <div className="flex-1 flex items-start justify-center px-4 pb-12">
         <div className="w-full relative max-w-5xl overflow-hidden flex flex-col md:flex-row shadow-2xl rounded-2xl">
 
         {/* Left panel */}
@@ -438,6 +438,6 @@ export const FullScreenSignup = ({ mode = "register" }: FullScreenSignupProps) =
         </div>
       </div>
       </div>
-    </div>
+    </main>
   );
 };


### PR DESCRIPTION
## Description

Fixes #276

This PR fixes the navbar overlap issue on the authentication pages.

The Sign In and Join Guild pages were starting too close to the top of the viewport, causing the fixed/floating navbar to overlap the page content. This made the left-side hero text and auth layout appear broken.

## Changes Made

- Updated the auth page wrapper from `div` to semantic `main`
- Added top padding so the auth content starts below the navbar
- Adjusted the auth card alignment to prevent content from being hidden behind the navbar
- Preserved the existing responsive layout and visual design

## Pages Fixed

- Sign In page
- Join Guild / Sign Up page

## Testing

- Checked Sign In page layout
- Checked Join Guild page layout
- Verified navbar no longer overlaps the auth content
- Verified the auth card remains properly visible

