### PR TITLE
fix: Invalidate previous quest submissions on new submission (#344)

### DIFF
--- a/app/api/quests/submissions/route.ts
+++ b/app/api/quests/submissions/route.ts
@@ -1,7 +1,7 @@
 // app/api/quests/submissions/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { AssignmentStatus, Prisma } from '@prisma/client';
+import { AssignmentStatus, Prisma, SubmissionStatus } from '@prisma/client';
 import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 import { getAuthUser } from '@/lib/api-auth';
 import { logActivity } from '@/lib/activity-logger';
@@ -141,6 +141,13 @@ export async function POST(request: NextRequest) {
           },
         });
 
+        // Invalidate all previous submissions for this assignment so QA/client always sees the latest.
+        // This prevents stale work from being reviewable (especially important for needs_rework resubmissions).
+        await tx.questSubmission.updateMany({
+          where: { assignmentId, id: { not: submission.id } },
+          data: { status: SubmissionStatus.superseded },
+        });
+
         await tx.questAssignment.update({
           where: { id: assignmentId },
           data: { status: postSubmitStatus },
@@ -185,6 +192,10 @@ export async function PUT(request: NextRequest) {
     });
     if (!submission) {
       return NextResponse.json({ error: 'Submission not found', success: false }, { status: 404 });
+    }
+
+    if (submission.status === SubmissionStatus.superseded) {
+      return NextResponse.json({ error: 'Cannot review a superseded submission', success: false }, { status: 400 });
     }
 
     const assignmentData = await prisma.questAssignment.findUnique({

--- a/lib/qa-utils.ts
+++ b/lib/qa-utils.ts
@@ -8,7 +8,7 @@ export async function fetchSubmissionsForReview(
   status: string | null = null
 ) {
   const where: Prisma.QuestSubmissionWhereInput = {
-    status: { notIn: ['approved', 'rejected'] },
+    status: { notIn: ['approved', 'rejected', 'superseded'] },
   };
 
   if (status) {

--- a/lib/status-utils.ts
+++ b/lib/status-utils.ts
@@ -17,6 +17,7 @@ const STATUS_COLOR_MAP: Record<string, string> = {
   review: 'bg-amber-100 text-amber-700 border-amber-300',
   submitted: 'bg-yellow-100 text-yellow-700 border-yellow-300',
   under_review: 'bg-sky-100 text-sky-700 border-sky-300',
+  superseded: 'bg-slate-100 text-slate-700 border-slate-300',
 };
 
 export function getStatusColor(status: string): string {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,7 @@ enum SubmissionStatus {
   approved
   needs_rework
   rejected
+  superseded
 }
 
 enum RevisionStatus {


### PR DESCRIPTION
## Summary
Fixes #344. When a new `QuestSubmission` is created, all previous submissions for the same assignment are now marked `superseded`. This prevents QA (and company reviewers) from accidentally seeing or acting on stale work, especially on resubmissions after `needs_rework`.

## Problem
- New submissions did not invalidate prior ones.
- `fetchSubmissionsForReview` and general submission queries could return multiple non-final records per assignment.
- Risk of approving the wrong/old revision.

## Solution
- Added `superseded` to the `SubmissionStatus` enum.
- In `POST /api/quests/submissions`, inside the existing transaction, atomically run `updateMany` to set `status: 'superseded'` on every other submission for the `assignmentId`.
- Updated the "active for review" filter in `lib/qa-utils.ts`.
- Added a defensive guard in the submission review `PUT` handler.
- Added UI color mapping for the new status.

Review surfaces that already did `orderBy: { submittedAt: 'desc' }, take: 1` (QA queue list/detail, company quest assignment loading) are now further hardened at the persistence layer.

Superseded records remain in the database and are still loadable for history/audit (e.g. the per-assignment QA detail page intentionally loads the full submissions list).

## Changes
- `prisma/schema.prisma`
- `app/api/quests/submissions/route.ts`
- `lib/qa-utils.ts`
- `lib/status-utils.ts`

## Verification
- `npm run type-check` passes cleanly.

## Notes for reviewers / deploy
- A database migration is required after merge to add the enum value to Postgres (`ALTER TYPE "SubmissionStatus" ADD VALUE 'superseded';` or `prisma migrate`).
- No other query sites needed changes because the primary consumer paths already prefer latest-per-assignment, and the creation site is now the source of truth.