### PR TITLE
fix: persist password reset token before sending email (#341)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -27,8 +27,15 @@ export async function POST(request: NextRequest) {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
     const resetLink = `${appUrl}/reset-password?token=${token}`;
 
-    // Send email FIRST — only save the token to DB if email succeeds.
-    // This prevents dangling tokens when the mail service is down.
+    // Persist the token to the DB *first*, then send the email.
+    // If the email send fails (Resend transient error, config issue, etc.), the token already exists.
+    // The user can re-request a reset; deleteMany + create will replace it with a fresh token.
+    // This prevents the bad case: email delivered with a link that has no matching record in the database.
+    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
+    await prisma.passwordResetToken.create({
+      data: { userId: user.id, token: tokenHash, expiresAt },
+    });
+
     await sendEmail({
       to: normalizedEmail,
       subject: 'Reset your password — Guild',
@@ -43,12 +50,6 @@ export async function POST(request: NextRequest) {
           <p style="color:#94a3b8;font-size:11px;word-break:break-all">Or copy this link: ${resetLink}</p>
         </div>
       `,
-    });
-
-    // Email sent — now persist the token
-    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
-    await prisma.passwordResetToken.create({
-      data: { userId: user.id, token: tokenHash, expiresAt },
     });
 
     return NextResponse.json({ message: 'If an account exists, a reset link has been sent.' });


### PR DESCRIPTION
## Summary
Fixes #341 (MEDIUM). Reorders the forgot-password flow so the `PasswordResetToken` is persisted to the database **before** the reset email is sent.

## Problem
In `app/api/auth/forgot-password/route.ts`, the code sent the email first (with a "only save to DB if email succeeds" comment) then wrote the token.

If the email succeeded but the subsequent DB write failed (or any error occurred between them), the user received a reset link containing a token that had no matching record in the database. The link would permanently fail, forcing another request with no good recovery path.

## Solution
- Move the `deleteMany` + `create` (the existing pattern that ensures only one active reset token per user) to happen **before** `sendEmail`.
- The email is now sent only after the token is safely stored.
- If email delivery fails after the write, the user can simply request another reset. The next call will replace the token via the existing `deleteMany` + `create`.
- Updated inline comments to document the rationale and the avoided failure mode.

The security-preserving "always return the same generic success message" behavior and early return for non-existent users are unchanged.

## Changes
- `app/api/auth/forgot-password/route.ts` (minimal, targeted reorder + comment update)

## Verification
- `npm run type-check` passes.
- No schema changes, no new dependencies, follows existing patterns in the file and the `reset-password` route.

## Notes
- The `reset-password` validation logic (`usedAt`, `expiresAt`, hash comparison, transaction to mark used + update password) is unaffected and continues to work correctly.
- This is the correct "write first, notify second" pattern for one-time tokens.