### PR TITLE
fix: await queue refresh before re-enabling QA approve/reject (#337)

### DIFF
--- a/app/admin/qa-queue/page.tsx
+++ b/app/admin/qa-queue/page.tsx
@@ -102,27 +102,35 @@ export default function QAQueuePage() {
 
   const handleApprove = async (item: QueueItem) => {
     setSubmitting(true);
-    await fetchWithAuth(`/api/admin/qa-queue/${item.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'approve', criteriaResults: buildCriteriaResults(item) }),
-    });
-    setSubmitting(false);
-    fetchQueue();
+    try {
+      await fetchWithAuth(`/api/admin/qa-queue/${item.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'approve', criteriaResults: buildCriteriaResults(item) }),
+      });
+      // Await the refresh so buttons stay disabled until the stale item is gone.
+      await fetchQueue();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleReject = async () => {
     if (!rejectTarget || !rejectNotes.trim()) return;
     setSubmitting(true);
-    await fetchWithAuth(`/api/admin/qa-queue/${rejectTarget.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim(), criteriaResults: buildCriteriaResults(rejectTarget) }),
-    });
-    setSubmitting(false);
-    setRejectTarget(null);
-    setRejectNotes('');
-    fetchQueue();
+    try {
+      await fetchWithAuth(`/api/admin/qa-queue/${rejectTarget.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim(), criteriaResults: buildCriteriaResults(rejectTarget) }),
+      });
+      setRejectTarget(null);
+      setRejectNotes('');
+      // Await the refresh so buttons stay disabled until the stale item is gone.
+      await fetchQueue();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   if (status === 'loading' || loading) {


### PR DESCRIPTION
## Summary

Fixes #337

### Problem
In the Admin QA Queue, after approving or rejecting a submission, the `fetchQueue()` function was being called **without `await`**. Because of this, `setSubmitting(false)` was executed immediately, which re-enabled the Approve/Reject buttons before the queue was refreshed. This allowed a fast admin to double-approve or double-reject the same submission.

### Changes Made
- Modified `handleApprove()` and `handleReject()` functions in `app/admin/qa-queue/page.tsx`.
- Added `await fetchQueue()` after the PATCH request so that buttons remain disabled until the refreshed queue is loaded.
- Wrapped the logic in a `try/finally` block to ensure `setSubmitting(false)` is always called (even if the request fails).

### Benefits
- Prevents accidental double-approval or double-rejection.
- Improves data integrity in the QA review process.
- Buttons no longer get stuck in a disabled state if a request throws an error.

### Verification
- `npm run type-check` passes successfully.
- No existing tests for QA queue (verified).
- Changes are minimal and follow existing code patterns.