### PR TITLE
fix: defer Resend instantiation — fixes CI build crash on all branches

### DIFF
--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -6,8 +6,6 @@ interface SendEmailParams {
   html: string;
 }
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export async function sendEmail({ to, subject, html }: SendEmailParams): Promise<void> {
   const isDev = process.env.NODE_ENV !== 'production';
   const resendConfigured = !!process.env.RESEND_API_KEY;
@@ -27,6 +25,7 @@ export async function sendEmail({ to, subject, html }: SendEmailParams): Promise
     throw new Error('Resend API key is not configured. Set RESEND_API_KEY environment variable.');
   }
 
+  const resend = new Resend(process.env.RESEND_API_KEY);
   try {
     console.log('[mail] Calling Resend API...');
     const result = await resend.emails.send({


### PR DESCRIPTION
## What this does

Fixes a build-time crash that has been breaking CI on every PR that includes `lib/mail.ts`.

Closes #288

## Root cause

```ts
// Before — crashes at build time when RESEND_API_KEY is unset:
const resend = new Resend(process.env.RESEND_API_KEY); // top-level module code
```

`new Resend()` throws `Missing API key` when the env var isn't set. Next.js runs module-level code during static analysis / build, so CI fails on the `forgot-password` route without the key.

```ts
// After — only runs at call time, after the env check:
const resend = new Resend(process.env.RESEND_API_KEY); // inside sendEmail(), after resendConfigured check
```

## Test plan
- [ ] `npm run build` passes without `RESEND_API_KEY` set
- [ ] Email sending still works in production with the key set

🤖 Generated with [Claude Code](https://claude.com/claude-code)