### PR TITLE
fix: quest detail performance — parallel fetches + canSubmit bug + skeleton

### DIFF
--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -136,37 +136,45 @@ export default function QuestDetailPage() {
         setLoading(true);
         setError(null);
 
-        const questResponse = await fetchWithAuth(`/api/quests/${questId}`);
-        const questData = await questResponse.json();
+        // Fire all three requests in parallel — cuts load time from ~9s to ~3s
+        const userId = session?.user?.id;
+        const [questResult, assignmentResult, profileResult] = await Promise.allSettled([
+          fetchWithAuth(`/api/quests/${questId}`).then((r) => r.json()),
+          userId
+            ? fetchWithAuth(`/api/quests/assignments?userId=${userId}&questId=${questId}`).then((r) => r.json())
+            : Promise.resolve(null),
+          userId
+            ? fetchWithAuth('/api/adventurer/profile').then((r) => r.json())
+            : Promise.resolve(null),
+        ]);
 
+        // Quest is required — fail fast if it errors
+        if (questResult.status === 'rejected') {
+          setError('Failed to load quest details');
+          return;
+        }
+        const questData = questResult.value;
         if (!questData.success) {
           setError(questData.error || 'Failed to fetch quest');
           return;
         }
-
         const normalizedQuest = questData.quest ?? questData.quests?.[0] ?? null;
         if (!normalizedQuest) {
           setError('Quest details not found');
           return;
         }
-
         setQuest(normalizedQuest);
 
-        if (session?.user?.id) {
-          const assignmentResponse = await fetchWithAuth(
-            `/api/quests/assignments?userId=${session.user.id}&questId=${questId}`
-          );
-          const assignmentData = await assignmentResponse.json();
-
+        // Assignment — optional, don't block on failure
+        if (assignmentResult.status === 'fulfilled' && assignmentResult.value) {
+          const assignmentData = assignmentResult.value;
           const assignments = Array.isArray(assignmentData.assignments) ? assignmentData.assignments : [];
-          if (assignmentData.success && assignments.length > 0) {
-            setAssignment(assignments[0]);
-          } else {
-            setAssignment(null);
-          }
+          setAssignment(assignmentData.success && assignments.length > 0 ? assignments[0] : null);
+        }
 
-          const profileResponse = await fetchWithAuth('/api/adventurer/profile');
-          const profileData = await profileResponse.json();
+        // Profile / streak — optional, don't block on failure
+        if (profileResult.status === 'fulfilled' && profileResult.value) {
+          const profileData = profileResult.value;
           if (profileData.success && profileData.profile) {
             setCurrentStreak(profileData.profile.currentStreak ?? 0);
           }
@@ -186,7 +194,8 @@ export default function QuestDetailPage() {
 
   const isAssigned = !!assignment;
   const canAssign = quest?.status === 'available' && !isAssigned;
-  const canSubmit = !!assignment && ['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status);
+  // 'assigned' excluded — company must accept first (backend rejects submissions in that state)
+  const canSubmit = !!assignment && ['started', 'in_progress', 'needs_rework'].includes(assignment.status);
   const showPartyPanel = (quest?.maxParticipants ?? 1) > 1;
 
   useEffect(() => {
@@ -296,9 +305,40 @@ export default function QuestDetailPage() {
   if (status === 'loading' || loading) {
     return (
       <GuildPage>
-        <GuildPanel className="flex min-h-[320px] items-center justify-center">
-          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-primary" />
-        </GuildPanel>
+        {/* Hero skeleton */}
+        <div className="rounded-2xl border border-slate-200 bg-white p-8 animate-pulse">
+          <div className="flex gap-2 mb-4">
+            <div className="h-5 w-20 rounded-full bg-slate-200" />
+            <div className="h-5 w-14 rounded-full bg-slate-200" />
+            <div className="h-5 w-16 rounded-full bg-slate-200" />
+          </div>
+          <div className="h-9 w-3/4 rounded-lg bg-slate-200 mb-3" />
+          <div className="h-4 w-1/3 rounded bg-slate-100" />
+        </div>
+        {/* KPI row skeleton */}
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {[0,1,2,3].map((i) => (
+            <div key={i} className="rounded-2xl border border-slate-200 bg-white p-5 animate-pulse">
+              <div className="h-3 w-16 rounded bg-slate-200 mb-3" />
+              <div className="h-7 w-24 rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+        {/* Body skeleton */}
+        <div className="grid gap-6 xl:grid-cols-[1.3fr_0.9fr]">
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 space-y-4 animate-pulse">
+            <div className="h-5 w-28 rounded bg-slate-200" />
+            <div className="space-y-2">
+              {[80,95,70,85,60].map((w, i) => (
+                <div key={i} className={`h-3 rounded bg-slate-100`} style={{ width: `${w}%` }} />
+              ))}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 animate-pulse">
+            <div className="h-5 w-36 rounded bg-slate-200 mb-4" />
+            <div className="h-10 w-full rounded-xl bg-slate-200" />
+          </div>
+        </div>
       </GuildPage>
     );
   }
@@ -463,7 +503,9 @@ export default function QuestDetailPage() {
                         ? 'Your delivery is in review.'
                         : assignment.status === 'needs_rework'
                           ? 'Your submission needs revision. Check reviewer feedback and resubmit.'
-                          : 'You are currently responsible for this quest. Keep delivery momentum high.'}
+                          : assignment.status === 'assigned'
+                            ? 'Application received — waiting for the company to accept you. You can start work but submit only after acceptance.'
+                            : 'You are currently responsible for this quest. Keep delivery momentum high.'}
                   </div>
                   {assignment.status === 'completed' && (
                     <div className="flex items-center gap-2 text-sm font-medium text-emerald-700">


### PR DESCRIPTION
## Problem

- **LCP 9.01s** on quest detail page — reported by contributor Aryan. Three API calls (quest, assignment, profile) fired sequentially on mount. On Neon cold-start each takes 2-3s → 7-9s before anything renders.
- **Submission bug** — users in `assigned` state (applied, not yet accepted) saw the submit form, clicked submit, got a silent 400 from the API. Aryan described it as 'auto load' / confusing UX that causes drop-off.
- **Full-page spinner** — user saw nothing for 9 seconds.

## Fix

### Parallel fetches (`Promise.allSettled`)
All three API calls now fire simultaneously. Page renders in ~3s instead of ~9s. Quest is required (fail-fast), assignment + profile are optional (non-blocking on failure).

### canSubmit bug fixed
Removed `'assigned'` from the allowed-to-submit statuses on the frontend. Backend already rejects in `f36ac33` — frontend now matches. Users in `assigned` state see a clear message: *"waiting for company to accept you"* instead of a broken form.

### Skeleton loader
Replaced the full-page spinner with a layout-matching skeleton (hero + KPI row + body) so the page feels interactive immediately.

## Test plan
- [ ] Open a quest detail page — should reach LCP < 3s on a warm connection
- [ ] Apply to a quest — status `assigned` → submit form should NOT appear, shows waiting message
- [ ] After company accepts (status `started`) → submit form appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)