### PR TITLE
feat: referral system — invite codes, milestone XP, dashboard UI

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
+import { generateReferralCode, REFEREE_SIGNUP_XP } from '@/lib/referral-utils';
 
 const registerSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
@@ -10,6 +11,7 @@ const registerSchema = z.object({
   role: z.enum(['adventurer', 'company']).default('adventurer'),
   companyName: z.string().optional(),
   username: z.string().min(3, 'Username must be at least 3 characters').max(20, 'Username must be at most 20 characters').regex(/^[a-z0-9]+$/, 'Username can only contain lowercase letters and numbers').optional(),
+  referralCode: z.string().optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -24,7 +26,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { name, email, password, role, companyName } = result.data;
+    const { name, email, password, role, companyName, referralCode: incomingRefCode } = result.data;
     const normalizedEmail = email.trim().toLowerCase();
 
     if (role === 'company' && !companyName) {
@@ -74,17 +76,46 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Resolve referrer from the incoming referral code
+    let referrerId: string | null = null;
+    if (incomingRefCode) {
+      const referrer = await withDbRetry(() =>
+        prisma.user.findUnique({
+          where: { referralCode: incomingRefCode.toUpperCase() },
+          select: { id: true },
+        })
+      );
+      referrerId = referrer?.id ?? null;
+    }
+
+    // Generate a unique referral code for the new user
+    let newReferralCode: string | null = null;
+    for (let i = 0; i < 5; i++) {
+      const candidate = generateReferralCode(name);
+      const taken = await withDbRetry(() =>
+        prisma.user.findUnique({ where: { referralCode: candidate }, select: { id: true } })
+      );
+      if (!taken) { newReferralCode = candidate; break; }
+    }
+
     const user = await withDbRetry(() => prisma.$transaction(async (tx) => {
       const newUser = await tx.user.create({
-        data: { name, email: normalizedEmail, passwordHash, role, username },
+        data: {
+          name,
+          email: normalizedEmail,
+          passwordHash,
+          role,
+          username,
+          referralCode: newReferralCode,
+          referredById: referrerId ?? undefined,
+          // Referee XP bonus on signup
+          xp: referrerId ? REFEREE_SIGNUP_XP : 0,
+        },
       });
 
       if (role === 'company') {
         await tx.companyProfile.create({
-          data: {
-            userId: newUser.id,
-            companyName: companyName!,
-          },
+          data: { userId: newUser.id, companyName: companyName! },
         });
       } else {
         await tx.adventurerProfile.create({ data: { userId: newUser.id } });
@@ -93,7 +124,11 @@ export async function POST(request: NextRequest) {
       return newUser;
     }));
 
-    return NextResponse.json({ success: true, userId: user.id }, { status: 201 });
+    return NextResponse.json({
+      success: true,
+      userId: user.id,
+      referralBonus: referrerId ? REFEREE_SIGNUP_XP : 0,
+    }, { status: 201 });
   } catch (error) {
     console.error('Registration error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -318,6 +318,13 @@ export async function PUT(request: NextRequest) {
         assignmentData.questId
       );
 
+      // Referral milestone check — award XP to the referrer if applicable
+      const completionCount = await prisma.questCompletion.count({
+        where: { userId: reviewResult.rewardsPayload.userId },
+      });
+      const { processReferralMilestone } = await import('@/lib/referral-utils');
+      await processReferralMilestone(reviewResult.rewardsPayload.userId, completionCount);
+
       // Bootcamp tutorial tracking — matched by source enum, not fragile title string
       const { questTitle, questSource, userId: rewardUserId } = reviewResult.rewardsPayload;
       if (questSource === 'TUTORIAL') {

--- a/app/api/referral/route.ts
+++ b/app/api/referral/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/api-auth';
+import { prisma } from '@/lib/db';
+import { ensureReferralCode, REFERRAL_XP, REFEREE_SIGNUP_XP } from '@/lib/referral-utils';
+
+export async function GET(request: NextRequest) {
+  const user = await requireAuth(request);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const code = await ensureReferralCode(user.id, user.name ?? 'USER');
+
+  const [referrals, rewards] = await Promise.all([
+    prisma.user.findMany({
+      where: { referredById: user.id },
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        createdAt: true,
+        questCompletions: { select: { id: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.referralReward.findMany({
+      where: { giverId: user.id },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ]);
+
+  const totalXpEarned = rewards.reduce((sum, r) => sum + r.xpAwarded, 0);
+
+  return NextResponse.json({
+    success: true,
+    referralCode: code,
+    referralLink: `${process.env.NEXT_PUBLIC_APP_URL}/register?ref=${code}`,
+    stats: {
+      totalReferrals: referrals.length,
+      totalXpEarned,
+      milestoneXp: REFERRAL_XP,
+      refereeSignupBonus: REFEREE_SIGNUP_XP,
+    },
+    referrals: referrals.map((r) => ({
+      id: r.id,
+      name: r.name,
+      username: r.username,
+      joinedAt: r.createdAt,
+      questsCompleted: r.questCompletions.length,
+      reward: rewards.find((rw) => rw.earnerId === r.id),
+    })),
+  });
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,12 +1,99 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
+import { toast } from 'sonner';
+import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface ValidationErrors {
   accountHolderName?: string;
   accountNumber?: string;
   ifscCode?: string;
+}
+
+interface ReferralStats {
+  referralCode: string;
+  referralLink: string;
+  stats: { totalReferrals: number; totalXpEarned: number; milestoneXp: Record<string, number>; refereeSignupBonus: number };
+  referrals: Array<{ id: string; name: string | null; username: string; joinedAt: string; questsCompleted: number }>;
+}
+
+function ReferralCard() {
+  const [data, setData] = useState<ReferralStats | null>(null);
+
+  useEffect(() => {
+    fetchWithAuth('/api/referral').then(r => r.json()).then(d => { if (d.success) setData(d); }).catch(() => {});
+  }, []);
+
+  const copyLink = useCallback(() => {
+    if (!data?.referralLink) return;
+    navigator.clipboard.writeText(data.referralLink).then(() => toast.success('Referral link copied!')).catch(() => {});
+  }, [data?.referralLink]);
+
+  if (!data) return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 animate-pulse">
+      <div className="h-5 w-32 rounded bg-slate-200 mb-4" />
+      <div className="h-10 w-full rounded-xl bg-slate-100" />
+    </section>
+  );
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900">Referral Program</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Share your link. When a friend signs up they get 50 XP — and when they complete their first quest you earn 200 XP. Three quests earns you 500 XP more.
+        </p>
+      </div>
+
+      {/* Code + copy */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-sm text-slate-800 select-all">
+          {data.referralLink}
+        </div>
+        <button
+          onClick={copyLink}
+          className="rounded-xl border border-slate-900 bg-slate-900 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-800 transition-colors"
+        >
+          Copy
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-center">
+          <p className="text-2xl font-bold text-slate-900">{data.stats.totalReferrals}</p>
+          <p className="text-xs text-slate-500 mt-1">Friends referred</p>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-center">
+          <p className="text-2xl font-bold text-orange-500">{data.stats.totalXpEarned}</p>
+          <p className="text-xs text-slate-500 mt-1">XP earned</p>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-center">
+          <p className="text-2xl font-bold text-slate-900">{data.stats.milestoneXp.first_quest_completed}</p>
+          <p className="text-xs text-slate-500 mt-1">XP per referral</p>
+        </div>
+      </div>
+
+      {/* Referral list */}
+      {data.referrals.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Your referrals</p>
+          {data.referrals.map((r) => (
+            <div key={r.id} className="flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 px-4 py-2.5">
+              <div>
+                <p className="text-sm font-medium text-slate-900">{r.name ?? r.username}</p>
+                <p className="text-xs text-slate-400">{r.questsCompleted} quest{r.questsCompleted !== 1 ? 's' : ''} completed</p>
+              </div>
+              <span className={`text-xs font-semibold px-2 py-1 rounded-full ${r.questsCompleted >= 1 ? 'bg-orange-100 text-orange-700' : 'bg-slate-100 text-slate-500'}`}>
+                {r.questsCompleted >= 1 ? '+200 XP earned' : 'Pending'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
 }
 
 export default function SettingsPage() {
@@ -185,6 +272,8 @@ export default function SettingsPage() {
           </form>
         )}
       </section>
+
+      {session?.user?.role === 'adventurer' && <ReferralCard />}
     </div>
   );
 }

--- a/components/ui/full-screen-signup.tsx
+++ b/components/ui/full-screen-signup.tsx
@@ -214,6 +214,7 @@ function RegisterFormInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const defaultTab = searchParams.get("tab") === "company" ? "company" : "adventurer";
+  const refCode = searchParams.get("ref") ?? undefined;
   const { data: session, status } = useSession();
   const [isLoading, setIsLoading] = useState(false);
   const [tab, setTab] = useState<"adventurer" | "company">(defaultTab as "adventurer" | "company");
@@ -248,6 +249,7 @@ function RegisterFormInner() {
           email, password, name, role,
           companyName: role === "company" ? cName : "",
           username: role === "adventurer" ? aUsername : undefined,
+          referralCode: refCode,
         }),
       });
       if (!res.ok) {
@@ -268,6 +270,11 @@ function RegisterFormInner() {
 
   return (
     <div className="flex flex-col gap-4">
+      {refCode && (
+        <div className="rounded-xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-800">
+          🎉 You were referred by a friend! You'll get <strong>50 bonus XP</strong> when you sign up.
+        </div>
+      )}
       {tab === "adventurer" ? (
         <>
           <OAuthSignInButton

--- a/lib/referral-utils.ts
+++ b/lib/referral-utils.ts
@@ -1,0 +1,78 @@
+import { prisma } from '@/lib/db';
+import { updateUserXpAndSkills } from '@/lib/xp-utils';
+
+// XP given to the referrer at each milestone
+export const REFERRAL_XP: Record<string, number> = {
+  first_quest_completed: 200,
+  three_quests_completed: 500,
+};
+
+// XP bonus given to the referee on signup
+export const REFEREE_SIGNUP_XP = 50;
+
+/** Generate a short unique referral code like ABID4X2K */
+export function generateReferralCode(name: string): string {
+  const prefix = name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+    .slice(0, 4)
+    .padEnd(4, 'X');
+  const suffix = Math.random().toString(36).toUpperCase().slice(2, 6);
+  return `${prefix}${suffix}`;
+}
+
+/** Ensure the user has a referral code; generate one if missing. */
+export async function ensureReferralCode(userId: string, name: string): Promise<string> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { referralCode: true },
+  });
+  if (user?.referralCode) return user.referralCode;
+
+  // Try up to 5 times for uniqueness
+  for (let i = 0; i < 5; i++) {
+    const code = generateReferralCode(name ?? 'USER');
+    try {
+      const updated = await prisma.user.update({
+        where: { id: userId },
+        data: { referralCode: code },
+        select: { referralCode: true },
+      });
+      return updated.referralCode!;
+    } catch {
+      // Unique constraint violation — retry
+    }
+  }
+  throw new Error('Could not generate unique referral code');
+}
+
+/**
+ * Called after a quest is approved (XP awarded). Checks if the completing user
+ * was referred and whether the referrer should earn a milestone reward.
+ */
+export async function processReferralMilestone(refereeId: string, completionCount: number) {
+  const referee = await prisma.user.findUnique({
+    where: { id: refereeId },
+    select: { referredById: true },
+  });
+  if (!referee?.referredById) return;
+
+  const referrerId = referee.referredById;
+  const events: string[] = [];
+
+  if (completionCount === 1) events.push('first_quest_completed');
+  if (completionCount === 3) events.push('three_quests_completed');
+
+  for (const event of events) {
+    const xp = REFERRAL_XP[event];
+    try {
+      // @@unique([giverId, earnerId, event]) prevents double-awarding
+      await prisma.referralReward.create({
+        data: { giverId: referrerId, earnerId: refereeId, event, xpAwarded: xp },
+      });
+      await updateUserXpAndSkills(referrerId, xp, 0, undefined);
+    } catch {
+      // Already awarded — skip
+    }
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -229,12 +229,19 @@ model User {
   partyMembers         PartyMember[]
   activityLogs         ActivityLog[]
   achievements         Achievement[]
+  referralCode         String?               @unique @map("referral_code")
+  referredById         String?               @map("referred_by_id") @db.Uuid
+  referredBy           User?                 @relation("Referrals", fields: [referredById], references: [id])
+  referrals            User[]                @relation("Referrals")
+  referralRewardsGiven ReferralReward[]      @relation("ReferralGiver")
+  referralRewardsEarned ReferralReward[]     @relation("ReferralEarner")
 
   @@index([email])
   @@index([username])
   @@index([role])
   @@index([rank])
   @@index([isActive])
+  @@index([referralCode])
   @@map("users")
 }
 
@@ -707,4 +714,21 @@ model Achievement {
   @@unique([userId, type])
   @@index([userId])
   @@map("achievements")
+}
+
+model ReferralReward {
+  id         String   @id @default(uuid()) @db.Uuid
+  giverId    String   @map("giver_id") @db.Uuid   // the referrer who earns
+  earnerId   String   @map("earner_id") @db.Uuid  // the referee who triggered it
+  event      String   // 'first_quest_completed' | 'three_quests_completed'
+  xpAwarded  Int      @map("xp_awarded")
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  giver  User @relation("ReferralGiver", fields: [giverId], references: [id], onDelete: Cascade)
+  earner User @relation("ReferralEarner", fields: [earnerId], references: [id], onDelete: Cascade)
+
+  @@unique([giverId, earnerId, event])
+  @@index([giverId])
+  @@index([earnerId])
+  @@map("referral_rewards")
 }


### PR DESCRIPTION
## What this adds

A complete referral system. Students share their link, referred friends get a bonus on signup, referrer earns XP when the friend actually completes quests (not just signs up — prevents spam).

## Schema
- `User.referralCode` — unique short code generated on signup (e.g. `ABID4X2K`)
- `User.referredById` — self-relation tracking who referred who
- `ReferralReward` — audit table with `@@unique([giverId, earnerId, event])` to prevent double-awarding

## How it works
1. Student goes to `/dashboard/settings` → copies their referral link (`guilds.work/register?ref=ABID4X2K`)
2. Friend opens link → sees orange banner "You were referred! +50 XP on signup"
3. Friend signs up → gets 50 XP instantly, referrer is recorded
4. Friend completes **first quest** → referrer gets **200 XP** automatically
5. Friend completes **3 quests** → referrer gets **500 XP** more
6. All tracked in `ReferralReward` — idempotent, can't double-award

## Files
- `lib/referral-utils.ts` — code generation, `ensureReferralCode`, `processReferralMilestone`
- `app/api/referral/route.ts` — GET endpoint: code, link, stats, referral list
- `app/api/auth/register/route.ts` — accepts `referralCode` param, awards signup XP, generates code for new user
- `app/api/quests/submissions/route.ts` — hooks `processReferralMilestone` after quest approval
- `components/ui/full-screen-signup.tsx` — reads `?ref=` param, shows banner, passes code to API
- `app/dashboard/settings/page.tsx` — `ReferralCard` component with copy link, stats, referral list

## Test plan
- [ ] Sign up without ref code → no bonus XP, gets own code generated
- [ ] Sign up with `?ref=VALIDCODE` → +50 XP on account, orange banner shown
- [ ] Sign up with `?ref=INVALID` → registers normally, no error, no bonus
- [ ] Approve a quest for a referred user → referrer gets 200 XP in ReferralReward
- [ ] Approve same quest twice → no double-award (unique constraint)
- [ ] `/dashboard/settings` shows ReferralCard with correct link and stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)