### PR TITLE
fix: filter out non-visible quests from quest board (#333)

### DIFF
--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -129,7 +129,11 @@ export async function getQuests(searchParams: URLSearchParams, user: SessionUser
     };
   });
 
-  return { data: enrichedQuests as Quest[], error: null, status: 200 };
+  // Drop quests the user shouldn't even discover (2+ ranks above their own).
+  // Filtered server-side so hidden quests never reach the client.
+  const visibleQuests = enrichedQuests.filter((quest) => quest.isVisible !== false);
+
+  return { data: visibleQuests as Quest[], error: null, status: 200 };
 }
 
 export async function createQuest(body: CreateQuestBody, user: SessionUser): Promise<ServiceResult<Quest>> {


### PR DESCRIPTION
## Summary

Fixes #333

`getQuests()` enriched each quest with an `isVisible` flag (false for quests 2+ ranks above the user) but never filtered on it, so hidden quests were still returned and rendered on the board — cluttering the view and breaking rank-progression discovery.

### Changes
- **`lib/services/quest-service.ts`** — filter the enriched list server-side (`isVisible !== false`) so hidden quests never reach the client. Chosen over a client-side filter so the data is not shipped to the browser at all.

### Verification
- `npm run type-check` passes (exit 0).
- `__tests__/lib/quest-access.test.ts` → 22/22 passing.


