### PR TITLE
fix: company quest edit flow — admin bypass, allowlist sync, visibility

### DIFF
--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -13,7 +13,8 @@ export async function GET(request: NextRequest) {
 
     // Parse query parameters
     const { searchParams } = new URL(request.url);
-    const companyId = authUser.id;
+    const isOwner = authUser.role === 'company';
+    const ownerCompanyId = authUser.id;
     const status = searchParams.get('status');
     const questType = searchParams.get('questType');
     const difficulty = searchParams.get('difficulty');
@@ -21,8 +22,8 @@ export async function GET(request: NextRequest) {
     const limit = searchParams.get('limit') || '10';
     const offset = searchParams.get('offset') || '0';
 
-    // Build where clause
-    const where: Prisma.QuestWhereInput = { companyId };
+    // Build where clause — admins see all quests, companies see only their own
+    const where: Prisma.QuestWhereInput = isOwner ? { companyId: ownerCompanyId } : {};
 
     if (status) {
       if (!Object.values(QuestStatus).includes(status as QuestStatus)) {
@@ -153,29 +154,33 @@ export async function PUT(request: NextRequest) {
 
     const body = await request.json();
     const { questId } = body;
-    const companyId = authUser.id;
+    const isOwner = authUser.role === 'company';
+    const ownerCompanyId = authUser.id;
 
     if (!questId) {
       return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
 
-    // Verify the company owns this quest
+    // Verify the company owns this quest (admins can edit any quest)
     const quest = await prisma.quest.findUnique({
       where: { id: questId },
       select: { companyId: true },
     });
 
-    if (!quest || quest.companyId !== companyId) {
+    if (!quest) {
+      return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
+    }
+
+    if (isOwner && quest.companyId !== ownerCompanyId) {
       return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 
-    // Explicit allowlist — never spread raw body into Prisma to prevent field injection
+    // Explicit allowlist — matches the Quest model fields exactly
     const ALLOWED_FIELDS = [
       'title', 'description', 'detailedDescription', 'questType', 'difficulty',
       'xpReward', 'skillPointsReward', 'monetaryReward', 'requiredSkills',
       'requiredRank', 'maxParticipants', 'questCategory', 'track', 'source', 'deadline',
-      'partnerOrgName',
-      'submissionInstructions', 'expectedDeliverables',
+      'partnerOrgName', 'fieldTemplateId', 'briefData', 'acceptanceCriteria', 'parentQuestId',
     ] as const;
 
     const prismaUpdateFields: Record<string, unknown> = {};
@@ -207,20 +212,25 @@ export async function DELETE(request: NextRequest) {
 
     const body = await request.json();
     const { questId } = body;
-    const companyId = authUser.id;
+    const isOwner = authUser.role === 'company';
+    const ownerCompanyId = authUser.id;
 
     // Validate required fields
-    if (!questId || !companyId) {
-      return NextResponse.json({ error: 'Quest ID and Company ID are required', success: false }, { status: 400 });
+    if (!questId) {
+      return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
 
-    // Verify the company owns this quest
+    // Verify the company owns this quest (admins can cancel any quest)
     const quest = await prisma.quest.findUnique({
       where: { id: questId },
       select: { companyId: true },
     });
 
-    if (!quest || quest.companyId !== companyId) {
+    if (!quest) {
+      return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
+    }
+
+    if (isOwner && quest.companyId !== ownerCompanyId) {
       return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 

--- a/app/dashboard/company/quests/[id]/edit/page.tsx
+++ b/app/dashboard/company/quests/[id]/edit/page.tsx
@@ -49,6 +49,9 @@ interface QuestData {
   deadline?: string | null;
   status: string;
   companyId?: string | null;
+  partnerOrgName?: string | null;
+  track?: string | null;
+  source?: string | null;
 }
 
 export default function EditQuestPage({ params }: { params: Promise<{ id: string }> }) {
@@ -70,6 +73,9 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
     requiredRank: '',
     maxParticipants: 1,
     deadline: '',
+    partnerOrgName: '',
+    track: 'OPEN',
+    source: 'CLIENT_PORTAL',
   });
 
   const [fetchLoading, setFetchLoading] = useState(true);
@@ -122,6 +128,9 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
           requiredRank: q.requiredRank || '',
           maxParticipants: q.maxParticipants ?? 1,
           deadline: q.deadline ? new Date(q.deadline).toISOString().split('T')[0] : '',
+          partnerOrgName: q.partnerOrgName || '',
+          track: q.track || 'OPEN',
+          source: q.source || 'CLIENT_PORTAL',
         });
       } catch {
         toast.error('Failed to load quest');
@@ -174,6 +183,9 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
         requiredRank: form.requiredRank || null,
         maxParticipants: Number(form.maxParticipants) || 1,
         deadline: form.deadline || null,
+        partnerOrgName: form.partnerOrgName.trim() || null,
+        track: form.track,
+        source: form.source,
       };
 
       const response = await fetchWithAuth('/api/company/quests', {
@@ -384,6 +396,40 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
                     />
                   </div>
                 </div>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="space-y-2">
+                <Label>Track</Label>
+                <Select value={form.track} onValueChange={v => updateField('track', v)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="OPEN">Open</SelectItem>
+                    <SelectItem value="BOOTCAMP">Bootcamp</SelectItem>
+                    <SelectItem value="INTERN">Intern</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Source</Label>
+                <Select value={form.source} onValueChange={v => updateField('source', v)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="CLIENT_PORTAL">Client Portal</SelectItem>
+                    <SelectItem value="TUTORIAL">Tutorial</SelectItem>
+                    <SelectItem value="HACKATHON">Hackathon</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="partnerOrgName">Partner Org Name</Label>
+                <Input
+                  id="partnerOrgName"
+                  placeholder="Optional partner organization"
+                  value={form.partnerOrgName}
+                  onChange={e => updateField('partnerOrgName', e.target.value)}
+                />
               </div>
             </div>
 

--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -6,8 +6,6 @@ interface SendEmailParams {
   html: string;
 }
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export async function sendEmail({ to, subject, html }: SendEmailParams): Promise<void> {
   const isDev = process.env.NODE_ENV !== 'production';
   const resendConfigured = !!process.env.RESEND_API_KEY;
@@ -27,6 +25,7 @@ export async function sendEmail({ to, subject, html }: SendEmailParams): Promise
     throw new Error('Resend API key is not configured. Set RESEND_API_KEY environment variable.');
   }
 
+  const resend = new Resend(process.env.RESEND_API_KEY);
   try {
     console.log('[mail] Calling Resend API...');
     const result = await resend.emails.send({

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -39,7 +39,8 @@ export async function getQuests(searchParams: URLSearchParams, user: SessionUser
     // no restriction
     console.log('[quest-service] Admin view - no restrictions');
   } else if (user.role === 'company') {
-    visibilityFilter = { OR: [{ companyId: user.id }, { status: 'available', track: 'OPEN' }] };
+    // Companies see their own quests (any status) + public open quests
+    visibilityFilter = { OR: [{ companyId: user.id }, { companyId: null, status: 'available', track: 'OPEN' }] };
     console.log('[quest-service] Company view');
   } else if (bootcampLink) {
     // Bootcamp students: locked to BOOTCAMP track, tutorial-only until eligible


### PR DESCRIPTION
## What this does

Fixes three overlapping bugs that prevented companies (and admins) from editing quests.

Closes #288

## Root cause

**1. Admin authorization bug** — PUT/DELETE handlers in `app/api/company/quests/route.ts` used `companyId = authUser.id` with no admin bypass. Admins have no `CompanyProfile`, so the ownership check always failed with 403.

**2. PUT allowlist out of sync** — The allowlist had non-schema fields (`submissionInstructions`, `expectedDeliverables`) and was missing schema fields (`fieldTemplateId`, `briefData`, `acceptanceCriteria`, `parentQuestId`). Those fields were silently dropped on save.

**3. Quest visibility fix** — `quest-service.ts` public quest filter now requires `companyId: null` to avoid accidentally surfacing company-owned quests with wrong status.

## Changes

### `app/api/company/quests/route.ts`
- **GET**: Admin gets all quests (`where = {}`); company gets only their own
- **PUT**: `isOwner` flag — admin skips ownership check; allowlist synced to Prisma schema
- **DELETE**: Same `isOwner` pattern

### `app/dashboard/company/quests/[id]/edit/page.tsx`
- Added `partnerOrgName`, `track`, `source` to form state, pre-fill, and submit body
- Added 3-column grid with Track / Source / Partner Org fields

### `lib/services/quest-service.ts`
- Public quest filter now explicitly requires `companyId: null`

### `lib/mail.ts`
- Moved `new Resend()` inside `sendEmail()` to prevent build crash when `RESEND_API_KEY` is unset in CI

## Test plan
- [ ] Admin can save edits on any company quest
- [ ] Admin can cancel any company quest
- [ ] Company can still only edit/cancel their own quests (ownership enforced)
- [ ] `partnerOrgName`, `track`, `source` fields save correctly on edit
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)