### PR TITLE
fix: UX polish — bookmarks, XP display, apply loading, active statuses, Suspense (#302)

### DIFF
--- a/app/dashboard/company/page.tsx
+++ b/app/dashboard/company/page.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/components/guild/primitives';
 import { getStatusColor } from '@/lib/status-utils';
 
-const ACTIVE_ASSIGNMENT_STATUSES = ['assigned', 'started', 'in_progress', 'submitted', 'review'] as const;
+const ACTIVE_ASSIGNMENT_STATUSES = ['assigned', 'started', 'in_progress', 'submitted', 'review', 'needs_rework', 'pending_admin_review'] as const;
 
 export default async function CompanyDashboardPage() {
   const session = await getServerSession(authOptions);

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -101,8 +101,8 @@ export default function ProfilePage() {
     .join('')
     .toUpperCase() || 'U';
 
-  const xpToNextLevel = profile ? (profile.level + 1) * 1000 : 1000;
-  const xpProgress = profile ? ((profile.xp % 1000) / 10) : 0;
+  const xpInLevel = profile ? profile.xp % 1000 : 0;
+  const xpProgress = profile ? (xpInLevel / 10) : 0;
   const rankColor = RANK_COLORS[profile?.rank || 'F'] || RANK_COLORS.F;
 
   return (
@@ -182,7 +182,7 @@ export default function ProfilePage() {
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Level Progress</CardTitle>
           <CardDescription>
-            {profile?.xp || 0} / {xpToNextLevel} XP to Level {(profile?.level || 1) + 1}
+            {xpInLevel} / 1000 XP — {1000 - xpInLevel} more to Level {(profile?.level || 1) + 1}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
@@ -178,6 +180,7 @@ export default function QuestDetailPage() {
   const [submissionContent, setSubmissionContent] = useState('');
   const [submissionNotes, setSubmissionNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
   const [currentStreak, setCurrentStreak] = useState(0);
   const [shareCount, setShareCount] = useState(0);
   const [isStandupOpen, setIsStandupOpen] = useState(false);
@@ -532,8 +535,9 @@ export default function QuestDetailPage() {
                 </div>
                 <Button
                   className="w-full"
-                  disabled={!!(quest.maxParticipants && quest.maxParticipants <= 0)}
+                  disabled={isApplying || !!(quest.maxParticipants && quest.maxParticipants <= 0)}
                   onClick={async () => {
+                    setIsApplying(true);
                     try {
                       const res = await fetchWithAuth('/api/quests/assignments', {
                         method: 'POST',
@@ -545,10 +549,10 @@ export default function QuestDetailPage() {
                       if (!data.success) { toast.error(data.error || 'Failed to assign to quest'); return; }
                       setAssignment(data.assignment);
                       toast.success('Successfully assigned to quest!');
-                    } catch { toast.error('An error occurred while assigning to quest'); }
+                    } catch { toast.error('An error occurred while assigning to quest'); } finally { setIsApplying(false); }
                   }}
                 >
-                  Claim Quest
+                  {isApplying ? 'Claiming...' : 'Claim Quest'}
                 </Button>
               </div>
             ) : (

--- a/app/quests/[id]/page.tsx
+++ b/app/quests/[id]/page.tsx
@@ -65,6 +65,7 @@ export default function QuestDetailPage() {
 
   useEffect(() => {
     if (!questId) return;
+    setIsBookmarked(localStorage.getItem(`bookmark:${questId}`) === '1');
     fetchQuest();
   }, [questId]);
 
@@ -171,8 +172,11 @@ export default function QuestDetailPage() {
                 <TooltipTrigger asChild>
                   <button
                     onClick={() => {
-                      setIsBookmarked(!isBookmarked);
-                      toast(isBookmarked ? 'Removed from bookmarks' : 'Saved to bookmarks');
+                      const next = !isBookmarked;
+                      setIsBookmarked(next);
+                      if (next) { localStorage.setItem(`bookmark:${questId}`, '1'); }
+                      else { localStorage.removeItem(`bookmark:${questId}`); }
+                      toast(next ? 'Saved to bookmarks' : 'Removed from bookmarks');
                     }}
                     className="p-2 rounded-lg text-slate-500 hover:text-amber-600 hover:bg-slate-100 transition-colors"
                   >


### PR DESCRIPTION
## Summary

- **Bookmark persistence**: quest bookmarks were lost on page refresh — now reads/writes `localStorage` under `bookmark:<questId>` key
- **XP level progress display**: was showing total XP vs next-level threshold (e.g. `2500 / 3000 XP to Level 3`) which was confusing and inconsistent with the progress bar (which uses `xp % 1000`). Fixed to `750 / 1000 XP — 250 more to Level 3`
- **Quest apply button loading state**: added `isApplying` state — button shows `Claiming...` and is disabled during the API call, preventing double-submit
- **ACTIVE_ASSIGNMENT_STATUSES** on company dashboard: added `needs_rework` and `pending_admin_review` — company was seeing 0 active quests when adventurers were in these states
- **useSearchParams Suspense**: added `export const dynamic = 'force-dynamic'` to `dashboard/quests/[id]/page.tsx` to resolve Next.js 15 static rendering warning for `useSearchParams()`

## Test plan

- [ ] Bookmark a quest, refresh page → still bookmarked
- [ ] Profile page XP display shows progress within current level (not total vs threshold)
- [ ] Click "Claim Quest" → button shows "Claiming..." and is disabled until response
- [ ] Company dashboard active quest count includes needs_rework and pending_admin_review assignments
- [ ] No Suspense/useSearchParams console warnings in Next.js 15 dev mode

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)