### PR TITLE
fix: company quest edit — admin bypass, full field support, profile pre-fill

### DIFF
--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -4,6 +4,10 @@ import { requireAuth } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 import { Prisma, QuestStatus, QuestType, UserRank, QuestTrack, QuestSource } from '@prisma/client';
 
+function canManageQuest(authUser: { id: string; role: string }, questCompanyId: string | null) {
+  return authUser.role === 'admin' || (!!questCompanyId && questCompanyId === authUser.id);
+}
+
 export async function GET(request: NextRequest) {
   try {
     const authUser = await requireAuth(request, 'company', 'admin');
@@ -15,6 +19,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const isOwner = authUser.role === 'company';
     const ownerCompanyId = authUser.id;
+    const requestedCompanyId = searchParams.get('companyId');
     const status = searchParams.get('status');
     const questType = searchParams.get('questType');
     const difficulty = searchParams.get('difficulty');
@@ -22,8 +27,12 @@ export async function GET(request: NextRequest) {
     const limit = searchParams.get('limit') || '10';
     const offset = searchParams.get('offset') || '0';
 
-    // Build where clause — admins see all quests, companies see only their own
-    const where: Prisma.QuestWhereInput = isOwner ? { companyId: ownerCompanyId } : {};
+    // Build where clause — companies see only their own, admins see all (or filter by ?companyId=)
+    const where: Prisma.QuestWhereInput = isOwner
+      ? { companyId: ownerCompanyId }
+      : requestedCompanyId
+        ? { companyId: requestedCompanyId }
+        : {};
 
     if (status) {
       if (!Object.values(QuestStatus).includes(status as QuestStatus)) {
@@ -154,9 +163,6 @@ export async function PUT(request: NextRequest) {
 
     const body = await request.json();
     const { questId } = body;
-    const isOwner = authUser.role === 'company';
-    const ownerCompanyId = authUser.id;
-
     if (!questId) {
       return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
     }
@@ -171,23 +177,62 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
     }
 
-    if (isOwner && quest.companyId !== ownerCompanyId) {
+    if (!canManageQuest(authUser, quest.companyId)) {
       return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 
-    // Explicit allowlist — matches the Quest model fields exactly
-    const ALLOWED_FIELDS = [
-      'title', 'description', 'detailedDescription', 'questType', 'difficulty',
-      'xpReward', 'skillPointsReward', 'monetaryReward', 'requiredSkills',
-      'requiredRank', 'maxParticipants', 'questCategory', 'track', 'source', 'deadline',
-      'partnerOrgName', 'fieldTemplateId', 'briefData', 'acceptanceCriteria', 'parentQuestId',
-    ] as const;
+    if (body.questType && !Object.values(QuestType).includes(body.questType as QuestType)) {
+      return NextResponse.json({ error: 'Invalid questType value', success: false }, { status: 400 });
+    }
+    if (body.difficulty && !Object.values(UserRank).includes(body.difficulty as UserRank)) {
+      return NextResponse.json({ error: 'Invalid difficulty value', success: false }, { status: 400 });
+    }
+    if (body.track && !Object.values(QuestTrack).includes(body.track as QuestTrack)) {
+      return NextResponse.json({ error: 'Invalid track value', success: false }, { status: 400 });
+    }
+    if (body.source && !Object.values(QuestSource).includes(body.source as QuestSource)) {
+      return NextResponse.json({ error: 'Invalid source value', success: false }, { status: 400 });
+    }
 
-    const prismaUpdateFields: Record<string, unknown> = {};
-    for (const field of ALLOWED_FIELDS) {
-      if (field in body && body[field] !== undefined) {
-        prismaUpdateFields[field] = body[field];
-      }
+    const prismaUpdateFields: Prisma.QuestUpdateInput = {};
+
+    if ('title' in body) prismaUpdateFields.title = body.title;
+    if ('description' in body) prismaUpdateFields.description = body.description;
+    if ('detailedDescription' in body) prismaUpdateFields.detailedDescription = body.detailedDescription;
+    if ('questType' in body) prismaUpdateFields.questType = body.questType;
+    if ('difficulty' in body) prismaUpdateFields.difficulty = body.difficulty;
+    if ('xpReward' in body) prismaUpdateFields.xpReward = body.xpReward;
+    if ('skillPointsReward' in body) prismaUpdateFields.skillPointsReward = body.skillPointsReward;
+    if ('monetaryReward' in body) prismaUpdateFields.monetaryReward = body.monetaryReward;
+    if ('requiredSkills' in body) prismaUpdateFields.requiredSkills = body.requiredSkills;
+    if ('requiredRank' in body) prismaUpdateFields.requiredRank = body.requiredRank;
+    if ('maxParticipants' in body) prismaUpdateFields.maxParticipants = body.maxParticipants;
+    if ('questCategory' in body) prismaUpdateFields.questCategory = body.questCategory;
+    if ('track' in body) prismaUpdateFields.track = body.track;
+    if ('source' in body) prismaUpdateFields.source = body.source;
+    if ('partnerOrgName' in body) prismaUpdateFields.partnerOrgName = body.partnerOrgName;
+    if ('parentQuestId' in body) {
+      prismaUpdateFields.parentQuest = body.parentQuestId
+        ? { connect: { id: body.parentQuestId } }
+        : { disconnect: true };
+    }
+    if ('fieldTemplateId' in body) {
+      prismaUpdateFields.fieldTemplate = body.fieldTemplateId
+        ? { connect: { id: body.fieldTemplateId } }
+        : { disconnect: true };
+    }
+    if ('acceptanceCriteria' in body) {
+      prismaUpdateFields.acceptanceCriteria = Array.isArray(body.acceptanceCriteria) ? body.acceptanceCriteria : [];
+    }
+    if ('briefData' in body) {
+      prismaUpdateFields.briefData = body.briefData ?? Prisma.JsonNull;
+    }
+    if ('deadline' in body) {
+      prismaUpdateFields.deadline = body.deadline ? new Date(body.deadline) : null;
+    }
+
+    if (Object.keys(prismaUpdateFields).length === 0) {
+      return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });
     }
 
     // Update the quest
@@ -212,9 +257,6 @@ export async function DELETE(request: NextRequest) {
 
     const body = await request.json();
     const { questId } = body;
-    const isOwner = authUser.role === 'company';
-    const ownerCompanyId = authUser.id;
-
     // Validate required fields
     if (!questId) {
       return NextResponse.json({ error: 'Quest ID is required', success: false }, { status: 400 });
@@ -230,7 +272,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Quest not found', success: false }, { status: 404 });
     }
 
-    if (isOwner && quest.companyId !== ownerCompanyId) {
+    if (!canManageQuest(authUser, quest.companyId)) {
       return NextResponse.json({ error: 'Unauthorized: You do not own this quest', success: false }, { status: 403 });
     }
 

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -3,6 +3,48 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/api-auth';
 import { prisma } from '@/lib/db';
 
+export async function GET(request: NextRequest) {
+  try {
+    const authUser = await getAuthUser(request);
+    if (!authUser) {
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: authUser.id },
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        email: true,
+        bio: true,
+        location: true,
+        website: true,
+        github: true,
+        linkedin: true,
+        discord: true,
+        role: true,
+        companyProfile: {
+          select: {
+            companyName: true,
+            companyWebsite: true,
+            companyDescription: true,
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found', success: false }, { status: 404 });
+    }
+
+    return NextResponse.json({ user, success: true });
+  } catch (error) {
+    console.error('Error fetching user profile:', error);
+    return NextResponse.json({ error: 'Failed to fetch profile', success: false }, { status: 500 });
+  }
+}
+
 export async function PATCH(request: NextRequest) {
   try {
     const authUser = await getAuthUser(request);

--- a/app/dashboard/company/profile/page.tsx
+++ b/app/dashboard/company/profile/page.tsx
@@ -25,6 +25,15 @@ import { toast } from 'sonner';
 import { useApiFetch } from '@/lib/hooks';
 import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
+interface CompanyProfileData {
+  name: string | null;
+  companyProfile: {
+    companyName: string | null;
+    companyWebsite: string | null;
+    companyDescription: string | null;
+  } | null;
+}
+
 export default function CompanyProfilePage() {
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -34,10 +43,13 @@ export default function CompanyProfilePage() {
   const [website, setWebsite] = useState('');
   const shouldFetch =
     status === 'authenticated' && (session?.user?.role === 'company' || session?.user?.role === 'admin');
-  const { data, loading } = useApiFetch<{ success: boolean; quests: Array<{ status: string }> }>(
+  const { data, loading } = useApiFetch<{ quests: Array<{ status: string }>; success: boolean }>(
     '/api/company/quests',
     { skip: !shouldFetch }
   );
+  const { data: profileData } = useApiFetch<CompanyProfileData>('/api/users/me', {
+    skip: !shouldFetch,
+  });
 
   useEffect(() => {
     if (status === 'authenticated' && session?.user?.role !== 'company' && session?.user?.role !== 'admin') {
@@ -46,12 +58,20 @@ export default function CompanyProfilePage() {
     }
 
     if (status === 'authenticated') {
-      setCompanyName(session?.user?.name || '');
+      setCompanyName(
+        profileData?.companyProfile?.companyName ||
+        profileData?.name ||
+        session?.user?.name ||
+        ''
+      );
+      setWebsite(profileData?.companyProfile?.companyWebsite || '');
+      setDescription(profileData?.companyProfile?.companyDescription || '');
     }
-  }, [status, session, router]);
+  }, [status, session, router, profileData]);
 
   const quests = data?.quests || [];
   const questCount = quests.length;
+
   const completedCount = quests.filter((quest) => quest.status === 'completed').length;
 
   const handleSave = async () => {

--- a/app/dashboard/company/quests/[id]/edit/page.tsx
+++ b/app/dashboard/company/quests/[id]/edit/page.tsx
@@ -49,9 +49,19 @@ interface QuestData {
   deadline?: string | null;
   status: string;
   companyId?: string | null;
-  partnerOrgName?: string | null;
   track?: string | null;
   source?: string | null;
+  partnerOrgName?: string | null;
+  parentQuestId?: string | null;
+  fieldTemplateId?: string | null;
+  briefData?: unknown;
+  acceptanceCriteria?: string[];
+}
+
+function mergeDeadlineDateWithExistingTime(dateOnly: string, existingIso: string | null) {
+  if (!dateOnly) return null;
+  if (!existingIso || !existingIso.includes('T')) return dateOnly;
+  return `${dateOnly}${existingIso.slice(existingIso.indexOf('T'))}`;
 }
 
 export default function EditQuestPage({ params }: { params: Promise<{ id: string }> }) {
@@ -82,6 +92,16 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [questData, setQuestData] = useState<QuestData | null>(null);
+  const [metadata, setMetadata] = useState({
+    track: null as string | null,
+    source: null as string | null,
+    partnerOrgName: null as string | null,
+    parentQuestId: null as string | null,
+    fieldTemplateId: null as string | null,
+    briefData: null as unknown,
+    acceptanceCriteria: [] as string[],
+    deadlineIso: null as string | null,
+  });
 
   useEffect(() => {
     if (status === 'unauthenticated') {
@@ -105,6 +125,16 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
         }
         const q: QuestData = data.quest;
         setQuestData(q);
+        setMetadata({
+          track: q.track ?? null,
+          source: q.source ?? null,
+          partnerOrgName: q.partnerOrgName ?? null,
+          parentQuestId: q.parentQuestId ?? null,
+          fieldTemplateId: q.fieldTemplateId ?? null,
+          briefData: q.briefData ?? null,
+          acceptanceCriteria: Array.isArray(q.acceptanceCriteria) ? q.acceptanceCriteria : [],
+          deadlineIso: q.deadline ?? null,
+        });
 
         // Verify ownership (admin can edit any quest)
         if (session?.user?.role === 'company' && q.companyId !== session.user.id) {
@@ -182,10 +212,16 @@ export default function EditQuestPage({ params }: { params: Promise<{ id: string
           : [],
         requiredRank: form.requiredRank || null,
         maxParticipants: Number(form.maxParticipants) || 1,
-        deadline: form.deadline || null,
+        deadline: form.deadline
+          ? mergeDeadlineDateWithExistingTime(form.deadline, metadata.deadlineIso)
+          : null,
         partnerOrgName: form.partnerOrgName.trim() || null,
         track: form.track,
         source: form.source,
+        parentQuestId: metadata.parentQuestId,
+        fieldTemplateId: metadata.fieldTemplateId,
+        briefData: metadata.briefData,
+        acceptanceCriteria: metadata.acceptanceCriteria,
       };
 
       const response = await fetchWithAuth('/api/company/quests', {

--- a/app/dashboard/company/quests/page.tsx
+++ b/app/dashboard/company/quests/page.tsx
@@ -55,7 +55,7 @@ export default function CompanyQuestsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const shouldFetch =
     status === 'authenticated' && (session?.user?.role === 'company' || session?.user?.role === 'admin');
-  const { data, loading, error } = useApiFetch<{ success: boolean; quests: Quest[]; error?: string }>(
+  const { data, loading, error } = useApiFetch<{ quests: Quest[]; success: boolean }>(
     '/api/company/quests?limit=80',
     { skip: !shouldFetch }
   );

--- a/components/company/useCompanyPortalState.ts
+++ b/components/company/useCompanyPortalState.ts
@@ -21,7 +21,7 @@ export function useCompanyPortalState(companyId: string) {
     loading,
     refetch: loadCompanyQuests,
     mutate,
-  } = useApiFetch<CompanyQuestsResponse>(`/api/company/quests?company_id=${companyId}`, {
+  } = useApiFetch<CompanyQuestsResponse>(`/api/company/quests?companyId=${companyId}`, {
     skip: !shouldFetch,
   });
   const companyQuests = data?.quests ?? EMPTY_COMPANY_QUESTS;

--- a/lib/services/public-quest-service.ts
+++ b/lib/services/public-quest-service.ts
@@ -19,10 +19,11 @@ export async function getPublicQuests(filters: PublicQuestFilters = {}) {
     status: QuestStatus.available,
   };
 
-  // Track filter (default to OPEN for public visitors)
+  // Track filter — default to OPEN for public visitors, but respect explicit filter
   if (track && Object.values(QuestTrack).includes(track as QuestTrack)) {
     where.track = track as QuestTrack;
   } else {
+    // Show OPEN quests publicly (INTERN and BOOTCAMP are private tracks)
     where.track = QuestTrack.OPEN;
   }
 


### PR DESCRIPTION
## Summary

- **Admin can now edit/cancel any quest** — `canManageQuest()` helper replaces the raw `companyId === authUser.id` check that always blocked admins
- **Full field support on edit** — PUT handler now uses `Prisma.QuestUpdateInput` with proper relational connect/disconnect for `parentQuestId` and `fieldTemplateId`, `Prisma.JsonNull` for `briefData`, enum validation, Date coercion for deadline
- **Profile page pre-fills correctly** — new GET `/api/users/me` returns companyProfile fields; profile page loads companyName/website/description from DB instead of stale session token
- **Quest list pages fixed** — TypeScript types corrected (API returns `{ quests: [...] }` object, not a bare array; a wrong `Array.isArray` guard was causing the list to always render empty)
- **`?companyId=` query param aligned** — `useCompanyPortalState` was sending `?company_id=` but the GET handler reads `companyId`

## Bugs fixed (from previous agent's work)

The previous agent did valid core work (admin bypass pattern, Prisma type improvements, metadata state, deadline time-preservation). It introduced 3 bugs:

1. Duplicate `const quests` declaration in `profile/page.tsx` (lines 50 + 73) — TypeScript error
2. TypeScript type set to `Quest[]` (direct array) but API returns `{ quests: Quest[] }` — `Array.isArray(data)` always false → quest list always empty
3. Fragile `as string[]` Prisma cast in `public-quest-service.ts` — simplified back to `track: QuestTrack.OPEN`

`tsc --noEmit` passes clean.

## Test plan
- [ ] Company user can edit their quest (title, description, deadline, track, etc.)
- [ ] Admin can edit any quest via `/dashboard/company/quests/[id]/edit`
- [ ] Company quests list loads (not empty)
- [ ] Company profile page pre-fills companyName/website/description from DB
- [ ] Admin can cancel/delete a quest
- [ ] Public quest board shows only OPEN-track quests

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)