### PR TITLE
fix: remove dead hasBootcampLinksTable() schema check (#339)

### DIFF
--- a/app/api/admin/api-budgets/route.ts
+++ b/app/api/admin/api-budgets/route.ts
@@ -31,34 +31,17 @@ function decimalToNumber(value: Prisma.Decimal | number | string) {
   return value instanceof Prisma.Decimal ? value.toNumber() : Number(value);
 }
 
-async function hasBootcampLinksTable() {
-  const [result] = await prisma.$queryRaw<Array<{ exists: boolean }>>`
-    SELECT EXISTS (
-      SELECT 1
-      FROM information_schema.tables
-      WHERE table_schema = 'public'
-        AND table_name = 'bootcamp_links'
-    ) AS "exists"
-  `;
-
-  return Boolean(result?.exists);
-}
-
 async function getTrackMapForUsers(userIds: string[]) {
   if (userIds.length === 0) {
     return new Map<string, UserTrack>();
   }
 
-  if (!(await hasBootcampLinksTable())) {
-    return new Map<string, UserTrack>();
-  }
+  const bootcampLinks = await prisma.bootcampLink.findMany({
+    where: { userId: { in: userIds } },
+    select: { userId: true },
+  });
 
-  const bootcampLinks = await prisma.$queryRaw<Array<{ user_id: string }>>`
-    SELECT user_id FROM bootcamp_links
-    WHERE user_id = ANY(${userIds}::uuid[])
-  `;
-
-  const bootcampUserIds = new Set(bootcampLinks.map((link) => link.user_id));
+  const bootcampUserIds = new Set(bootcampLinks.map((link) => link.userId));
 
   return new Map<string, UserTrack>(
     userIds.map((userId) => [


### PR DESCRIPTION
## Summary

Fixes #339

### Problem
The function `hasBootcampLinksTable()` was executing a raw `SELECT EXISTS` query against `information_schema.tables` on **every** admin request to `/api/admin/api-budgets`. This was unnecessary dead code because the `BootcampLink` model always exists in production.

### Changes Made
- Removed the `hasBootcampLinksTable()` function entirely.
- Removed the defensive existence check inside `getTrackMapForUsers`.
- Replaced the raw `$queryRaw` query with a clean Prisma query:
  ```ts
  const bootcampLinks = await prisma.bootcampLink.findMany({
    where: { userId: { in: userIds } },
    select: { userId: true },
  });