### PR TITLE
feat: send feedback button in footer

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendEmail } from '@/lib/mail';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { type, message, email, page } = body;
+
+    if (!message || typeof message !== 'string' || message.trim().length < 5) {
+      return NextResponse.json({ error: 'Message is required (min 5 characters)', success: false }, { status: 400 });
+    }
+
+    const feedbackType = typeof type === 'string' ? type : 'General';
+    const userEmail = typeof email === 'string' && email.trim() ? email.trim() : 'anonymous';
+    const fromPage = typeof page === 'string' && page.trim() ? page.trim() : 'unknown';
+
+    await sendEmail({
+      to: 'abid@guilds.work',
+      subject: `[Guild Feedback] ${feedbackType} — from ${userEmail}`,
+      html: `
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+          <h2 style="color: #1e293b; margin-bottom: 8px;">New Feedback Received</h2>
+          <p style="color: #64748b; font-size: 13px; margin-bottom: 24px;">Submitted via Guild platform feedback form</p>
+
+          <table style="width: 100%; border-collapse: collapse; margin-bottom: 20px;">
+            <tr>
+              <td style="padding: 8px 12px; background: #f8fafc; border: 1px solid #e2e8f0; font-size: 12px; font-weight: 600; color: #475569; width: 120px;">Type</td>
+              <td style="padding: 8px 12px; border: 1px solid #e2e8f0; font-size: 13px; color: #1e293b;">${feedbackType}</td>
+            </tr>
+            <tr>
+              <td style="padding: 8px 12px; background: #f8fafc; border: 1px solid #e2e8f0; font-size: 12px; font-weight: 600; color: #475569;">From</td>
+              <td style="padding: 8px 12px; border: 1px solid #e2e8f0; font-size: 13px; color: #1e293b;">${userEmail}</td>
+            </tr>
+            <tr>
+              <td style="padding: 8px 12px; background: #f8fafc; border: 1px solid #e2e8f0; font-size: 12px; font-weight: 600; color: #475569;">Page</td>
+              <td style="padding: 8px 12px; border: 1px solid #e2e8f0; font-size: 13px; color: #1e293b;">${fromPage}</td>
+            </tr>
+          </table>
+
+          <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px;">
+            <p style="font-size: 12px; font-weight: 600; color: #475569; margin: 0 0 8px 0; text-transform: uppercase; letter-spacing: 0.05em;">Message</p>
+            <p style="font-size: 14px; color: #1e293b; white-space: pre-wrap; margin: 0;">${message.trim().replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>
+          </div>
+        </div>
+      `,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[feedback] Error sending feedback:', error);
+    return NextResponse.json({ error: 'Failed to send feedback. Please try again.', success: false }, { status: 500 });
+  }
+}

--- a/components/ui/feedback-button.tsx
+++ b/components/ui/feedback-button.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { X, MessageSquare, Loader2, CheckCircle2 } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+type FeedbackType = "Bug" | "Suggestion" | "Praise" | "Other";
+
+const TYPES: { value: FeedbackType; emoji: string; label: string }[] = [
+  { value: "Bug", emoji: "🐛", label: "Bug" },
+  { value: "Suggestion", emoji: "💡", label: "Idea" },
+  { value: "Praise", emoji: "🙌", label: "Praise" },
+  { value: "Other", emoji: "💬", label: "Other" },
+];
+
+export function FeedbackButton() {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<FeedbackType>("Bug");
+  const [message, setMessage] = useState("");
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const pathname = usePathname();
+
+  const handleOpen = () => {
+    setOpen(true);
+    setStatus("idle");
+    setMessage("");
+    setEmail("");
+    setErrorMsg("");
+    setType("Bug");
+  };
+
+  const handleClose = () => {
+    if (status === "loading") return;
+    setOpen(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (message.trim().length < 5) {
+      setErrorMsg("Please describe the issue in at least 5 characters.");
+      return;
+    }
+    setStatus("loading");
+    setErrorMsg("");
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, message, email, page: pathname }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to send feedback");
+      setStatus("success");
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium text-slate-500 hover:text-slate-800 bg-slate-100 hover:bg-slate-200 border border-slate-200 hover:border-slate-300 rounded-lg transition-all"
+      >
+        <MessageSquare className="w-3 h-3" />
+        Send Feedback
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm">
+          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md animate-in fade-in slide-in-from-bottom-4 sm:slide-in-from-bottom-0 sm:zoom-in-95 duration-200">
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-slate-100">
+              <div>
+                <h3 className="text-[15px] font-bold text-slate-900">Send Feedback</h3>
+                <p className="text-[12px] text-slate-500 mt-0.5">Report bugs, suggest features, or just say hi.</p>
+              </div>
+              <button
+                onClick={handleClose}
+                disabled={status === "loading"}
+                className="text-slate-400 hover:text-slate-700 hover:bg-slate-100 p-1.5 rounded-lg transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {status === "success" ? (
+              <div className="px-5 py-10 flex flex-col items-center gap-3 text-center">
+                <div className="w-12 h-12 bg-emerald-50 rounded-full flex items-center justify-center">
+                  <CheckCircle2 className="w-6 h-6 text-emerald-500" />
+                </div>
+                <p className="text-[15px] font-semibold text-slate-900">Thanks for the feedback!</p>
+                <p className="text-[13px] text-slate-500 max-w-[260px]">
+                  We read every report and use it to make Guild better.
+                </p>
+                <button
+                  onClick={handleClose}
+                  className="mt-2 px-5 py-2 text-[13px] font-semibold bg-slate-900 hover:bg-slate-800 text-white rounded-xl transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="px-5 pt-4 pb-5 space-y-4">
+                {/* Type selector */}
+                <div className="grid grid-cols-4 gap-2">
+                  {TYPES.map((t) => (
+                    <button
+                      key={t.value}
+                      type="button"
+                      onClick={() => setType(t.value)}
+                      className={`flex flex-col items-center gap-1 py-2.5 rounded-xl border text-[11px] font-semibold transition-all ${
+                        type === t.value
+                          ? "border-orange-500 bg-orange-50 text-orange-700"
+                          : "border-slate-200 bg-slate-50 text-slate-600 hover:border-slate-300 hover:bg-white"
+                      }`}
+                    >
+                      <span className="text-base leading-none">{t.emoji}</span>
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Message */}
+                <div className="space-y-1.5">
+                  <label className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                    {type === "Bug" ? "What went wrong?" : type === "Suggestion" ? "What would you like to see?" : type === "Praise" ? "What did you love?" : "Your message"}
+                    <span className="text-orange-500 ml-0.5">*</span>
+                  </label>
+                  <textarea
+                    required
+                    rows={4}
+                    placeholder={
+                      type === "Bug"
+                        ? "Describe what happened and where — page, action, what you expected vs what you got..."
+                        : type === "Suggestion"
+                        ? "Describe your idea — how would it work and why would it be useful..."
+                        : type === "Praise"
+                        ? "Tell us what you enjoyed..."
+                        : "Anything on your mind..."
+                    }
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    className="w-full p-3 border border-slate-200 rounded-xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-[13px] focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-400 placeholder-slate-400 resize-none transition-all"
+                  />
+                </div>
+
+                {/* Email */}
+                <div className="space-y-1.5">
+                  <label className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                    Your email <span className="text-slate-400 normal-case font-normal">(optional — so we can follow up)</span>
+                  </label>
+                  <input
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="w-full h-9 px-3 border border-slate-200 rounded-xl bg-slate-50 hover:bg-white focus:bg-white text-slate-900 text-[13px] focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-400 placeholder-slate-400 transition-all"
+                  />
+                </div>
+
+                {errorMsg && (
+                  <p className="text-[12px] text-rose-600 bg-rose-50 border border-rose-100 px-3 py-2 rounded-lg">
+                    {errorMsg}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={status === "loading" || message.trim().length < 5}
+                  className="w-full bg-slate-900 hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed text-white text-[13px] font-semibold py-2.5 rounded-xl transition-all flex items-center justify-center gap-2"
+                >
+                  {status === "loading" ? (
+                    <>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      Sending...
+                    </>
+                  ) : (
+                    "Send Feedback"
+                  )}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/ui/footer-taped-design.tsx
+++ b/components/ui/footer-taped-design.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { Github, Twitter } from 'lucide-react';
+import { FeedbackButton } from '@/components/ui/feedback-button';
 
 const tape = <svg xmlns="http://www.w3.org/2000/svg" width="95" height="80" viewBox="0 0 95 80" fill="none">
 <path d="M1 45L70.282 5L88.282 36.1769L19 76.1769L1 45Z" fill="#222222"/>
@@ -83,6 +84,7 @@ export const Component = () => {
         </div>
 
         <div className="flex gap-3 items-center">
+          <FeedbackButton />
           <a
             href="https://github.com/LarytheLord/Adventurers-Guild"
             target="_blank"


### PR DESCRIPTION
## Summary
- Adds a **Send Feedback** button to the site footer (visible on `/`, `/login`, `/register`, `/quests`, `/faq`, etc.)
- Clicking opens a modal dialog with: type selector (Bug 🐛 / Idea 💡 / Praise 🙌 / Other 💬), message textarea, optional email field
- Submits to `POST /api/feedback` which sends an email via Resend to abid@guilds.work with the page URL, type, and message
- TypeScript passes clean, no new deps required

## Files
- `components/ui/feedback-button.tsx` — client component, self-contained modal dialog
- `app/api/feedback/route.ts` — POST handler using existing `lib/mail.ts` sendEmail
- `components/ui/footer-taped-design.tsx` — adds `<FeedbackButton />` to bottom bar alongside GitHub/Twitter icons

## Test plan
- [ ] Click "Send Feedback" in footer on landing page — modal opens
- [ ] Select each type — placeholder text changes contextually
- [ ] Submit with message < 5 chars — inline error shown, no API call
- [ ] Submit valid bug report — success state shown, email arrives at abid@guilds.work
- [ ] Verify email includes: type, from email (if provided), page URL, formatted message
- [ ] Test on mobile — modal slides up from bottom, scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #311