### PR TITLE
fix: unblock quest submission flow — Start Quest button, active/history split

### DIFF
--- a/app/dashboard/my-quests/page.tsx
+++ b/app/dashboard/my-quests/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma, withDbRetry } from "@/lib/db";
+import { AssignmentStatus } from "@prisma/client";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { MyQuestCard } from "@/components/my-quest-card";
@@ -19,36 +20,36 @@ export default async function MyQuestsPage() {
     redirect('/dashboard/company');
   }
 
-  // Fetch user's assignments
-  const assignments = await withDbRetry(() => prisma.questAssignment.findMany({
-    where: {
-      userId: session.user.id,
-    },
-    include: {
-      quest: {
-        include: {
-          company: true,
-        },
-      },
-    },
-    orderBy: {
-      assignedAt: 'desc',
-    },
-  }));
+  const ACTIVE_STATUSES: AssignmentStatus[] = ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'needs_rework'];
+
+  const [activeAssignments, pastAssignments] = await Promise.all([
+    withDbRetry(() => prisma.questAssignment.findMany({
+      where: { userId: session.user.id, status: { in: ACTIVE_STATUSES } },
+      include: { quest: { include: { company: true } } },
+      orderBy: { assignedAt: 'desc' },
+    })),
+    withDbRetry(() => prisma.questAssignment.findMany({
+      where: { userId: session.user.id, status: { in: ['completed', 'cancelled'] as AssignmentStatus[] } },
+      include: { quest: { include: { company: true } } },
+      orderBy: { completedAt: 'desc' },
+      take: 10,
+    })),
+  ]);
 
   return (
     <div className="container py-8 max-w-5xl">
       <h1 className="text-3xl font-bold mb-2">My Quests</h1>
       <p className="text-muted-foreground mb-8">Manage your active quests and view your history.</p>
 
-      <div className="grid gap-6">
-        {assignments.length === 0 ? (
+      {/* Active quests */}
+      <div className="grid gap-6 mb-10">
+        {activeAssignments.length === 0 ? (
           <Card>
             <CardContent className="flex flex-col items-center justify-center py-8 sm:py-12 px-4">
               <div className="rounded-full bg-muted p-4 mb-4">
                 <AlertCircle className="h-8 w-8 text-muted-foreground" />
               </div>
-              <h3 className="text-lg font-semibold mb-2 text-center">No quests found</h3>
+              <h3 className="text-lg font-semibold mb-2 text-center">No active quests</h3>
               <p className="text-muted-foreground mb-4 text-center text-sm sm:text-base">You haven&apos;t accepted any quests yet.</p>
               <Button asChild>
                 <Link href="/dashboard/quests">Find Quests</Link>
@@ -56,11 +57,23 @@ export default async function MyQuestsPage() {
             </CardContent>
           </Card>
         ) : (
-          assignments.map((assignment) => (
+          activeAssignments.map((assignment) => (
             <MyQuestCard key={assignment.id} initialAssignment={assignment} />
           ))
         )}
       </div>
+
+      {/* Quest history */}
+      {pastAssignments.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4 text-slate-700">History</h2>
+          <div className="grid gap-4">
+            {pastAssignments.map((assignment) => (
+              <MyQuestCard key={assignment.id} initialAssignment={assignment} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -511,11 +511,11 @@ export default function QuestDetailPage() {
                         const res = await fetchWithAuth(`/api/quests/assignments/${assignment.id}`, {
                           method: 'PATCH',
                           headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ status: 'in_progress' }),
+                          body: JSON.stringify({ status: 'started' }),
                         });
                         const data = await res.json();
                         if (!data.success) { toast.error(data.error || 'Failed to start quest'); return; }
-                        setAssignment((prev) => prev ? { ...prev, status: 'in_progress' } : prev);
+                        setAssignment((prev) => prev ? { ...prev, status: 'started' } : prev);
                         toast.success('Quest started! Submit your work below.');
                       } catch { toast.error('Failed to start quest'); }
                       finally { setIsStarting(false); }

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -181,6 +181,7 @@ export default function QuestDetailPage() {
   const [submissionNotes, setSubmissionNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
   const [currentStreak, setCurrentStreak] = useState(0);
   const [shareCount, setShareCount] = useState(0);
   const [isStandupOpen, setIsStandupOpen] = useState(false);
@@ -251,7 +252,8 @@ export default function QuestDetailPage() {
 
   const isAssigned = !!assignment;
   const canAssign = quest?.status === 'available' && !isAssigned;
-  const canSubmit = !!assignment && ['assigned', 'started', 'in_progress', 'needs_rework'].includes(assignment.status);
+  const canSubmit = !!assignment && ['started', 'in_progress', 'needs_rework'].includes(assignment.status);
+  const canStart = !!assignment && assignment.status === 'assigned';
   const showPartyPanel = (quest?.maxParticipants ?? 1) > 1;
 
   if (status === 'loading' || loading) {
@@ -493,9 +495,35 @@ export default function QuestDetailPage() {
                     : assignment.status === 'submitted' || assignment.status === 'pending_admin_review'
                       ? 'Delivery is in review.'
                       : assignment.status === 'needs_rework'
-                        ? 'Submission needs revision — resubmit below.'
-                        : 'You are responsible for this quest. Keep momentum.'}
+                        ? 'Submission needs revision — use the form below to resubmit.'
+                        : assignment.status === 'assigned'
+                          ? 'Quest claimed! Start working to unlock the submission form.'
+                          : 'Quest in progress. Submit your work using the form below.'}
                 </div>
+                {canStart && (
+                  <Button
+                    className="w-full bg-emerald-600 hover:bg-emerald-700 text-white text-xs"
+                    disabled={isStarting}
+                    onClick={async () => {
+                      if (!assignment?.id) return;
+                      setIsStarting(true);
+                      try {
+                        const res = await fetchWithAuth(`/api/quests/assignments/${assignment.id}`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ status: 'in_progress' }),
+                        });
+                        const data = await res.json();
+                        if (!data.success) { toast.error(data.error || 'Failed to start quest'); return; }
+                        setAssignment((prev) => prev ? { ...prev, status: 'in_progress' } : prev);
+                        toast.success('Quest started! Submit your work below.');
+                      } catch { toast.error('Failed to start quest'); }
+                      finally { setIsStarting(false); }
+                    }}
+                  >
+                    {isStarting ? 'Starting…' : 'Start Quest'}
+                  </Button>
+                )}
                 {assignment.status === 'completed' && (
                   <div className="flex items-center gap-2 text-xs font-medium text-emerald-700">
                     <CheckCircle className="h-3.5 w-3.5" /> Completed successfully

--- a/components/my-quest-card.tsx
+++ b/components/my-quest-card.tsx
@@ -78,11 +78,11 @@ export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
       const res = await fetchWithAuth(`/api/quests/assignments/${assignment.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "in_progress" }),
+        body: JSON.stringify({ status: "started" }),
       });
       const data = await res.json();
       if (!data.success) { toast.error(data.error || "Failed to start quest"); return; }
-      setAssignment((prev: any) => ({ ...prev, status: "in_progress" }));
+      setAssignment((prev: any) => ({ ...prev, status: "started" }));
       toast.success("Quest started! Use the Submit Work button when ready.");
     } catch { toast.error("Failed to start quest"); }
     finally { setIsStarting(false); }

--- a/components/my-quest-card.tsx
+++ b/components/my-quest-card.tsx
@@ -6,14 +6,16 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { QuestSubmissionDialog } from "@/components/quest-submission-dialog";
 import { DailyStandupModal } from "./daily-standup-modal";
-import { Clock, CheckCircle2, AlertTriangle, ListTodo, CalendarDays } from "lucide-react";
+import { Clock, CheckCircle2, AlertTriangle, ListTodo, CalendarDays, Play } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
   const [assignment, setAssignment] = useState(initialAssignment);
   const [isStandupOpen, setIsStandupOpen] = useState(false);
   const [togglingTask, setTogglingTask] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
 
   const quest = assignment.quest;
   const tasks = quest.tasks || [];
@@ -67,7 +69,24 @@ export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
 
   const isCompletedStatus = assignment.status === "completed";
   const isUnderReviewStatus = assignment.status === "submitted" || assignment.status === "pending_admin_review";
-  const isActive = ["assigned", "started", "in_progress", "needs_rework"].includes(assignment.status);
+  const isActive = ["started", "in_progress", "needs_rework"].includes(assignment.status);
+  const isJustAssigned = assignment.status === "assigned";
+
+  const handleStartQuest = async () => {
+    setIsStarting(true);
+    try {
+      const res = await fetchWithAuth(`/api/quests/assignments/${assignment.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "in_progress" }),
+      });
+      const data = await res.json();
+      if (!data.success) { toast.error(data.error || "Failed to start quest"); return; }
+      setAssignment((prev: any) => ({ ...prev, status: "in_progress" }));
+      toast.success("Quest started! Use the Submit Work button when ready.");
+    } catch { toast.error("Failed to start quest"); }
+    finally { setIsStarting(false); }
+  };
 
   return (
     <Card className="flex flex-col md:flex-row overflow-hidden border-slate-200 bg-white shadow-sm text-slate-900 transition-all hover:shadow-md hover:border-slate-300">
@@ -160,7 +179,7 @@ export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
                     >
                       <input
                         type="checkbox"
-                        disabled={!isActive || togglingTask === task}
+                        disabled={(!isActive && !isJustAssigned) || togglingTask === task}
                         checked={isChecked}
                         onChange={() => handleToggleTask(task)}
                         className="h-4 w-4 rounded border-slate-300 text-orange-500 bg-white focus:ring-orange-500 focus:ring-offset-white cursor-pointer disabled:opacity-50"
@@ -194,16 +213,27 @@ export function MyQuestCard({ initialAssignment }: { initialAssignment: any }) {
               <Link href={`/dashboard/quests/${quest.id}`}>View Details</Link>
             </Button>
             
+            {isJustAssigned && (
+              <Button
+                onClick={handleStartQuest}
+                disabled={isStarting}
+                className="bg-emerald-600 hover:bg-emerald-700 text-white shadow-sm flex items-center gap-1.5"
+              >
+                <Play className="h-4 w-4" />
+                {isStarting ? "Starting…" : "Start Quest"}
+              </Button>
+            )}
+
             {isActive && (
               <>
-                <Button 
+                <Button
                   onClick={() => setIsStandupOpen(true)}
                   className="bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 shadow-sm flex items-center gap-1.5"
                 >
                   <CalendarDays className="h-4 w-4 text-slate-500" />
                   Daily Standup
                 </Button>
-                
+
                 <QuestSubmissionDialog
                   questTitle={quest.title}
                   assignmentId={assignment.id}


### PR DESCRIPTION
## Summary

- Adds **Start Quest** button for `assigned` status quests — calls `PATCH /api/quests/assignments/:id` with `{ status: 'started' }` (corrected from `in_progress` which caused a 422)
- Removes `assigned` from `canSubmit` — submission form only shows after quest is started
- Splits My Quests page into **Active** (6 statuses, parallel query) and **History** (completed/cancelled, last 10) sections

## Root Cause Fixed

The `Start Quest` button was sending `{ status: 'in_progress' }` but the API's transition table only allows `assigned → started`. Every click returned a 422 error, leaving students permanently stuck at `assigned` with no path forward.

Closes #315

## Test Plan
- [ ] Claim a quest → see "Start Quest" button
- [ ] Click Start Quest → status changes to `started`, submission form appears
- [ ] Fill and submit form → status moves to `pending_admin_review`
- [ ] My Quests page shows Active/History split correctly