### PR TITLE
fix: company portal — submission review state, member since date, unauth redirect (#301)

### DIFF
--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest) {
         linkedin: true,
         discord: true,
         role: true,
+        createdAt: true,
         companyProfile: {
           select: {
             companyName: true,

--- a/app/dashboard/company/profile/page.tsx
+++ b/app/dashboard/company/profile/page.tsx
@@ -27,6 +27,7 @@ import { fetchWithAuth } from '@/lib/fetch-with-auth';
 
 interface CompanyProfileData {
   name: string | null;
+  createdAt: string;
   companyProfile: {
     companyName: string | null;
     companyWebsite: string | null;
@@ -52,6 +53,10 @@ export default function CompanyProfilePage() {
   });
 
   useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+      return;
+    }
     if (status === 'authenticated' && session?.user?.role !== 'company' && session?.user?.role !== 'admin') {
       router.push('/dashboard');
       return;
@@ -148,7 +153,9 @@ export default function CompanyProfilePage() {
                 </span>
                 <span className="flex items-center gap-1">
                   <Clock className="w-3.5 h-3.5" />
-                  Member since 2025
+                  Member since {profileData?.createdAt
+                    ? new Date(profileData.createdAt).getFullYear()
+                    : new Date().getFullYear()}
                 </span>
               </div>
             </div>

--- a/app/dashboard/company/quests/[id]/page.tsx
+++ b/app/dashboard/company/quests/[id]/page.tsx
@@ -45,7 +45,7 @@ interface Submission {
 interface Applicant {
   id: string;
   userId: string;
-  status: 'assigned' | 'started' | 'in_progress' | 'submitted' | 'review' | 'completed' | 'cancelled';
+  status: 'assigned' | 'started' | 'in_progress' | 'submitted' | 'review' | 'pending_admin_review' | 'needs_rework' | 'completed' | 'cancelled';
   assignedAt: string;
   user: {
     name: string;
@@ -161,7 +161,9 @@ export default function CompanyQuestDetailsPage({ params }: { params: Promise<{ 
 
       if (data.success) {
         const newAssignmentStatus: Applicant['status'] =
-          action === 'approved' ? 'completed' : 'in_progress';
+          action === 'approved' ? 'completed'
+          : action === 'needs_rework' ? 'needs_rework'
+          : 'cancelled';
         const label = action === 'approved' ? 'Approved' : action === 'needs_rework' ? 'Sent back for rework' : 'Rejected';
         toast.success(label);
         setQuest(prev => prev ? {


### PR DESCRIPTION
## Summary

- **Submission review optimistic state bug**: when a company rejects or requests rework on a submission, the UI was setting assignment status to `in_progress` for both cases — fixed to `needs_rework` → `needs_rework`, `rejected` → `cancelled`
- **Applicant type**: added missing `needs_rework` and `pending_admin_review` to the `Applicant['status']` union (was causing silent type mismatches)
- **Company profile unauth redirect**: page only checked role mismatch for redirect; unauthenticated users would see a blank/broken page — added `status === 'unauthenticated'` → redirect to `/login`
- **Member since year**: was hardcoded as `2025`; now reads actual `createdAt` year from DB via `/api/users/me` (also added `createdAt` to the select in that endpoint)

## Test plan

- [ ] Company approves/rejects/requests rework on a submission → verify UI status updates correctly without page refresh
- [ ] Visit `/dashboard/company/profile` while logged out → redirected to `/login`
- [ ] Company profile "Member since" shows the correct year from account creation

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)