### PR TITLE
feat: implement daily standup workflow with automated quest task trac…

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -206,6 +206,13 @@ export default function AdminDashboard() {
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </Button>
+            <Button variant="outline" asChild className="border-rose-500/30 text-rose-400 hover:bg-rose-500/10">
+              <Link href="/admin/updates">
+                <Clock className="h-4 w-4" />
+                Missed Updates
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
             <Button variant="outline" asChild>
               <Link href="/admin/quest-templates">
                 <ClipboardList className="h-4 w-4" />

--- a/app/admin/updates/page.tsx
+++ b/app/admin/updates/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
+import { Loader2, Phone, AlertTriangle, ArrowLeft, RefreshCw, Award, UserX } from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+
+interface MissedAssignment {
+  assignmentId: string;
+  questId: string;
+  questTitle: string;
+  studentId: string;
+  studentName: string;
+  studentEmail: string;
+  studentPhone: string;
+  guildScore: number;
+  lastUpdateAt: string | null;
+  startedAt: string;
+  hoursSinceLastUpdate: number;
+}
+
+export default function MissedUpdatesPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [assignments, setAssignments] = useState<MissedAssignment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+      return;
+    }
+    if (status === "authenticated" && session?.user?.role !== "admin") {
+      router.push("/dashboard");
+    }
+  }, [router, session, status]);
+
+  const fetchMissedUpdates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth("/api/admin/missed-updates");
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Failed to load missed updates");
+      }
+      setAssignments(data.assignments);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === "authenticated" && session?.user?.role === "admin") {
+      fetchMissedUpdates();
+    }
+  }, [status, session, fetchMissedUpdates]);
+
+  const sendWhatsAppNudge = (item: MissedAssignment) => {
+    if (!item.studentPhone) {
+      toast.error("Student does not have a phone number on record.");
+      return;
+    }
+
+    const cleanPhone = item.studentPhone.replace(/\D/g, "");
+    const message = `Hi ${item.studentName}, you are currently assigned to the quest "${item.questTitle}". We noticed you haven't submitted a daily standup update in ${item.hoursSinceLastUpdate} hours. Please submit your update in the dashboard to maintain your Guild Score (${item.guildScore}) and prevent reward deductions! Let us know if you have any blockers. Thanks, Adventurers Guild Team.`;
+    
+    const waUrl = `https://wa.me/${cleanPhone}?text=${encodeURIComponent(message)}`;
+    window.open(waUrl, "_blank");
+    toast.success(`WhatsApp nudge window opened for ${item.studentName}`);
+  };
+
+  const handleReassign = async (assignmentId: string, studentName: string) => {
+    if (!confirm(`Are you sure you want to cancel ${studentName}'s assignment and release the quest?`)) return;
+
+    try {
+      const res = await fetchWithAuth("/api/admin/updates/reassign", {
+        method: "POST",
+        body: JSON.stringify({ assignmentId }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.error);
+      
+      toast.success("Quest reassigned successfully");
+      fetchMissedUpdates();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to reassign quest");
+    }
+  };
+
+  if (status === "loading" || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-950 text-white">
+        <Loader2 className="h-10 w-10 animate-spin text-orange-500" />
+      </div>
+    );
+  }
+
+  if (status !== "authenticated" || session?.user?.role !== "admin") {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 border-b border-slate-800 pb-5">
+        <div className="space-y-1">
+          <Link href="/admin" className="text-xs text-slate-400 hover:text-white flex items-center gap-1 mb-2">
+            <ArrowLeft className="h-3 w-3" />
+            Back to Dashboard
+          </Link>
+          <h1 className="text-2xl font-bold tracking-tight text-white flex items-center gap-2">
+            <AlertTriangle className="h-6 w-6 text-rose-500" />
+            Overdue Daily Updates
+          </h1>
+          <p className="text-sm text-slate-400">
+            Active quest assignments that have missed the 24-hour update window.
+          </p>
+        </div>
+
+        <Button onClick={fetchMissedUpdates} variant="outline" className="border-slate-800 hover:bg-slate-800 text-white bg-slate-900 gap-1.5 self-start">
+          <RefreshCw className="h-4 w-4" />
+          Refresh List
+        </Button>
+      </div>
+
+      {/* Main Table */}
+      <Card className="border-slate-800 bg-slate-900/40 backdrop-blur-md text-white">
+        <CardHeader>
+          <CardTitle>Missed Standups ({assignments.length})</CardTitle>
+          <CardDescription className="text-slate-400">
+            Nudge adventurers directly via WhatsApp to submit their daily updates.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="p-4 bg-rose-500/10 border border-rose-500/20 text-rose-400 rounded-xl text-sm mb-4">
+              {error}
+            </div>
+          )}
+
+          {assignments.length === 0 ? (
+            <div className="py-12 flex flex-col items-center justify-center text-center">
+              <div className="h-12 w-12 rounded-full bg-emerald-500/10 text-emerald-400 flex items-center justify-center mb-3">
+                <Award className="h-6 w-6" />
+              </div>
+              <h3 className="font-semibold text-white">All caught up!</h3>
+              <p className="text-xs text-slate-400 mt-1 max-w-[280px]">
+                Every active student has submitted their daily update in the last 24 hours.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left text-slate-300">
+                <thead className="text-xs uppercase bg-slate-950/60 text-slate-400 border-b border-slate-800">
+                  <tr>
+                    <th className="px-4 py-3">Adventurer</th>
+                    <th className="px-4 py-3">Guild Score</th>
+                    <th className="px-4 py-3">Quest</th>
+                    <th className="px-4 py-3">Last Update</th>
+                    <th className="px-4 py-3 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-800/60">
+                  {assignments.map((item) => (
+                    <tr key={item.assignmentId} className="hover:bg-slate-800/20 transition-colors">
+                      <td className="px-4 py-4 font-medium text-white">
+                        <div>{item.studentName}</div>
+                        <div className="text-[11px] text-slate-500 font-normal">{item.studentEmail}</div>
+                      </td>
+                      <td className="px-4 py-4">
+                        <Badge className={`font-semibold ${
+                          item.guildScore >= 80 
+                            ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20" 
+                            : item.guildScore >= 50 
+                            ? "bg-amber-500/10 text-amber-400 border-amber-500/20" 
+                            : "bg-rose-500/10 text-rose-400 border-rose-500/20"
+                        }`}>
+                          {item.guildScore} / 100
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-4 max-w-[200px] truncate">
+                        {item.questTitle}
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="flex flex-col">
+                          <span className="text-rose-400 font-semibold text-xs">
+                            {item.hoursSinceLastUpdate}h overdue
+                          </span>
+                          <span className="text-[10px] text-slate-500">
+                            {item.lastUpdateAt 
+                              ? `Last: ${new Date(item.lastUpdateAt).toLocaleDateString()}` 
+                              : `Started: ${new Date(item.startedAt).toLocaleDateString()}`}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            onClick={() => sendWhatsAppNudge(item)}
+                            disabled={!item.studentPhone}
+                            className="bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-bold py-1.5 px-3 rounded-lg gap-1.5 inline-flex items-center disabled:opacity-40 disabled:hover:bg-emerald-600"
+                          >
+                            <Phone className="h-3.5 w-3.5" />
+                            Nudge
+                          </Button>
+                          <Button
+                            onClick={() => handleReassign(item.assignmentId, item.studentName)}
+                            variant="destructive"
+                            className="text-xs font-bold py-1.5 px-3 rounded-lg gap-1.5 inline-flex items-center"
+                          >
+                            <UserX className="h-3.5 w-3.5" />
+                            Reassign
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/admin/missed-updates/route.ts
+++ b/app/api/admin/missed-updates/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { getAuthUser } from '@/lib/api-auth';
+
+export async function GET(request: NextRequest) {
+  const user = await getAuthUser(request);
+  if (!user || (user.role !== 'admin' && user.role !== 'company')) {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  try {
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    // Build the query to find started/in-progress quest assignments that have missed a 24-hour update window.
+    // That means status is in ['started', 'in_progress', 'needs_rework'] and:
+    // (lastUpdateAt < oneDayAgo OR (lastUpdateAt IS NULL AND startedAt < oneDayAgo))
+    const where: any = {
+      status: { in: ['started', 'in_progress', 'needs_rework'] },
+      startedAt: { not: null },
+      OR: [
+        { lastUpdateAt: { lt: oneDayAgo } },
+        {
+          AND: [
+            { lastUpdateAt: null },
+            { startedAt: { lt: oneDayAgo } }
+          ]
+        }
+      ]
+    };
+
+    // If company role, filter assignments by company's quests
+    if (user.role === 'company') {
+      where.quest = { companyId: user.id };
+    }
+
+    const assignments = await prisma.questAssignment.findMany({
+      where,
+      include: {
+        quest: {
+          select: {
+            id: true,
+            title: true,
+          },
+        },
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            adventurerProfile: {
+              select: {
+                phoneNumber: true,
+                guildScore: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        lastUpdateAt: 'asc',
+      },
+    });
+
+    const formatted = assignments.map((ass) => {
+      const lastUpdate = ass.lastUpdateAt || ass.startedAt;
+      const hoursSince = lastUpdate 
+        ? Math.floor((Date.now() - new Date(lastUpdate).getTime()) / (1000 * 60 * 60))
+        : 24;
+
+      return {
+        assignmentId: ass.id,
+        questId: ass.quest.id,
+        questTitle: ass.quest.title,
+        studentId: ass.user.id,
+        studentName: ass.user.name || 'Unknown',
+        studentEmail: ass.user.email,
+        studentPhone: ass.user.adventurerProfile?.phoneNumber || '',
+        guildScore: ass.user.adventurerProfile?.guildScore ?? 100,
+        lastUpdateAt: ass.lastUpdateAt,
+        startedAt: ass.startedAt,
+        hoursSinceLastUpdate: hoursSince,
+      };
+    });
+
+    return NextResponse.json({ assignments: formatted, success: true });
+  } catch (error) {
+    console.error('Failed to fetch missed updates:', error);
+    return NextResponse.json({ error: 'Internal server error', success: false }, { status: 500 });
+  }
+}

--- a/app/api/admin/updates/reassign/route.ts
+++ b/app/api/admin/updates/reassign/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
+import { getAuthUser } from '@/lib/api-auth';
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthUser(req);
+  if (!user || user.role !== 'admin') {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  try {
+    const { assignmentId } = await req.json();
+
+    if (!assignmentId) {
+      return NextResponse.json({ error: 'assignmentId is required', success: false }, { status: 400 });
+    }
+
+    const assignment = await prisma.questAssignment.findUnique({
+      where: { id: assignmentId },
+    });
+
+    if (!assignment) {
+      return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
+    }
+
+    await prisma.$transaction(async (tx) => {
+      // Cancel the assignment
+      await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: { status: 'cancelled' },
+      });
+
+      // Re-evaluate quest status (it will go back to available if slots open up)
+      await syncQuestLifecycleStatus(tx, assignment.questId);
+    });
+
+    return NextResponse.json({ success: true, message: 'Quest reassigned successfully' });
+  } catch (error) {
+    console.error('Error reassigning quest:', error);
+    return NextResponse.json({ error: 'Failed to reassign quest', success: false }, { status: 500 });
+  }
+}

--- a/app/api/company/quests/route.ts
+++ b/app/api/company/quests/route.ts
@@ -136,6 +136,7 @@ export async function POST(request: NextRequest) {
         fieldTemplateId: body.fieldTemplateId || null,
         briefData: body.briefData ?? Prisma.JsonNull,
         acceptanceCriteria: Array.isArray(body.acceptanceCriteria) ? body.acceptanceCriteria : [],
+        tasks: Array.isArray(body.tasks) ? body.tasks : [],
       },
     });
 
@@ -223,6 +224,9 @@ export async function PUT(request: NextRequest) {
     }
     if ('acceptanceCriteria' in body) {
       prismaUpdateFields.acceptanceCriteria = Array.isArray(body.acceptanceCriteria) ? body.acceptanceCriteria : [];
+    }
+    if ('tasks' in body) {
+      prismaUpdateFields.tasks = Array.isArray(body.tasks) ? body.tasks : [];
     }
     if ('briefData' in body) {
       prismaUpdateFields.briefData = body.briefData ?? Prisma.JsonNull;

--- a/app/api/cron/check-assignments/route.ts
+++ b/app/api/cron/check-assignments/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
+
+export async function GET(req: Request) {
+  // In a real production scenario, we'd verify a secret or vercel cron header here
+  // const authHeader = req.headers.get('authorization');
+  // if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  //   return new Response('Unauthorized', { status: 401 });
+  // }
+
+  try {
+    const now = new Date();
+    
+    // 1. Check for unaccepted auto-assignments (> 6 hours)
+    const sixHoursAgo = new Date(now.getTime() - 6 * 60 * 60 * 1000);
+    
+    const unacceptedAssignments = await prisma.questAssignment.findMany({
+      where: {
+        status: 'assigned',
+        assignedAt: { lt: sixHoursAgo },
+      },
+    });
+
+    const unacceptedIds = unacceptedAssignments.map(a => a.id);
+    const unacceptedQuestIds = [...new Set(unacceptedAssignments.map(a => a.questId))];
+
+    if (unacceptedIds.length > 0) {
+      await prisma.$transaction(async (tx) => {
+        // Cancel the assignments
+        await tx.questAssignment.updateMany({
+          where: { id: { in: unacceptedIds } },
+          data: { status: 'cancelled' },
+        });
+
+        // Set quests back to available (syncQuestLifecycleStatus handles this logic perfectly)
+        // We just need to trigger it for each quest
+        for (const questId of unacceptedQuestIds) {
+          await syncQuestLifecycleStatus(tx, questId);
+        }
+      });
+    }
+
+    // 2. Check for stalled active assignments (no updates for > 48 hours)
+    const fortyEightHoursAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+
+    const stalledAssignments = await prisma.questAssignment.findMany({
+      where: {
+        status: { in: ['started', 'in_progress'] },
+        OR: [
+          {
+            lastUpdateAt: { lt: fortyEightHoursAgo },
+          },
+          {
+            lastUpdateAt: null,
+            startedAt: { lt: fortyEightHoursAgo },
+          }
+        ]
+      },
+    });
+
+    const stalledIds = stalledAssignments.map(a => a.id);
+    const stalledQuestIds = [...new Set(stalledAssignments.map(a => a.questId))];
+
+    if (stalledIds.length > 0) {
+      await prisma.$transaction(async (tx) => {
+        // Cancel the assignments
+        await tx.questAssignment.updateMany({
+          where: { id: { in: stalledIds } },
+          data: { status: 'cancelled' },
+        });
+
+        // Sync lifecycle for affected quests, which will revert them to available if slots open up
+        for (const questId of stalledQuestIds) {
+          await syncQuestLifecycleStatus(tx, questId);
+        }
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `Processed cron job. Cancelled ${unacceptedIds.length} unaccepted assignments. Cancelled ${stalledIds.length} stalled assignments.`,
+      details: {
+        unaccepted: unacceptedIds,
+        stalled: stalledIds
+      }
+    });
+
+  } catch (error) {
+    console.error('Error in cron check-assignments:', error);
+    return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/cron/check-assignments/route.ts
+++ b/app/api/cron/check-assignments/route.ts
@@ -3,11 +3,10 @@ import { prisma } from '@/lib/db';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 export async function GET(req: Request) {
-  // In a real production scenario, we'd verify a secret or vercel cron header here
-  // const authHeader = req.headers.get('authorization');
-  // if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-  //   return new Response('Unauthorized', { status: 401 });
-  // }
+  const authHeader = req.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
 
   try {
     const now = new Date();

--- a/app/api/quests/assignments/[id]/tasks/route.ts
+++ b/app/api/quests/assignments/[id]/tasks/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { getAuthUser } from '@/lib/api-auth';
+import { z } from 'zod';
+
+const taskToggleSchema = z.object({
+  taskName: z.string().min(1, 'Task name is required'),
+  completed: z.boolean(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  const params = await props.params;
+  const user = await getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  try {
+    const assignmentId = params.id;
+    const body = await request.json();
+    const { taskName, completed } = taskToggleSchema.parse(body);
+
+    // Fetch assignment and its quest tasks
+    const assignment = await prisma.questAssignment.findUnique({
+      where: { id: assignmentId },
+      include: {
+        quest: {
+          select: {
+            tasks: true,
+          },
+        },
+      },
+    });
+
+    if (!assignment) {
+      return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
+    }
+
+    if (assignment.userId !== user.id && user.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized to modify tasks for this assignment', success: false }, { status: 403 });
+    }
+
+    // Calculate new completedTasks array
+    let completedTasks = [...assignment.completedTasks];
+    if (completed) {
+      if (!completedTasks.includes(taskName)) {
+        completedTasks.push(taskName);
+      }
+    } else {
+      completedTasks = completedTasks.filter((t) => t !== taskName);
+    }
+
+    // Calculate progress percentage
+    const totalTasks = assignment.quest.tasks.length;
+    const progress = totalTasks > 0 ? (completedTasks.length / totalTasks) * 100 : 0;
+
+    const updatedAssignment = await prisma.questAssignment.update({
+      where: { id: assignmentId },
+      data: {
+        completedTasks,
+        progress: Number(progress.toFixed(2)),
+      },
+      select: {
+        id: true,
+        completedTasks: true,
+        progress: true,
+      },
+    });
+
+    return NextResponse.json({ assignment: updatedAssignment, success: true });
+  } catch (error) {
+    console.error('Failed to update task completion:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message, success: false }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal server error', success: false }, { status: 500 });
+  }
+}

--- a/app/api/quests/assignments/[id]/updates/route.ts
+++ b/app/api/quests/assignments/[id]/updates/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { getAuthUser } from '@/lib/api-auth';
+import { recalculateGuildScore } from '@/lib/guild-score';
+import { z } from 'zod';
+
+const updateSchema = z.object({
+  yesterday: z.string().min(3, 'Please describe what you did yesterday'),
+  today: z.string().min(3, 'Please describe what you plan to do today'),
+  blockers: z.string().optional(),
+  evidenceUrl: z.string().url('Please enter a valid evidence URL').optional().or(z.literal('')),
+});
+
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  const params = await props.params;
+  const user = await getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+  }
+
+  try {
+    const assignmentId = params.id;
+    const body = await request.json();
+    const parsed = updateSchema.parse(body);
+
+    // Fetch assignment to verify ownership and state
+    const assignment = await prisma.questAssignment.findUnique({
+      where: { id: assignmentId },
+      select: { userId: true, status: true },
+    });
+
+    if (!assignment) {
+      return NextResponse.json({ error: 'Assignment not found', success: false }, { status: 404 });
+    }
+
+    if (assignment.userId !== user.id && user.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized to post updates for this assignment', success: false }, { status: 403 });
+    }
+
+    // Create the DailyUpdate entry
+    const dailyUpdate = await prisma.$transaction(async (tx) => {
+      const update = await tx.dailyUpdate.create({
+        data: {
+          assignmentId,
+          userId: user.id,
+          yesterday: parsed.yesterday,
+          today: parsed.today,
+          blockers: parsed.blockers || null,
+          evidenceUrl: parsed.evidenceUrl || null,
+        },
+      });
+
+      // Update the lastUpdateAt field on QuestAssignment
+      await tx.questAssignment.update({
+        where: { id: assignmentId },
+        data: { lastUpdateAt: new Date() },
+      });
+
+      // Recalculate Guild Score for the user
+      await recalculateGuildScore(user.id, tx);
+
+      return update;
+    });
+
+    return NextResponse.json({ dailyUpdate, success: true }, { status: 201 });
+  } catch (error) {
+    console.error('Failed to submit daily update:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message, success: false }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal server error', success: false }, { status: 500 });
+  }
+}

--- a/app/api/quests/generate-tasks/route.ts
+++ b/app/api/quests/generate-tasks/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/api-auth';
+import { generateDefaultTasks } from '@/lib/ai-generator';
+import { z } from 'zod';
+
+const generateSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().min(1, 'Description is required'),
+  category: z.string().min(1, 'Category is required'),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthUser(request);
+    if (!user || (user.role !== 'company' && user.role !== 'admin')) {
+      return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { title, description, category } = generateSchema.parse(body);
+
+    const tasks = generateDefaultTasks(title, description, category);
+
+    return NextResponse.json({ tasks, success: true });
+  } catch (error) {
+    console.error('Failed to generate tasks:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message, success: false }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal server error', success: false }, { status: 500 });
+  }
+}

--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -192,6 +192,8 @@ export async function PUT(request: NextRequest) {
       select: {
         questId: true,
         userId: true,
+        startedAt: true,
+        assignedAt: true,
         quest: {
           select: {
             companyId: true,
@@ -262,6 +264,26 @@ export async function PUT(request: NextRequest) {
           });
           if (!quest) throw new Error('Quest not found for completion recording');
 
+          // Calculate daily standup penalty (5% per missed daily update)
+          const startedTime = assignmentData.startedAt ?? assignmentData.assignedAt;
+          const activeMs = new Date().getTime() - startedTime.getTime();
+          const expectedUpdates = Math.floor(activeMs / (1000 * 60 * 60 * 24));
+          
+          const actualUpdatesCount = await tx.dailyUpdate.count({
+            where: { assignmentId: submission.assignmentId }
+          });
+          
+          let penaltyPercentage = 0;
+          if (expectedUpdates > 0 && actualUpdatesCount < expectedUpdates) {
+            const missedUpdates = expectedUpdates - actualUpdatesCount;
+            penaltyPercentage = Math.min(100, missedUpdates * 5); // 5% per missed update, max 100%
+          }
+          
+          const multiplier = 1 - (penaltyPercentage / 100);
+          const finalXpReward = Math.round(quest.xpReward * multiplier);
+          const finalSkillPointsReward = Math.round(quest.skillPointsReward * multiplier);
+          const finalMonetaryReward = quest.monetaryReward ? Number(quest.monetaryReward) * multiplier : 0;
+
           await tx.questCompletion.upsert({
             where: {
               questId_userId: {
@@ -272,21 +294,21 @@ export async function PUT(request: NextRequest) {
             create: {
               questId: assignmentData.questId,
               userId: assignmentData.userId,
-              xpEarned: quest.xpReward,
-              skillPointsEarned: quest.skillPointsReward,
+              xpEarned: finalXpReward,
+              skillPointsEarned: finalSkillPointsReward,
               qualityScore: quality_score ?? null,
             },
             update: {
-              xpEarned: quest.xpReward,
-              skillPointsEarned: quest.skillPointsReward,
+              xpEarned: finalXpReward,
+              skillPointsEarned: finalSkillPointsReward,
               qualityScore: quality_score ?? null,
             },
           });
 
           rewardsPayload = {
             userId: assignmentData.userId,
-            xpReward: quest.xpReward,
-            skillPointsReward: quest.skillPointsReward,
+            xpReward: finalXpReward,
+            skillPointsReward: finalSkillPointsReward,
             questTitle: assignmentData.quest?.title ?? '',
             questSource: quest.source,
           };
@@ -298,7 +320,7 @@ export async function PUT(request: NextRequest) {
               userId: assignmentData.userId,
               track: quest.track,
               source: quest.source,
-              monetaryReward: Number(quest.monetaryReward),
+              monetaryReward: finalMonetaryReward,
             };
           }
         }

--- a/app/api/user/onboarding/route.ts
+++ b/app/api/user/onboarding/route.ts
@@ -10,10 +10,14 @@ const onboardingSchema = z.object({
   }),
   institutionName: z.string().min(1, 'Please enter the name of your school, college, or workplace'),
   yearOrExperience: z.string().min(1, 'Please select or enter your class, year, or work experience'),
+  phoneNumber: z.string().min(10, 'Please enter a valid WhatsApp number'),
   skills: z.array(z.string()).min(1, 'Please add at least one skill'),
   interests: z.array(z.string()).min(1, 'Please select at least one interest'),
   dailyWorkHours: z.string().min(1, 'Please select how much you can work daily'),
   expectations: z.string().min(10, 'Please write at least a few sentences about your expectations'),
+  autoAssign: z.boolean({
+    required_error: 'Please select your quest assignment preference',
+  }),
 });
 
 export async function GET() {
@@ -31,11 +35,13 @@ export async function GET() {
       where: { userId: session.user.id },
       select: {
         onboardingCompleted: true,
+        phoneNumber: true,
       },
     });
 
     return NextResponse.json({
       onboardingCompleted: profile?.onboardingCompleted ?? false,
+      hasPhoneNumber: !!profile?.phoneNumber,
     });
   } catch (error) {
     console.error('Failed to get onboarding status:', error);
@@ -64,13 +70,16 @@ export async function POST(req: Request) {
         studentType: data.studentType,
         institutionName: data.institutionName,
         yearOrExperience: data.yearOrExperience,
+        phoneNumber: data.phoneNumber,
         primarySkills: data.skills, // sync with primarySkills in schema
         interests: data.interests,
         dailyWorkHours: data.dailyWorkHours,
         expectations: data.expectations,
+        autoAssign: data.autoAssign,
         onboardingCompleted: true,
       },
     });
+
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/user/phone-number/route.ts
+++ b/app/api/user/phone-number/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { z } from 'zod';
+
+const schema = z.object({
+  phoneNumber: z.string().min(10, 'Please enter a valid WhatsApp number'),
+});
+
+export async function PATCH(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (session.user.role !== 'adventurer') {
+      return NextResponse.json({ error: 'Only adventurers can update this profile' }, { status: 403 });
+    }
+
+    const json = await req.json();
+    const data = schema.parse(json);
+
+    await prisma.adventurerProfile.update({
+      where: { userId: session.user.id },
+      data: {
+        phoneNumber: data.phoneNumber,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to update phone number:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.errors[0].message }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: 'Something went wrong' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/company/create-quest/page.tsx
+++ b/app/dashboard/company/create-quest/page.tsx
@@ -83,6 +83,37 @@ export default function CreateQuestPage() {
 
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [tasks, setTasks] = useState<string[]>([]);
+  const [isGeneratingTasks, setIsGeneratingTasks] = useState(false);
+
+  const handleGenerateTasks = async () => {
+    if (!form.title.trim() || !form.description.trim()) {
+      toast.error("Please fill in the Quest Title and Description first.");
+      return;
+    }
+    setIsGeneratingTasks(true);
+    try {
+      const res = await fetchWithAuth("/api/quests/generate-tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: form.title.trim(),
+          description: form.description.trim(),
+          category: form.questCategory,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Failed to generate tasks");
+      }
+      setTasks(data.tasks);
+      toast.success("Tasks generated successfully! Feel free to edit them.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to generate tasks");
+    } finally {
+      setIsGeneratingTasks(false);
+    }
+  };
 
   // ── Structured brief (Quest Context Loop) ───────────────────────────────
   const [templates, setTemplates] = useState<BriefTemplate[]>([]);
@@ -241,6 +272,7 @@ export default function CreateQuestPage() {
         partnerOrgName: ossPartnerName.trim() || null,
         track: intakeMode === 'oss' ? 'OPEN' : undefined,
         source: intakeMode === 'oss' ? 'CLIENT_PORTAL' : undefined,
+        tasks: tasks.map((t) => t.trim()).filter(Boolean),
       };
 
       const response = await fetchWithAuth('/api/company/quests', {
@@ -643,6 +675,64 @@ export default function CreateQuestPage() {
                 </div>
                 <Button type="button" variant="outline" size="sm" onClick={() => setCriteria((prev) => [...prev, ''])}>
                   <Plus className="h-4 w-4" /> Add criterion
+                </Button>
+              </div>
+
+              {/* Quest Checklist Tasks */}
+              <div className="space-y-2 border-t border-sky-200/70 pt-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <Label>Quest Tasks (To-Do List)</Label>
+                    <p className="text-xs text-slate-500">
+                      Predefined to-do list tasks that the adventurer must complete to finish the quest.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleGenerateTasks}
+                    disabled={isGeneratingTasks}
+                    className="border-indigo-200 text-indigo-700 bg-indigo-50/50 hover:bg-indigo-100/70"
+                  >
+                    {isGeneratingTasks ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                        Generating...
+                      </>
+                    ) : (
+                      <>
+                        <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+                        AI Generate Tasks
+                      </>
+                    )}
+                  </Button>
+                </div>
+
+                <div className="space-y-2 mt-2">
+                  {tasks.map((task, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <Input
+                        value={task}
+                        placeholder={`Task ${i + 1}`}
+                        onChange={(e) =>
+                          setTasks((prev) => prev.map((p, idx) => (idx === i ? e.target.value : p)))
+                        }
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setTasks((prev) => prev.filter((_, idx) => idx !== i))}
+                        aria-label="Remove task"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={() => setTasks((prev) => [...prev, ''])}>
+                  <Plus className="h-4 w-4" /> Add Task
                 </Button>
               </div>
             </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -17,6 +17,7 @@ import {
 
 import NotificationBell from '@/components/NotificationBell';
 import { OnboardingPrompt } from '@/components/ui/onboarding-prompt';
+import { PhoneNumberPrompt } from '@/components/ui/phone-number-prompt';
 import {
   BarChart3,
   Briefcase,
@@ -118,6 +119,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   return (
     <div className="min-h-screen guild-shell">
       <OnboardingPrompt />
+      <PhoneNumberPrompt />
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div

--- a/app/dashboard/my-quests/[id]/story/page.tsx
+++ b/app/dashboard/my-quests/[id]/story/page.tsx
@@ -1,0 +1,42 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { prisma, withDbRetry } from "@/lib/db";
+import { StoryClient } from "./story-client";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Quest Story - Adventurers Guild",
+};
+
+export default async function QuestStoryPage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const assignment = await withDbRetry(() => prisma.questAssignment.findUnique({
+    where: {
+      questId_userId: {
+        questId: params.id,
+        userId: session.user.id,
+      }
+    },
+    include: {
+      quest: {
+        include: { company: true },
+      },
+      dailyUpdates: {
+        orderBy: { createdAt: 'desc' },
+      }
+    }
+  }));
+
+  if (!assignment) {
+    redirect("/dashboard/my-quests");
+  }
+
+  return <StoryClient assignment={assignment} quest={assignment.quest} updates={assignment.dailyUpdates} />;
+}

--- a/app/dashboard/my-quests/[id]/story/story-client.tsx
+++ b/app/dashboard/my-quests/[id]/story/story-client.tsx
@@ -50,7 +50,7 @@ export function StoryClient({ assignment, quest, updates }: { assignment: any; q
           <div className="text-center py-12 bg-slate-50 rounded-2xl border border-dashed border-slate-200">
             <FileText className="h-8 w-8 text-slate-400 mx-auto mb-3" />
             <h3 className="text-lg font-semibold text-slate-900 mb-1">No updates yet</h3>
-            <p className="text-sm text-slate-500 mb-4">You haven't submitted any daily standups for this quest.</p>
+            <p className="text-sm text-slate-500 mb-4">You haven&apos;t submitted any daily standups for this quest.</p>
             <Button onClick={() => setIsModalOpen(true)} variant="outline" className="border-orange-200 text-orange-600 hover:bg-orange-50">
               Submit Your First Update
             </Button>

--- a/app/dashboard/my-quests/[id]/story/story-client.tsx
+++ b/app/dashboard/my-quests/[id]/story/story-client.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Calendar, FileText, CheckCircle2, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DailyStandupModal } from "@/components/daily-standup-modal";
+import { Badge } from "@/components/ui/badge";
+
+export function StoryClient({ assignment, quest, updates }: { assignment: any; quest: any; updates: any[] }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSuccess = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="container max-w-4xl py-8">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8 border-b border-slate-200 pb-6">
+        <div className="space-y-1">
+          <Link href="/dashboard/my-quests" className="text-xs text-slate-500 hover:text-slate-900 flex items-center gap-1 mb-3 transition-colors">
+            <ArrowLeft className="h-3 w-3" /> Back to My Quests
+          </Link>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900">{quest.title}</h1>
+            <Badge variant="secondary" className="bg-slate-100 text-slate-700 hover:bg-slate-200">
+              {assignment.status.replace("_", " ").toUpperCase()}
+            </Badge>
+          </div>
+          <p className="text-sm text-slate-500 flex items-center gap-1">
+            <Calendar className="h-4 w-4" />
+            Update History
+          </p>
+        </div>
+        
+        <Button 
+          onClick={() => setIsModalOpen(true)}
+          className="bg-orange-500 hover:bg-orange-600 text-white shadow-sm shrink-0"
+        >
+          <FileText className="h-4 w-4 mr-2" />
+          Submit Next Update
+        </Button>
+      </div>
+
+      {/* Timeline */}
+      <div className="space-y-6">
+        {updates.length === 0 ? (
+          <div className="text-center py-12 bg-slate-50 rounded-2xl border border-dashed border-slate-200">
+            <FileText className="h-8 w-8 text-slate-400 mx-auto mb-3" />
+            <h3 className="text-lg font-semibold text-slate-900 mb-1">No updates yet</h3>
+            <p className="text-sm text-slate-500 mb-4">You haven't submitted any daily standups for this quest.</p>
+            <Button onClick={() => setIsModalOpen(true)} variant="outline" className="border-orange-200 text-orange-600 hover:bg-orange-50">
+              Submit Your First Update
+            </Button>
+          </div>
+        ) : (
+          <div className="relative border-l-2 border-slate-200 ml-4 pl-6 space-y-8">
+            {updates.map((update, idx) => (
+              <div key={update.id} className="relative">
+                {/* Timeline dot */}
+                <div className="absolute -left-[35px] top-1 h-5 w-5 rounded-full bg-orange-100 border-2 border-orange-500 flex items-center justify-center">
+                  <div className="h-2 w-2 rounded-full bg-orange-500" />
+                </div>
+                
+                <Card className="border-slate-200 shadow-sm bg-white hover:shadow-md transition-shadow">
+                  <CardHeader className="bg-slate-50 border-b border-slate-100 pb-3 py-4">
+                    <CardTitle className="text-sm font-semibold flex items-center justify-between">
+                      <span className="text-slate-800">Day {updates.length - idx}</span>
+                      <span className="text-xs font-normal text-slate-500">
+                        {new Date(update.createdAt).toLocaleString(undefined, { 
+                          weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit'
+                        })}
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-4 space-y-5">
+                    
+                    <div>
+                      <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+                        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> Yesterday
+                      </h4>
+                      <p className="text-sm text-slate-700 whitespace-pre-wrap">{update.yesterday}</p>
+                    </div>
+
+                    <div>
+                      <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+                        <Calendar className="h-3.5 w-3.5 text-blue-500" /> Today
+                      </h4>
+                      <p className="text-sm text-slate-700 whitespace-pre-wrap">{update.today}</p>
+                    </div>
+
+                    {update.blockers && (
+                      <div className="bg-rose-50 border border-rose-100 p-3 rounded-xl">
+                        <h4 className="text-xs font-bold text-rose-700 uppercase tracking-wider mb-1 flex items-center gap-1.5">
+                          <ShieldAlert className="h-3.5 w-3.5 text-rose-500" /> Blockers
+                        </h4>
+                        <p className="text-sm text-rose-800 whitespace-pre-wrap">{update.blockers}</p>
+                      </div>
+                    )}
+
+                    {update.evidenceUrl && (
+                      <div className="pt-2 border-t border-slate-100 mt-2">
+                        <a 
+                          href={update.evidenceUrl} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center text-sm text-orange-600 hover:text-orange-700 font-medium hover:underline mt-2"
+                        >
+                          View Work Evidence ↗
+                        </a>
+                      </div>
+                    )}
+
+                  </CardContent>
+                </Card>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <DailyStandupModal 
+        isOpen={isModalOpen} 
+        onClose={() => setIsModalOpen(false)} 
+        assignmentId={assignment.id} 
+        onSuccess={handleSuccess} 
+        tasks={quest.tasks}
+        completedTasks={assignment.completedTasks}
+        questTitle={quest.title}
+        xpReward={quest.xpReward}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/my-quests/page.tsx
+++ b/app/dashboard/my-quests/page.tsx
@@ -3,10 +3,9 @@ import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma, withDbRetry } from "@/lib/db";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { QuestSubmissionDialog } from "@/components/quest-submission-dialog";
-import { Clock, CheckCircle2, AlertCircle } from "lucide-react";
+import { MyQuestCard } from "@/components/my-quest-card";
+import { AlertCircle } from "lucide-react";
 import Link from "next/link";
 
 export default async function MyQuestsPage() {
@@ -38,7 +37,7 @@ export default async function MyQuestsPage() {
   }));
 
   return (
-    <div className="container py-8">
+    <div className="container py-8 max-w-5xl">
       <h1 className="text-3xl font-bold mb-2">My Quests</h1>
       <p className="text-muted-foreground mb-8">Manage your active quests and view your history.</p>
 
@@ -58,59 +57,7 @@ export default async function MyQuestsPage() {
           </Card>
         ) : (
           assignments.map((assignment) => (
-            <Card key={assignment.id} className="flex flex-col md:flex-row overflow-hidden">
-              <div className={`w-2 md:w-2 ${
-                assignment.status === 'completed' ? 'bg-green-500' :
-                assignment.status === 'assigned' ? 'bg-blue-500' :
-                assignment.status === 'submitted' ? 'bg-yellow-500' :
-                'bg-gray-300'
-              }`} />
-              <div className="flex-1 flex flex-col md:flex-row">
-                <div className="flex-1 p-6">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Badge variant={
-                      assignment.status === 'completed' ? 'default' :
-                      assignment.status === 'assigned' ? 'secondary' :
-                      'outline'
-                    }>
-                      {assignment.status.charAt(0).toUpperCase() + assignment.status.slice(1)}
-                    </Badge>
-                    <span className="text-sm text-muted-foreground">
-                      {assignment.quest.company?.name}
-                    </span>
-                  </div>
-                  <h3 className="text-xl font-bold mb-2">{assignment.quest.title}</h3>
-                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <Clock className="h-4 w-4" />
-                      Due {assignment.quest.deadline ? new Date(assignment.quest.deadline).toLocaleDateString() : 'No deadline'}
-                    </span>
-                    <span>{assignment.quest.xpReward} XP</span>
-                    {assignment.quest.monetaryReward && <span>${Number(assignment.quest.monetaryReward)}</span>}
-                  </div>
-                </div>
-                <div className="p-6 bg-muted/30 flex items-center justify-end gap-3 border-t md:border-t-0 md:border-l">
-                  <Button variant="outline" asChild>
-                    <Link href={`/dashboard/quests/${assignment.quest.id}`}>View Details</Link>
-                  </Button>
-                  
-                  {assignment.status === 'assigned' && (
-                    <QuestSubmissionDialog
-                      questTitle={assignment.quest.title}
-                      assignmentId={assignment.id}
-                      questId={assignment.quest.id}
-                    />
-                  )}
-                  
-                  {assignment.status === 'submitted' && (
-                    <Button disabled variant="secondary">
-                      <CheckCircle2 className="mr-2 h-4 w-4" />
-                      Under Review
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </Card>
+            <MyQuestCard key={assignment.id} initialAssignment={assignment} />
           ))
         )}
       </div>

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -8,8 +8,10 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { AlertCircle, CheckCircle } from 'lucide-react';
+import { AlertCircle, CheckCircle, CalendarDays } from 'lucide-react';
 import { toast } from 'sonner';
+import Link from 'next/link';
+import { DailyStandupModal } from '@/components/daily-standup-modal';
 import { PartyPanel, type Party } from '@/components/quest/PartyPanel';
 import { fetchWithAuth } from '@/lib/fetch-with-auth';
 import { StreakMultiplierNotice } from '@/components/ui/streak-badge';
@@ -41,6 +43,7 @@ interface Quest {
   shareCount?: number;
   company?: { name: string; email?: string };
   party?: Party | null;
+  tasks?: string[];
 }
 
 interface Assignment {
@@ -52,6 +55,8 @@ interface Assignment {
   startedAt?: string;
   completedAt?: string;
   progress?: number;
+  completedTasks?: string[];
+  lastUpdateAt?: string;
 }
 
 function assignmentStatusClass(status: string) {
@@ -175,6 +180,7 @@ export default function QuestDetailPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentStreak, setCurrentStreak] = useState(0);
   const [shareCount, setShareCount] = useState(0);
+  const [isStandupOpen, setIsStandupOpen] = useState(false);
 
   useEffect(() => {
     if (status === 'unauthenticated') { router.push('/login'); return; }
@@ -492,12 +498,37 @@ export default function QuestDetailPage() {
                     <CheckCircle className="h-3.5 w-3.5" /> Completed successfully
                   </div>
                 )}
+                <div className="pt-2 flex flex-col gap-2">
+                  <Button asChild variant="outline" className="w-full text-xs border-slate-200 text-slate-600 hover:text-slate-900 bg-white hover:bg-slate-50 shadow-sm flex items-center justify-center gap-1.5">
+                    <Link href={`/dashboard/my-quests/${quest.id}/story`}>
+                      View Update Story
+                    </Link>
+                  </Button>
+                  {['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status) && (
+                    <Button 
+                      onClick={() => setIsStandupOpen(true)} 
+                      className="w-full text-xs bg-orange-500 hover:bg-orange-600 text-white shadow-sm flex items-center justify-center gap-1.5"
+                    >
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      Daily Standup
+                    </Button>
+                  )}
+                </div>
               </div>
             ) : canAssign ? (
               <div className="rounded-2xl border border-border/70 bg-white/95 shadow-[0_4px_16px_rgba(15,23,42,0.04)] p-5 space-y-3">
                 <div>
                   <h2 className="text-sm font-semibold text-slate-900">Accept This Quest</h2>
                   <p className="mt-0.5 text-xs text-slate-500">Claim the brief and move it into your active pipeline.</p>
+                </div>
+                <div className="p-3 bg-amber-50 border border-amber-200 rounded-xl text-[11px] text-amber-800 space-y-1">
+                  <div className="flex items-center gap-1 font-bold text-amber-900">
+                    <AlertCircle className="h-3.5 w-3.5 text-amber-600 shrink-0" />
+                    Daily Updates Required
+                  </div>
+                  <p className="leading-normal">
+                    You must submit a daily standup for this quest. Missing updates will decrease your Guild Score and reduce your final XP/Money payout by 5% per missed day.
+                  </p>
                 </div>
                 <Button
                   className="w-full"
@@ -577,6 +608,20 @@ export default function QuestDetailPage() {
           </div>
         </div>
       </div>
+      {assignment && (
+        <DailyStandupModal
+          isOpen={isStandupOpen}
+          onClose={() => setIsStandupOpen(false)}
+          assignmentId={assignment.id}
+          onSuccess={() => {
+            setAssignment((prev) => prev ? { ...prev, lastUpdateAt: new Date().toISOString() } : prev);
+          }}
+          tasks={quest.tasks}
+          completedTasks={assignment.completedTasks}
+          questTitle={quest.title}
+          xpReward={quest.xpReward}
+        />
+      )}
     </div>
   );
 }

--- a/app/quests/[id]/page.tsx
+++ b/app/quests/[id]/page.tsx
@@ -149,7 +149,7 @@ export default function QuestDetailPage() {
   ].filter(Boolean) as { label: string; icon: React.ReactNode; color: string }[];
 
   return (
-    <div className="min-h-screen bg-background ds-page-grain relative pt-24 pb-16">
+    <div className="min-h-screen bg-background ds-page-grain relative pt-24 pb-16 overflow-x-hidden">
       {/* Top radial light spreads */}
       <div className="absolute inset-x-0 top-0 h-96 bg-[radial-gradient(circle_at_top,rgba(249,115,22,0.12),transparent_60%)] pointer-events-none" />
       <div className="absolute right-[-8rem] top-20 h-80 w-80 rounded-full bg-orange-100/30 blur-3xl pointer-events-none" />

--- a/components/daily-standup-modal.tsx
+++ b/components/daily-standup-modal.tsx
@@ -255,7 +255,7 @@ export function DailyStandupModal({
             {/* Yesterday Input */}
             <div className="space-y-1.5">
               <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
-                Yesterday's Work <span className="text-orange-500">*</span>
+                Yesterday&apos;s Work <span className="text-orange-500">*</span>
               </label>
               <textarea
                 required
@@ -270,7 +270,7 @@ export function DailyStandupModal({
             {/* Today Input */}
             <div className="space-y-1.5">
               <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
-                Today's Objectives <span className="text-orange-500">*</span>
+                Today&apos;s Objectives <span className="text-orange-500">*</span>
               </label>
               <textarea
                 required

--- a/components/daily-standup-modal.tsx
+++ b/components/daily-standup-modal.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { 
+  X, 
+  Loader2, 
+  Award, 
+  Calendar, 
+  AlertCircle, 
+  CheckCircle2, 
+  PlayCircle, 
+  ShieldAlert, 
+  Link as LinkIcon, 
+  Flame, 
+  Check, 
+  ChevronRight, 
+  Sparkles 
+} from "lucide-react";
+
+interface DailyStandupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  assignmentId: string;
+  onSuccess?: () => void;
+  tasks?: string[];
+  completedTasks?: string[];
+  questTitle?: string;
+  xpReward?: number;
+}
+
+export function DailyStandupModal({ 
+  isOpen, 
+  onClose, 
+  assignmentId, 
+  onSuccess,
+  tasks = [],
+  completedTasks = [],
+  questTitle = "Active Quest",
+  xpReward
+}: DailyStandupModalProps) {
+  const [yesterday, setYesterday] = useState("");
+  const [today, setToday] = useState("");
+  const [blockers, setBlockers] = useState("");
+  const [evidenceUrl, setEvidenceUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleImportCompleted = () => {
+    if (!completedTasks || completedTasks.length === 0) {
+      toast.info("No completed tasks found in checklist.");
+      return;
+    }
+    const formatted = completedTasks.map(t => `- Completed: ${t}`).join("\n");
+    setYesterday(prev => {
+      const trimmed = prev.trim();
+      return trimmed ? `${trimmed}\n${formatted}` : formatted;
+    });
+    toast.success("Completed tasks appended to Yesterday's update!");
+  };
+
+  const handleImportRemaining = () => {
+    if (!tasks || tasks.length === 0) {
+      toast.info("No tasks found in checklist.");
+      return;
+    }
+    const remaining = tasks.filter(t => !completedTasks.includes(t));
+    if (remaining.length === 0) {
+      toast.info("All checklist tasks are already completed!");
+      return;
+    }
+    const formatted = remaining.map(t => `- Focus: ${t}`).join("\n");
+    setToday(prev => {
+      const trimmed = prev.trim();
+      return trimmed ? `${trimmed}\n${formatted}` : formatted;
+    });
+    toast.success("Active targets appended to Today's update!");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (yesterday.trim().length < 3) {
+      toast.error("Please describe what you did yesterday.");
+      return;
+    }
+    if (today.trim().length < 3) {
+      toast.error("Please describe what you plan to do today.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(`/api/quests/assignments/${assignmentId}/updates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          yesterday,
+          today,
+          blockers: blockers.trim() || undefined,
+          evidenceUrl: evidenceUrl.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to submit daily update");
+      }
+
+      toast.success("Daily standup submitted successfully! Your Guild Score has been updated.");
+      setYesterday("");
+      setToday("");
+      setBlockers("");
+      setEvidenceUrl("");
+      if (onSuccess) onSuccess();
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const blockerChips = [
+    "No blockers",
+    "Waiting on feedback",
+    "Technical blocker",
+    "API / Server down"
+  ];
+
+  const evidenceChips = [
+    { label: "GitHub PR", prefix: "https://github.com/" },
+    { label: "Figma", prefix: "https://figma.com/" },
+    { label: "Loom", prefix: "https://loom.com/" }
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-md overflow-y-auto">
+      <div className="bg-white border border-slate-200 w-full max-w-4xl rounded-3xl shadow-2xl overflow-hidden flex flex-col md:flex-row md:max-h-[80vh] h-auto md:h-[620px] animate-in fade-in zoom-in-95 duration-200">
+        
+        {/* Left Side: Info & Task Assistant Panel */}
+        <div className="relative w-full md:w-[320px] bg-slate-50 text-slate-900 p-5 md:p-6 flex flex-col justify-between border-b md:border-b-0 md:border-r border-slate-200 flex-shrink-0 overflow-visible md:overflow-y-auto md:max-h-none">
+          {/* Ambient Glows */}
+          <div className="absolute top-0 right-0 -mt-10 -mr-10 w-36 h-36 bg-orange-500/10 rounded-full blur-3xl pointer-events-none animate-pulse" />
+          <div className="absolute bottom-0 left-0 -mb-10 -ml-10 w-36 h-36 bg-amber-500/10 rounded-full blur-3xl pointer-events-none animate-pulse" />
+          
+          <div className="relative z-10 space-y-5">
+            {/* Scroll Indicator */}
+            <div className="flex items-center gap-2 bg-orange-500/10 border border-orange-500/20 px-3 py-1.5 rounded-full w-fit">
+              <span className="text-[10px] font-bold uppercase tracking-wider text-slate-700">Guild Standup Scroll</span>
+            </div>
+
+            {/* Quest Info */}
+            <div className="space-y-1.5">
+              <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">Active Quest</span>
+              <h2 className="text-base font-bold font-display tracking-tight text-slate-900 line-clamp-2 leading-tight">
+                {questTitle}
+              </h2>
+              {xpReward && (
+                <div className="flex items-center gap-1.5 text-xs text-slate-700 font-semibold bg-orange-500/10 w-fit px-2.5 py-1 rounded-lg border border-orange-500/20">
+                  <span>+{xpReward} XP Reward</span>
+                </div>
+              )}
+            </div>
+
+            {/* Task Assistant */}
+            <div className="pt-4 border-t border-slate-200">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 flex items-center gap-1">
+                  Checklist Assistant
+                </span>
+                {tasks.length > 0 && (
+                  <span className="text-[11px] text-slate-500 font-medium">
+                    {completedTasks.length}/{tasks.length} Done
+                  </span>
+                )}
+              </div>
+
+              {tasks.length > 0 ? (
+                <div className="space-y-2">
+                  <div className="space-y-1.5 max-h-[160px] overflow-visible md:overflow-y-auto pr-1 md:scrollbar-thin md:scrollbar-thumb-slate-300 md:scrollbar-track-transparent">
+                    {tasks.map((task, i) => {
+                      const isDone = completedTasks.includes(task);
+                      return (
+                        <div key={i} className="flex items-start gap-2 bg-white border border-slate-200 p-2 rounded-xl text-[11px] leading-tight font-sans">
+                          <span className={`mt-0.5 flex-shrink-0 h-3 w-3 rounded flex items-center justify-center ${isDone ? 'bg-emerald-50 text-emerald-500' : 'bg-slate-100 text-slate-500'}`}>
+                            {isDone ? <span className="text-[10px]">✓</span> : <div className="h-1 w-1 rounded-full bg-slate-300" />}
+                          </span>
+                          <span className={`flex-1 ${isDone ? 'text-slate-400 line-through' : 'text-slate-700'}`}>
+                            {task}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <div className="grid grid-cols-2 md:grid-cols-1 gap-2 pt-2">
+                    {completedTasks.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={handleImportCompleted}
+                        className="w-full text-left bg-emerald-50 hover:bg-emerald-100 border border-emerald-200 text-slate-700 font-bold text-[10px] uppercase tracking-wider px-3 py-2 rounded-xl transition-all flex items-center justify-between group"
+                      >
+                        <span>Import Completed</span>
+                      </button>
+                    )}
+                    {tasks.filter(t => !completedTasks.includes(t)).length > 0 && (
+                      <button
+                        type="button"
+                        onClick={handleImportRemaining}
+                        className="w-full text-left bg-orange-50 hover:bg-orange-100 border border-orange-200 text-slate-700 font-bold text-[10px] uppercase tracking-wider px-3 py-2 rounded-xl transition-all flex items-center justify-between group"
+                      >
+                        <span>Import Objectives</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="py-4 text-center text-slate-500 bg-slate-50 border border-dashed border-slate-200 rounded-xl">
+                  <p className="text-[11px]">No check-list targets assigned for this quest.</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer of Left Panel */}
+          <div className="relative z-10 pt-4 border-t border-slate-200 mt-6 hidden md:block">
+            <p className="text-[10px] text-slate-500 leading-normal font-sans">
+              Reports should be submitted every 24 hours to prove active contribution.
+            </p>
+          </div>
+        </div>
+
+        {/* Right Side: Standup Inputs Form */}
+        <div className="flex-1 flex flex-col min-w-0 bg-white overflow-visible md:overflow-y-auto md:max-h-none">
+          {/* Header */}
+          <div className="border-b border-slate-100 p-5 md:p-6 flex items-center justify-between flex-shrink-0">
+            <div>
+              <h3 className="text-lg font-bold font-display tracking-tight text-slate-900">Daily Standup</h3>
+              <p className="text-xs text-slate-500">Provide details on your progress and work evidence.</p>
+            </div>
+            <button 
+              type="button"
+              onClick={onClose}
+              className="text-slate-400 hover:text-slate-900 hover:bg-slate-50 p-2 rounded-xl transition-colors border border-transparent hover:border-slate-100"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Form Content */}
+          <form onSubmit={handleSubmit} className="p-5 md:p-6 space-y-5 overflow-visible md:overflow-y-auto flex-1">
+            
+            {/* Yesterday Input */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
+                Yesterday's Work <span className="text-orange-500">*</span>
+              </label>
+              <textarea
+                required
+                rows={3}
+                placeholder="What did you complete? List features, fixes, or deliverables..."
+                value={yesterday}
+                onChange={(e) => setYesterday(e.target.value)}
+                className="w-full p-3.5 border border-slate-200 rounded-2xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 placeholder-slate-400 resize-none transition-all shadow-sm"
+              />
+            </div>
+
+            {/* Today Input */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
+                Today's Objectives <span className="text-orange-500">*</span>
+              </label>
+              <textarea
+                required
+                rows={3}
+                placeholder="What are your goals for today? What will you commit next?"
+                value={today}
+                onChange={(e) => setToday(e.target.value)}
+                className="w-full p-3.5 border border-slate-200 rounded-2xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 placeholder-slate-400 resize-none transition-all shadow-sm"
+              />
+            </div>
+
+            {/* Blockers Input */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
+                Blockers (Optional)
+              </label>
+              <textarea
+                rows={2}
+                placeholder="Any technical issues, missing documentation, or dependencies?"
+                value={blockers}
+                onChange={(e) => setBlockers(e.target.value)}
+                className="w-full p-3.5 border border-slate-200 rounded-2xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 placeholder-slate-400 resize-none transition-all shadow-sm"
+              />
+              {/* Quick Tags */}
+              <div className="flex flex-wrap gap-1.5 pt-0.5">
+                {blockerChips.map((chip, idx) => (
+                  <button
+                    key={idx}
+                    type="button"
+                    onClick={() => setBlockers(chip)}
+                    className="px-2.5 py-1 text-[11px] font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors border border-slate-200"
+                  >
+                    {chip}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Evidence URL Input */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-slate-700 uppercase tracking-wider flex items-center gap-1.5">
+                Work Evidence URL (Optional)
+              </label>
+              <input
+                type="url"
+                placeholder="https://github.com/... or Figma, Loom, etc."
+                value={evidenceUrl}
+                onChange={(e) => setEvidenceUrl(e.target.value)}
+                className="w-full h-10 px-3.5 border border-slate-200 rounded-xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 placeholder-slate-400 transition-all shadow-sm"
+              />
+              {/* Quick Chips */}
+              <div className="flex flex-wrap gap-1.5 pt-0.5 items-center justify-between">
+                <div className="flex gap-1.5">
+                  {evidenceChips.map((chip, idx) => (
+                    <button
+                      key={idx}
+                      type="button"
+                      onClick={() => setEvidenceUrl(chip.prefix)}
+                      className="px-2.5 py-1 text-[11px] font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors border border-slate-200"
+                    >
+                      {chip.label}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-[10px] text-slate-500">Proof of progress is validated by Guild Admins.</p>
+              </div>
+            </div>
+
+            {/* Standup Penalty Note - Clean neutral style to avoid orange */}
+            <div className="p-3.5 bg-rose-50 border border-rose-100 rounded-2xl flex gap-3 text-[11px] text-rose-800 leading-normal items-start">
+              <p>
+                Missed standups result in a <strong className="text-rose-900">5% penalty</strong> to your final quest payout and lower your reliability. Payouts are calculated dynamically at approval.
+              </p>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="pt-2">
+              <button
+                type="submit"
+                disabled={isSubmitting || yesterday.trim().length < 3 || today.trim().length < 3}
+                className="w-full bg-orange-600 hover:bg-orange-500 text-white text-sm font-bold py-3.5 rounded-2xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-orange-900/20 disabled:opacity-50 disabled:shadow-none disabled:cursor-not-allowed transform active:scale-[0.99] border border-orange-500/50"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-white" />
+                ) : (
+                  <>
+                    Submit Standup Update
+                  </>
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/components/my-quest-card.tsx
+++ b/components/my-quest-card.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { QuestSubmissionDialog } from "@/components/quest-submission-dialog";
+import { DailyStandupModal } from "./daily-standup-modal";
+import { Clock, CheckCircle2, AlertTriangle, ListTodo, CalendarDays } from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+
+export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
+  const [assignment, setAssignment] = useState(initialAssignment);
+  const [isStandupOpen, setIsStandupOpen] = useState(false);
+  const [togglingTask, setTogglingTask] = useState<string | null>(null);
+
+  const quest = assignment.quest;
+  const tasks = quest.tasks || [];
+  const completedTasks = assignment.completedTasks || [];
+  const progress = assignment.progress || 0;
+
+  // Check if daily standup is overdue (older than 24h)
+  const isStandupOverdue = () => {
+    if (!["assigned", "started", "in_progress", "needs_rework"].includes(assignment.status)) {
+      return false;
+    }
+    const lastUpdate = assignment.lastUpdateAt || assignment.startedAt || assignment.assignedAt;
+    if (!lastUpdate) return false;
+
+    const lastUpdateTime = new Date(lastUpdate).getTime();
+    const timeSince = Date.now() - lastUpdateTime;
+    return timeSince > 24 * 60 * 60 * 1000;
+  };
+
+  const handleToggleTask = async (taskName: string) => {
+    const isCompleted = completedTasks.includes(taskName);
+    setTogglingTask(taskName);
+
+    try {
+      const res = await fetch(`/api/quests/assignments/${assignment.id}/tasks`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          taskName,
+          completed: !isCompleted,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to update task");
+      }
+
+      setAssignment((prev: any) => ({
+        ...prev,
+        completedTasks: data.assignment.completedTasks,
+        progress: data.assignment.progress,
+      }));
+      toast.success(isCompleted ? "Task marked incomplete" : "Task completed!");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setTogglingTask(null);
+    }
+  };
+
+  const isCompletedStatus = assignment.status === "completed";
+  const isUnderReviewStatus = assignment.status === "submitted" || assignment.status === "pending_admin_review";
+  const isActive = ["assigned", "started", "in_progress", "needs_rework"].includes(assignment.status);
+
+  return (
+    <Card className="flex flex-col md:flex-row overflow-hidden border-slate-200 bg-white shadow-sm text-slate-900 transition-all hover:shadow-md hover:border-slate-300">
+      <div
+        className={`w-full h-2 md:w-2 md:h-auto ${
+          isCompletedStatus
+            ? "bg-emerald-500"
+            : isUnderReviewStatus
+            ? "bg-amber-500"
+            : "bg-blue-500"
+        }`}
+      />
+      <div className="flex-1 flex flex-col">
+        <div className="p-6 space-y-4">
+          {/* Header */}
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 pb-3">
+            <div className="flex items-center gap-2">
+              <Badge
+                className={
+                  isCompletedStatus
+                    ? "bg-emerald-500/15 text-emerald-400 border-emerald-500/20"
+                    : isUnderReviewStatus
+                    ? "bg-amber-500/15 text-amber-400 border-amber-500/20"
+                    : "bg-blue-500/15 text-blue-400 border-blue-500/20"
+                }
+              >
+                {assignment.status.replace("_", " ").toUpperCase()}
+              </Badge>
+              <span className="text-xs text-slate-500">{quest.company?.name}</span>
+            </div>
+            <div className="flex items-center gap-4 text-xs text-slate-500 font-medium">
+              <span className="flex items-center gap-1">
+                <Clock className="h-3.5 w-3.5" />
+                Due {quest.deadline ? new Date(quest.deadline).toLocaleDateString() : "No deadline"}
+              </span>
+              <span className="text-orange-400 font-semibold">{quest.xpReward} XP</span>
+              {quest.monetaryReward && (
+                <span className="text-emerald-400 font-semibold">${Number(quest.monetaryReward)}</span>
+              )}
+            </div>
+          </div>
+
+          {/* Title & Warning */}
+          <div>
+            <h3 className="text-xl font-bold font-display tracking-tight text-slate-900 mb-2">{quest.title}</h3>
+            
+
+
+            {isStandupOverdue() && (
+              <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-xl flex items-center gap-2 text-rose-300 text-xs mt-3">
+                <AlertTriangle className="h-4 w-4 text-rose-400 flex-shrink-0" />
+                <div>
+                  <strong>Daily Update Overdue!</strong> Please submit a standup now to prevent a 5% reward penalty.
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* To-Do Checklist & Progress */}
+          {tasks.length > 0 && (
+            <div className="space-y-3 pt-2">
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <span className="flex items-center gap-1 font-semibold text-slate-700">
+                  <ListTodo className="h-3.5 w-3.5 text-slate-400" />
+                  Quest Tasks
+                </span>
+                <span className="font-medium">{completedTasks.length} / {tasks.length} completed ({Math.round(progress)}%)</span>
+              </div>
+              
+              {/* Progress bar */}
+              <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                <div 
+                  className="h-full bg-gradient-to-r from-orange-500 to-amber-500 rounded-full transition-all duration-300"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+
+              {/* Checkbox checklist */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2">
+                {tasks.map((task: string, idx: number) => {
+                  const isChecked = completedTasks.includes(task);
+                  return (
+                    <label
+                      key={idx}
+                      className={`flex items-center gap-3 p-3 rounded-xl border text-xs cursor-pointer transition-all ${
+                        isChecked
+                          ? "bg-emerald-50/50 border-emerald-200 text-emerald-800"
+                          : "bg-white border-slate-200 text-slate-700 hover:border-slate-300 hover:bg-slate-50/50"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        disabled={!isActive || togglingTask === task}
+                        checked={isChecked}
+                        onChange={() => handleToggleTask(task)}
+                        className="h-4 w-4 rounded border-slate-300 text-orange-500 bg-white focus:ring-orange-500 focus:ring-offset-white cursor-pointer disabled:opacity-50"
+                      />
+                      <span className={isChecked ? "line-through" : ""}>
+                        {togglingTask === task ? "Updating..." : task}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Action Bar */}
+        <div className="p-6 bg-slate-50/50 border-t border-slate-100 flex flex-wrap items-center justify-between gap-4">
+          <div className="text-xs text-slate-500 font-medium">
+            {assignment.lastUpdateAt ? (
+              <span>Last update: {new Date(assignment.lastUpdateAt).toLocaleString()}</span>
+            ) : (
+              <span>No daily updates submitted yet</span>
+            )}
+          </div>
+          
+          <div className="flex items-center gap-3 flex-wrap">
+            <Button variant="outline" asChild className="border-slate-200 text-slate-600 hover:text-slate-900 bg-white hover:bg-slate-50 shadow-sm">
+              <Link href={`/dashboard/my-quests/${quest.id}/story`}>View Story</Link>
+            </Button>
+            <Button variant="outline" asChild className="border-slate-200 text-slate-600 hover:text-slate-900 bg-white hover:bg-slate-50 shadow-sm">
+              <Link href={`/dashboard/quests/${quest.id}`}>View Details</Link>
+            </Button>
+            
+            {isActive && (
+              <>
+                <Button 
+                  onClick={() => setIsStandupOpen(true)}
+                  className="bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 shadow-sm flex items-center gap-1.5"
+                >
+                  <CalendarDays className="h-4 w-4 text-slate-500" />
+                  Daily Standup
+                </Button>
+                
+                <QuestSubmissionDialog
+                  questTitle={quest.title}
+                  assignmentId={assignment.id}
+                  questId={quest.id}
+                />
+              </>
+            )}
+
+            {isUnderReviewStatus && (
+              <Button disabled variant="secondary" className="bg-slate-100 text-slate-400 border border-slate-200 cursor-not-allowed">
+                <CheckCircle2 className="mr-2 h-4 w-4 text-slate-400" />
+                Under Review
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <DailyStandupModal
+        isOpen={isStandupOpen}
+        onClose={() => setIsStandupOpen(false)}
+        assignmentId={assignment.id}
+        onSuccess={() => {
+          // Refresh lastUpdateAt locally
+          setAssignment((prev: any) => ({
+            ...prev,
+            lastUpdateAt: new Date().toISOString(),
+          }));
+        }}
+        tasks={tasks}
+        completedTasks={completedTasks}
+        questTitle={quest.title}
+        xpReward={quest.xpReward}
+      />
+    </Card>
+  );
+}

--- a/components/ui/phone-number-prompt.tsx
+++ b/components/ui/phone-number-prompt.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { Loader2, Phone } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export function PhoneNumberPrompt() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [countryCode, setCountryCode] = useState("+91");
+  const [phoneNo, setPhoneNo] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (session?.user && session.user.role === "adventurer") {
+      fetch("/api/user/onboarding")
+        .then((res) => res.json())
+        .then((data) => {
+          // If onboarding is completed but they don't have a phone number
+          if (data.onboardingCompleted === true && data.hasPhoneNumber === false) {
+            setIsOpen(true);
+          }
+        })
+        .catch(console.error);
+    }
+  }, [session]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!countryCode.startsWith("+") || countryCode.length < 2) {
+      toast.error("Please enter a valid country code (e.g. +91)");
+      return;
+    }
+    if (!phoneNo || phoneNo.length < 8) {
+      toast.error("Please enter a valid phone number");
+      return;
+    }
+
+    const phoneNumber = `${countryCode}${phoneNo}`;
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/user/phone-number", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phoneNumber }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to save phone number");
+
+      toast.success("Phone number saved!");
+      setIsOpen(false);
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm">
+      <div className="bg-white border border-slate-200 text-slate-900 w-full max-w-md rounded-2xl shadow-2xl p-6 animate-in fade-in zoom-in-95 duration-200">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="h-10 w-10 rounded-full bg-orange-500/10 text-orange-500 border border-orange-500/20 flex items-center justify-center flex-shrink-0">
+            <Phone className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="text-xl font-bold tracking-tight">Add WhatsApp Number</h3>
+            <p className="text-sm text-slate-500">Required for Quest updates and standups.</p>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 mt-6">
+          <div className="flex gap-2">
+            <div className="w-24 space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">Code</label>
+              <input
+                type="text"
+                required
+                placeholder="+91"
+                value={countryCode}
+                onChange={(e) => {
+                  let val = e.target.value;
+                  if (val && !val.startsWith('+')) {
+                    val = '+' + val;
+                  }
+                  setCountryCode(val);
+                }}
+                className="w-full h-10 px-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 text-sm placeholder-slate-400 bg-slate-50 hover:bg-white focus:bg-white text-slate-900 transition-all shadow-sm"
+              />
+            </div>
+            <div className="flex-1 space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">Phone Number</label>
+              <input
+                type="tel"
+                required
+                placeholder="9876543210"
+                value={phoneNo}
+                onChange={(e) => setPhoneNo(e.target.value.replace(/\D/g, ""))}
+                className="w-full h-10 px-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 text-sm placeholder-slate-400 bg-slate-50 hover:bg-white focus:bg-white text-slate-900 transition-all shadow-sm"
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || phoneNo.length < 8}
+            className="w-full bg-orange-600 hover:bg-orange-500 text-white text-sm font-bold py-3 rounded-xl transition-colors flex items-center justify-center disabled:opacity-50 border border-orange-500/50"
+          >
+            {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin text-white" /> : "Save Number"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/ai-generator.ts
+++ b/lib/ai-generator.ts
@@ -1,0 +1,89 @@
+/**
+ * Smart To-Do List Generator for Quests.
+ * Provides context-aware tasks based on quest category, title, and description.
+ */
+export function generateDefaultTasks(title: string, description: string, category: string): string[] {
+  const tasks: string[] = [];
+  const normalizedTitle = title.toLowerCase();
+  const normalizedDesc = description.toLowerCase();
+
+  // 1. Initial Setup Task
+  if (normalizedTitle.includes("next.js") || normalizedTitle.includes("nextjs")) {
+    tasks.push("Setup Next.js project with TypeScript and Tailwind CSS");
+  } else if (normalizedTitle.includes("react")) {
+    tasks.push("Setup React project structure and configure package.json");
+  } else {
+    tasks.push("Initialize repository and setup project dependencies");
+  }
+
+  // 2. Database/Model setup if mentioned
+  if (normalizedTitle.includes("prisma") || normalizedDesc.includes("prisma") || normalizedDesc.includes("database") || normalizedDesc.includes("db ")) {
+    tasks.push("Design database schema, write Prisma models, and run migrations");
+  }
+
+  // 3. Category-Specific Core Tasks
+  switch (category.toLowerCase()) {
+    case "frontend":
+      tasks.push("Create responsive UI layouts based on design specifications");
+      if (normalizedTitle.includes("auth") || normalizedDesc.includes("login") || normalizedDesc.includes("signup")) {
+        tasks.push("Implement login, signup, and profile UI screens with form validation");
+      } else {
+        tasks.push("Develop interactive frontend components and manage local/global state");
+      }
+      tasks.push("Integrate backend API endpoints and handle loading/error states");
+      break;
+
+    case "backend":
+      if (normalizedTitle.includes("auth") || normalizedDesc.includes("jwt") || normalizedDesc.includes("login")) {
+        tasks.push("Implement secure user authentication endpoints (Signup/Login/JWT)");
+      } else {
+        tasks.push("Develop RESTful API routes and controller logic");
+      }
+      tasks.push("Configure request body validation using Zod or Joi");
+      tasks.push("Implement comprehensive error handling middleware");
+      break;
+
+    case "fullstack":
+      tasks.push("Implement secure backend APIs and connect database queries");
+      tasks.push("Build matching frontend pages and connect them to the backend API");
+      if (normalizedTitle.includes("auth")) {
+        tasks.push("Implement end-to-end authentication flow and route guards");
+      }
+      break;
+
+    case "design":
+      tasks.push("Research user flows and draft high-fidelity wireframes in Figma");
+      tasks.push("Build interactive UI prototype and document design system guidelines");
+      tasks.push("Validate designs via peer review or quick usability tests");
+      break;
+
+    case "qa":
+      tasks.push("Write a comprehensive test plan covering happy paths and edge cases");
+      tasks.push("Implement manual test cases and document reproducible steps");
+      tasks.push("Write automated end-to-end tests using Playwright or Jest");
+      break;
+
+    case "data_science":
+    case "analytics":
+      tasks.push("Perform exploratory data analysis (EDA) and clean dataset");
+      tasks.push("Train predictive model or build statistical analytics queries");
+      tasks.push("Create visual charts or an interactive dashboard for results");
+      break;
+
+    default:
+      tasks.push("Implement core business logic as specified in the quest brief");
+      tasks.push("Refactor code for clean architecture and readability");
+  }
+
+  // 4. Testing & Documentation Tasks
+  if (normalizedTitle.includes("api") || normalizedDesc.includes("api")) {
+    tasks.push("Document API endpoints using Postman collection or Swagger spec");
+  } else {
+    tasks.push("Write unit and integration tests for core logic");
+  }
+
+  // 5. Final deployment/verification Task
+  tasks.push("Perform self-review, run linters, and verify criteria before submitting");
+
+  return tasks;
+}

--- a/lib/guild-score.ts
+++ b/lib/guild-score.ts
@@ -1,0 +1,81 @@
+import { prisma } from './db';
+import { Prisma } from '@prisma/client';
+
+export async function recalculateGuildScore(userId: string, tx?: Prisma.TransactionClient) {
+  const client = tx || prisma;
+
+  // 1. Delivery Rate
+  const completedCount = await client.questAssignment.count({
+    where: { userId, startedAt: { not: null }, status: 'completed' },
+  });
+  const totalFinishedCount = await client.questAssignment.count({
+    where: { userId, startedAt: { not: null }, status: { in: ['completed', 'cancelled'] } },
+  });
+  const deliveryRate = totalFinishedCount === 0 ? 100.0 : (completedCount / totalFinishedCount) * 100;
+
+  // 2. On-Time Rate
+  const completedAssignments = await client.questAssignment.findMany({
+    where: { userId, status: 'completed' },
+    select: {
+      completedAt: true,
+      quest: {
+        select: {
+          deadline: true,
+        },
+      },
+    },
+  });
+  let onTimeCount = 0;
+  for (const ass of completedAssignments) {
+    if (!ass.quest.deadline || (ass.completedAt && ass.completedAt <= ass.quest.deadline)) {
+      onTimeCount++;
+    }
+  }
+  const onTimeRate = completedAssignments.length === 0 ? 100.0 : (onTimeCount / completedAssignments.length) * 100;
+
+  // 3. Update Consistency
+  const startedAssignments = await client.questAssignment.findMany({
+    where: { userId, startedAt: { not: null } },
+    select: {
+      id: true,
+      startedAt: true,
+      completedAt: true,
+      dailyUpdates: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  });
+  let totalExpected = 0;
+  let totalActual = 0;
+  for (const ass of startedAssignments) {
+    const endTime = ass.completedAt ?? new Date();
+    const durationMs = endTime.getTime() - ass.startedAt!.getTime();
+    const expectedForThis = Math.floor(durationMs / (1000 * 60 * 60 * 24));
+    totalExpected += expectedForThis;
+    totalActual += ass.dailyUpdates.length;
+  }
+  const updateConsistency = totalExpected === 0 ? 100.0 : Math.min(100.0, (totalActual / totalExpected) * 100);
+
+  // 4. Guild Score
+  const guildScore = Math.round((deliveryRate + onTimeRate + updateConsistency) / 3);
+
+  // Update profile
+  await client.adventurerProfile.update({
+    where: { userId },
+    data: {
+      guildScore,
+      deliveryRate: new Prisma.Decimal(deliveryRate.toFixed(2)),
+      onTimeRate: new Prisma.Decimal(onTimeRate.toFixed(2)),
+      updateConsistency: new Prisma.Decimal(updateConsistency.toFixed(2)),
+    },
+  });
+
+  return {
+    guildScore,
+    deliveryRate,
+    onTimeRate,
+    updateConsistency,
+  };
+}

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -149,7 +149,7 @@ export async function createQuest(body: CreateQuestBody, user: SessionUser): Pro
     title, description, detailedDescription, questType, difficulty,
     xpReward, skillPointsReward, monetaryReward, requiredSkills,
     requiredRank, maxParticipants, questCategory, track, source,
-    parentQuestId, deadline,
+    parentQuestId, deadline, tasks,
   } = body;
 
   if (!title || !description || !questType || !difficulty || !xpReward) {
@@ -179,6 +179,7 @@ export async function createQuest(body: CreateQuestBody, user: SessionUser): Pro
       parentQuestId: parentQuestId || null,
       companyId: user.id,
       deadline: deadline ? new Date(deadline) : null,
+      tasks: tasks || [],
     },
   });
 

--- a/lib/services/types.ts
+++ b/lib/services/types.ts
@@ -29,4 +29,5 @@ export type CreateQuestBody = {
   source: QuestSource;
   parentQuestId: string;
   deadline: string;
+  tasks?: string[];
 };

--- a/lib/xp-utils.ts
+++ b/lib/xp-utils.ts
@@ -6,6 +6,7 @@ import { UserRank } from '@prisma/client';
 import { logActivity } from './activity-logger';
 import { updateStreak } from './streak-utils';
 import { checkAchievements } from './achievement-checker';
+import { recalculateGuildScore } from './guild-score';
 
 /**
  * Calculate level from total XP.
@@ -76,6 +77,8 @@ export async function updateUserXpAndSkills(
         questCompletionRate: completionRate,
       },
     });
+
+    await recalculateGuildScore(userId, tx);
 
     await updateStreak(userId, tx);
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,6 +235,7 @@ model User {
   referrals            User[]                @relation("Referrals")
   referralRewardsGiven ReferralReward[]      @relation("ReferralGiver")
   referralRewardsEarned ReferralReward[]     @relation("ReferralEarner")
+  dailyUpdates          DailyUpdate[]
 
   @@index([email])
   @@index([username])
@@ -289,6 +290,13 @@ model AdventurerProfile {
   dailyWorkHours       String?            @map("daily_work_hours")
   expectations         String?            @map("expectations")
   onboardingCompleted  Boolean            @default(false) @map("onboarding_completed")
+  autoAssign           Boolean            @default(false) @map("auto_assign")
+  
+  guildScore           Int                @default(100) @map("guild_score")
+  deliveryRate         Decimal            @default(100.0) @map("delivery_rate") @db.Decimal(5, 2)
+  onTimeRate           Decimal            @default(100.0) @map("on_time_rate") @db.Decimal(5, 2)
+  updateConsistency    Decimal            @default(100.0) @map("update_consistency") @db.Decimal(5, 2)
+  phoneNumber          String?            @map("phone_number")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -346,6 +354,7 @@ model Quest {
   fieldTemplateId     String?       @map("field_template_id") @db.Uuid
   briefData           Json?         @map("brief_data") // { fieldKey: value } answered from template.briefFields
   acceptanceCriteria  String[]      @map("acceptance_criteria") // criteria the submission is evaluated against
+  tasks               String[]      @map("tasks") // predefined todo list items
 
   company          User?               @relation("CompanyQuests", fields: [companyId], references: [id])
   fieldTemplate    QuestFieldTemplate? @relation(fields: [fieldTemplateId], references: [id])
@@ -480,10 +489,13 @@ model QuestAssignment {
   startedAt   DateTime?        @map("started_at") @db.Timestamptz
   completedAt DateTime?        @map("completed_at") @db.Timestamptz
   progress    Decimal          @default(0.00) @db.Decimal(5, 2)
+  completedTasks String[]      @map("completed_tasks") // list of tasks completed by student
+  lastUpdateAt   DateTime?     @map("last_update_at") @db.Timestamptz // track last daily standup
 
   quest       Quest             @relation(fields: [questId], references: [id], onDelete: Cascade)
   user        User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   submissions QuestSubmission[]
+  dailyUpdates DailyUpdate[]
 
   @@unique([questId, userId])
   @@index([userId])
@@ -740,3 +752,23 @@ model ReferralReward {
   @@index([earnerId])
   @@map("referral_rewards")
 }
+
+model DailyUpdate {
+  id           String   @id @default(uuid()) @db.Uuid
+  assignmentId String   @map("assignment_id") @db.Uuid
+  userId       String   @map("user_id") @db.Uuid
+  yesterday    String   @db.Text
+  today        String   @db.Text
+  blockers     String?  @db.Text
+  evidenceUrl  String?  @map("evidence_url")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  assignment QuestAssignment @relation(fields: [assignmentId], references: [id], onDelete: Cascade)
+  user       User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([assignmentId])
+  @@index([userId])
+  @@index([createdAt])
+  @@map("daily_updates")
+}
+


### PR DESCRIPTION
## Summary

Implements the daily standup workflow for adventurers on active quest assignments.

### Features delivered
- **Daily standup submission** — yesterday/today/blockers/evidence per assignment
- **Guild score** — composite metric: delivery rate + on-time rate + update consistency
- **Task progress tracking** — checklist items per quest, toggle completion
- **XP penalty system** — 5% XP reduction per missed daily update on approval
- **Cron job** — auto-cancels assignments unaccepted >6h or with no updates >48h
- **Admin updates panel** — view missed updates, reassign stalled assignments
- **Phone number prompt** — collect contact info during onboarding

### Schema changes (requires migration after merge)
New fields on `AdventurerProfile`: `guildScore`, `deliveryRate`, `onTimeRate`, `updateConsistency`, `phoneNumber`
New fields on `QuestAssignment`: `completedTasks`, `lastUpdateAt`, `tasks`
New model: `DailyUpdate`

Closes #294