### PR TITLE
fix: auth/session hardening — reset link log leak, token order, concurrent signup, OAuth retry (#300)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -8,19 +8,14 @@ export async function POST(request: NextRequest) {
     const { email } = await request.json();
     const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
 
-    console.log('[forgot-password] Request received for email:', normalizedEmail);
-
     if (!normalizedEmail) {
-      console.log('[forgot-password] No email provided');
       return NextResponse.json({ error: 'Email is required' }, { status: 400 });
     }
 
     const user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    console.log('[forgot-password] User found:', !!user);
 
     // Always return success to prevent email enumeration
     if (!user) {
-      console.log('[forgot-password] User not found, returning success message anyway');
       return NextResponse.json({ message: 'If an account exists, a reset link has been sent.' });
     }
 
@@ -29,25 +24,11 @@ export async function POST(request: NextRequest) {
     const tokenHash = createHash('sha256').update(token).digest('hex');
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
-    console.log('[forgot-password] Generated reset token for user:', user.id);
-
-    // Delete any existing tokens for this user
-    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
-    console.log('[forgot-password] Cleaned up old tokens');
-
-    // Create new token
-    await prisma.passwordResetToken.create({
-      data: { userId: user.id, token: tokenHash, expiresAt },
-    });
-    console.log('[forgot-password] Created new reset token in DB');
-
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
     const resetLink = `${appUrl}/reset-password?token=${token}`;
 
-    console.log('[forgot-password] Reset link:', resetLink);
-    console.log('[forgot-password] Attempting to send email to:', normalizedEmail);
-
-    // sendEmail now throws on failure — let the outer catch handle it
+    // Send email FIRST — only save the token to DB if email succeeds.
+    // This prevents dangling tokens when the mail service is down.
     await sendEmail({
       to: normalizedEmail,
       subject: 'Reset your password — Guild',
@@ -64,14 +45,15 @@ export async function POST(request: NextRequest) {
       `,
     });
 
-    console.log('[forgot-password] Email sent successfully!');
+    // Email sent — now persist the token
+    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
+    await prisma.passwordResetToken.create({
+      data: { userId: user.id, token: tokenHash, expiresAt },
+    });
+
     return NextResponse.json({ message: 'If an account exists, a reset link has been sent.' });
   } catch (error) {
     console.error('[forgot-password] ERROR:', error);
-    if (error instanceof Error) {
-      console.error('[forgot-password] Error message:', error.message);
-      console.error('[forgot-password] Error stack:', error.stack);
-    }
     return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
   }
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma, withDbRetry } from '@/lib/db';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
+import { Prisma } from '@prisma/client';
 import { generateReferralCode, REFEREE_SIGNUP_XP } from '@/lib/referral-utils';
 
 const registerSchema = z.object({
@@ -130,6 +131,10 @@ export async function POST(request: NextRequest) {
       referralBonus: referrerId ? REFEREE_SIGNUP_XP : 0,
     }, { status: 201 });
   } catch (error) {
+    // Concurrent signup race: unique constraint on email or username
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return NextResponse.json({ error: 'User with this email already exists' }, { status: 409 });
+    }
     console.error('Registration error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -7,55 +7,33 @@ export async function POST(request: NextRequest) {
   try {
     const { token, password } = await request.json();
 
-    console.log('[reset-password] Request received');
-
     if (!token || !password) {
-      console.log('[reset-password] Missing token or password');
       return NextResponse.json({ error: 'Token and password are required' }, { status: 400 });
     }
 
     if (password.length < 8) {
-      console.log('[reset-password] Password too short');
       return NextResponse.json({ error: 'Password must be at least 8 characters' }, { status: 400 });
     }
 
-    console.log('[reset-password] Token received (length:', token.length, ')');
     const tokenHash = createHash('sha256').update(token).digest('hex');
-    console.log('[reset-password] Token hash:', tokenHash.substring(0, 16) + '...');
 
-    // Find the token
     const resetToken = await prisma.passwordResetToken.findUnique({
       where: { token: tokenHash },
       include: { user: true },
     });
 
-    console.log('[reset-password] Token lookup result:', !!resetToken);
-
     if (!resetToken) {
-      console.log('[reset-password] Token not found in database');
       return NextResponse.json({ error: 'Invalid or expired reset token' }, { status: 400 });
     }
 
-    console.log('[reset-password] Token found, checking validity...');
-
     if (resetToken.usedAt) {
-      console.log('[reset-password] Token already used');
       return NextResponse.json({ error: 'This reset token has already been used' }, { status: 400 });
     }
 
-    const now = new Date();
-    console.log('[reset-password] Expiration check:', {
-      now: now.toISOString(),
-      expiresAt: resetToken.expiresAt.toISOString(),
-      isExpired: now > resetToken.expiresAt,
-    });
-
-    if (now > resetToken.expiresAt) {
-      console.log('[reset-password] Token expired');
-      return NextResponse.json({ error: 'Reset token has expired' }, { status: 400 });
+    if (new Date() > resetToken.expiresAt) {
+      return NextResponse.json({ error: 'Reset token has expired. Please request a new one.' }, { status: 400 });
     }
 
-    // Hash new password and update
     const passwordHash = await bcrypt.hash(password, 12);
 
     await prisma.$transaction([
@@ -69,7 +47,6 @@ export async function POST(request: NextRequest) {
       }),
     ]);
 
-    console.log('[reset-password] Password reset successful for user:', resetToken.userId);
     return NextResponse.json({ message: 'Password reset successful' });
   } catch (error) {
     console.error('[reset-password] Error:', error);

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { SunIcon as Sunburst, ArrowRight, CheckCircle2, Loader2 } from 'lucide-react';
 
@@ -11,6 +11,7 @@ const labelClass = 'block text-sm mb-2';
 
 function ResetPasswordForm() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const token = searchParams.get('token');
 
   const [password, setPassword] = useState('');
@@ -20,7 +21,13 @@ function ResetPasswordForm() {
   const [loading, setLoading] = useState(false);
   const [isHydrated, setIsHydrated] = useState(false);
 
-  useEffect(() => { setIsHydrated(true); }, []);
+  useEffect(() => {
+    setIsHydrated(true);
+    if (!searchParams.get('token')) {
+      setError('Invalid reset link — please request a new one');
+    }
+  }, [searchParams]);
+
   if (!isHydrated) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -43,7 +50,7 @@ function ResetPasswordForm() {
         setError(data.error || 'Failed to reset password');
       } else {
         setSuccess(true);
-        setTimeout(() => { window.location.href = '/login'; }, 2000);
+        setTimeout(() => { router.push('/login'); }, 2000);
       }
     } catch {
       setError('An unexpected error occurred');

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,6 +6,7 @@ import GitHubProvider from 'next-auth/providers/github';
 import GoogleProvider from 'next-auth/providers/google';
 import bcrypt from 'bcryptjs';
 import { prisma, withDbRetry } from './db';
+import { generateReferralCode } from '@/lib/referral-utils';
 import { env } from '@/lib/env';
 import { UserRole, UserRank } from '@prisma/client';
 
@@ -21,16 +22,30 @@ async function upsertOAuthUser(user: User, account?: Account | null) {
   }
 
   const normalizedEmail = email.trim().toLowerCase();
-  const existingUser = await prisma.user.findUnique({
-    where: { email: normalizedEmail },
-    include: { adventurerProfile: true },
-  });
+  const existingUser = await withDbRetry(() =>
+    prisma.user.findUnique({
+      where: { email: normalizedEmail },
+      include: { adventurerProfile: true },
+    })
+  );
 
   if (existingUser?.role === 'company' || existingUser?.role === 'admin') {
     return { error: 'role_not_allowed' as const };
   }
 
-  const dbUser = await prisma.$transaction(async (tx) => {
+  // Generate a referral code for new OAuth users before entering the transaction
+  let newReferralCode: string | null = null;
+  if (!existingUser) {
+    for (let i = 0; i < 5; i++) {
+      const candidate = generateReferralCode(user.name ?? 'USER');
+      const taken = await withDbRetry(() =>
+        prisma.user.findUnique({ where: { referralCode: candidate }, select: { id: true } })
+      );
+      if (!taken) { newReferralCode = candidate; break; }
+    }
+  }
+
+  const dbUser = await withDbRetry(() => prisma.$transaction(async (tx) => {
     if (!existingUser) {
       const username =
         normalizedEmail.split('@')[0].replace(/[^a-zA-Z0-9_]/g, '') + Math.floor(Math.random() * 1000);
@@ -44,6 +59,7 @@ async function upsertOAuthUser(user: User, account?: Account | null) {
           role: 'adventurer' as UserRole,
           rank: 'F' as UserRank,
           xp: 0,
+          referralCode: newReferralCode,
           adventurerProfile: {
             create: {},
           },
@@ -63,7 +79,7 @@ async function upsertOAuthUser(user: User, account?: Account | null) {
       where: { id: existingUser.id },
       data: { lastLoginAt: new Date() },
     });
-  });
+  }));
 
   (user as unknown as Record<string, unknown>).id = dbUser.id;
   (user as unknown as Record<string, unknown>).role = dbUser.role;
@@ -143,12 +159,30 @@ export const authOptions: AuthOptions = {
       }
       return true;
     },
-    async jwt({ token, user }: { token: JWT; user?: User }) {
+    async jwt({ token, user, trigger }: { token: JWT; user?: User; trigger?: string }) {
       if (user) {
         token.id = user.id;
         token.role = user.role as UserRole;
         token.rank = user.rank;
         token.xp = user.xp;
+      }
+      // On session update (e.g. after XP/rank change), refresh from DB
+      if (trigger === 'update' && token.id) {
+        try {
+          const fresh = await withDbRetry(() =>
+            prisma.user.findUnique({
+              where: { id: token.id as string },
+              select: { rank: true, xp: true, role: true },
+            })
+          );
+          if (fresh) {
+            token.rank = fresh.rank;
+            token.xp = fresh.xp;
+            token.role = fresh.role as UserRole;
+          }
+        } catch (e) {
+          console.warn('[Auth] jwt refresh failed:', e);
+        }
       }
       return token;
     },


### PR DESCRIPTION
## Summary

- **CRITICAL security fix**: removes `console.log` that was logging live password reset URLs to Vercel production logs — anyone with log access could have used them to take over accounts
- Reorders `forgot-password` flow: email sends first, token saved to DB only on success (prevents dangling tokens when mail service is down)
- Cleans all console.logs from forgot/reset routes (were logging PII: emails, user IDs)
- `register`: catches Prisma `P2002` unique constraint on concurrent same-email signup → returns 409 instead of 500
- OAuth `upsertOAuthUser`: wraps DB calls in `withDbRetry` for Neon cold-start resilience
- OAuth new users now get a `referralCode` on signup (was missing — left them unable to share referral links)
- JWT callback: refreshes `rank`/`xp`/`role` from DB when `trigger === 'update'` (session now stays in sync after XP gains)
- `reset-password` page: uses `router.push` instead of `window.location.href`; shows missing-token error immediately on mount instead of waiting for form submit

## Test plan

- [ ] Forgot password: submit email → link arrives in inbox; check Vercel logs — no reset URL visible
- [ ] Forgot password: submit with broken SMTP → no token saved to DB; retry works after SMTP fixed
- [ ] Register with same email twice (fast) → second request returns 409 "already exists"
- [ ] Sign in with GitHub/Google → user created with a referralCode; referral link works
- [ ] Reset password page with no `?token` → error message shows immediately, not on submit
- [ ] XP gain in quest → call `update({ trigger: 'update' })` → session reflects new XP without re-login

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)