### PR TITLE
fix: disable Claim Quest button on rank-locked quests (#340)

### DIFF
--- a/app/api/quests/[id]/route.ts
+++ b/app/api/quests/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { UserRank } from '@prisma/client';
 import { prisma } from '@/lib/db';
 import { getAuthUser } from '@/lib/api-auth';
+import { getQuestAccessStatus } from '@/lib/quest-access';
 
 export async function GET(
   req: NextRequest,
@@ -140,10 +142,20 @@ export async function GET(
           }
         : null;
 
+    // Rank-based access gating (mirrors the quest list endpoint) so the
+    // detail page can disable the claim button for rank-locked quests.
+    const accessStatus =
+      user?.role === 'adventurer'
+        ? getQuestAccessStatus(user.rank as UserRank, quest.requiredRank)
+        : { canAccess: true, isVisible: true, lockedUntil: undefined };
+
     const normalizedQuest = {
       ...quest,
       company: sanitizedCompany,
       assignments,
+      canAccess: accessStatus.canAccess,
+      isVisible: accessStatus.isVisible,
+      lockedUntil: accessStatus.lockedUntil,
     };
 
     return NextResponse.json({

--- a/app/dashboard/quests/[id]/page.tsx
+++ b/app/dashboard/quests/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { AlertCircle, CheckCircle, CalendarDays } from 'lucide-react';
 import { toast } from 'sonner';
 import Link from 'next/link';
@@ -37,6 +38,8 @@ interface Quest {
   monetaryReward?: number;
   requiredSkills: string[];
   requiredRank?: string;
+  canAccess?: boolean;
+  lockedUntil?: string;
   maxParticipants?: number;
   questCategory: string;
   companyId: string;
@@ -251,7 +254,9 @@ export default function QuestDetailPage() {
   }, [getShareUrl, trackShare]);
 
   const isAssigned = !!assignment;
-  const canAssign = quest?.status === 'available' && !isAssigned;
+  const isRankLocked = quest?.canAccess === false;
+  const rankLockLabel = quest?.lockedUntil ?? quest?.requiredRank;
+  const canAssign = quest?.status === 'available' && !isAssigned && !isRankLocked;
   const canSubmit = !!assignment && ['started', 'in_progress', 'needs_rework'].includes(assignment.status);
   const canStart = !!assignment && assignment.status === 'assigned';
   const showPartyPanel = (quest?.maxParticipants ?? 1) > 1;
@@ -582,6 +587,33 @@ export default function QuestDetailPage() {
                 >
                   {isApplying ? 'Claiming...' : 'Claim Quest'}
                 </Button>
+              </div>
+            ) : isRankLocked ? (
+              <div className="rounded-2xl border border-border/70 bg-white/95 shadow-[0_4px_16px_rgba(15,23,42,0.04)] p-5 space-y-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-slate-900">Rank Locked</h2>
+                  <p className="mt-0.5 text-xs text-slate-500">
+                    {rankLockLabel
+                      ? `This quest requires ${rankToTier[rankLockLabel] ?? `${rankLockLabel}-Rank`} or above.`
+                      : 'You don’t meet the rank requirement for this quest yet.'}
+                  </p>
+                </div>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="block w-full">
+                        <Button className="w-full" disabled>
+                          🔒 Claim Quest
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {rankLockLabel
+                        ? `Reach Rank ${rankLockLabel} to unlock this quest.`
+                        : 'Increase your rank to unlock this quest.'}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
             ) : (
               <div className="rounded-2xl border border-border/70 bg-white/95 shadow-[0_4px_16px_rgba(15,23,42,0.04)] p-5">


### PR DESCRIPTION
## Summary

Fixes #340

The quest detail page computed `canAssign` from quest status alone, so a low-rank user opening a higher-rank quest via a shared/direct URL saw an active **Claim Quest** button. Clicking it produced a confusing 403 toast with no explanation. The quest board card already handled this; the detail page did not.

### Changes
- **`app/api/quests/[id]/route.ts`** — include `canAccess` / `isVisible` / `lockedUntil` in the single-quest response for adventurers, via the shared `getQuestAccessStatus()` util (mirrors the quest list endpoint).
- **`app/dashboard/quests/[id]/page.tsx`** — derive `isRankLocked` from `quest.canAccess`, exclude it from `canAssign`, and render a **disabled** Claim Quest button with a tooltip: *"Reach Rank X to unlock this quest."*

### Verification
- `npm run type-check` passes (exit 0).
- `__tests__/lib/quest-access.test.ts` → 22/22 passing.


