### PR TITLE
fix: award XP and create QuestCompletion on QA admin approval (#317)

### DIFF
--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db';
 import { requireAuth } from '@/lib/api-auth';
 import { Prisma } from '@prisma/client';
 import crypto from 'crypto';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 export async function GET(
   request: NextRequest,
@@ -100,7 +101,8 @@ export async function PATCH(
   const assignment = await prisma.questAssignment.findUnique({
     where: { id: assignmentId },
     include: {
-      quest: { select: { id: true } },
+      quest: { select: { id: true, xpReward: true, skillPointsReward: true, title: true, source: true } },
+      user: { select: { id: true } },
       submissions: { orderBy: { submittedAt: 'desc' }, take: 1 },
     },
   });
@@ -121,19 +123,84 @@ export async function PATCH(
     criteriaResults != null ? (criteriaResults as Prisma.InputJsonValue) : undefined;
 
   if (action === 'approve') {
-    await prisma.$transaction([
-      prisma.questAssignment.update({
+    const questRewards = await prisma.$transaction(async (tx) => {
+      await tx.questAssignment.update({
         where: { id: assignmentId },
-        data: { status: 'review' },
-      }),
-      ...(latestSubmission && criteriaJson !== undefined
-        ? [prisma.questSubmission.update({
-            where: { id: latestSubmission.id },
-            data: { criteriaResults: criteriaJson, reviewerId: adminId, reviewedAt: new Date() },
-          })]
-        : []),
-    ]);
-    return NextResponse.json({ message: 'Submission approved — forwarded to client review', success: true });
+        data: { status: 'completed', completedAt: new Date() },
+      });
+
+      const submissionUpdateData: Record<string, unknown> = {
+        reviewerId: adminId,
+        reviewedAt: new Date(),
+      };
+      if (criteriaJson !== undefined) {
+        submissionUpdateData.criteriaResults = criteriaJson;
+      }
+      if (latestSubmission) {
+        await tx.questSubmission.update({
+          where: { id: latestSubmission.id },
+          data: submissionUpdateData,
+        });
+      }
+
+      const quest = await tx.quest.findUnique({
+        where: { id: assignment.quest.id },
+        select: { xpReward: true, skillPointsReward: true, title: true, source: true },
+      });
+      if (!quest) throw new Error('Quest not found');
+
+      await tx.questCompletion.upsert({
+        where: {
+          questId_userId: {
+            questId: assignment.quest.id,
+            userId: assignment.user.id,
+          },
+        },
+        create: {
+          questId: assignment.quest.id,
+          userId: assignment.user.id,
+          xpEarned: quest.xpReward,
+          skillPointsEarned: quest.skillPointsReward,
+        },
+        update: {
+          xpEarned: quest.xpReward,
+          skillPointsEarned: quest.skillPointsReward,
+        },
+      });
+
+      await syncQuestLifecycleStatus(tx, assignment.quest.id);
+
+      return quest;
+    });
+
+    const { updateUserXpAndSkills } = await import('@/lib/xp-utils');
+    await updateUserXpAndSkills(
+      assignment.user.id,
+      questRewards.xpReward,
+      questRewards.skillPointsReward,
+      assignment.quest.id,
+    );
+
+    // Bootcamp tutorial tracking
+    if (questRewards.source === 'TUTORIAL') {
+      const bootcampLink = await prisma.bootcampLink.findUnique({
+        where: { userId: assignment.user.id },
+        select: { tutorialQuest1Complete: true, tutorialQuest2Complete: true },
+      });
+      if (bootcampLink) {
+        const updateData: Record<string, boolean> = {};
+        if (questRewards.title.startsWith('Tutorial: First Blood')) updateData.tutorialQuest1Complete = true;
+        if (questRewards.title.startsWith('Tutorial: Party Up')) updateData.tutorialQuest2Complete = true;
+        const tq1 = updateData.tutorialQuest1Complete ?? bootcampLink.tutorialQuest1Complete;
+        const tq2 = updateData.tutorialQuest2Complete ?? bootcampLink.tutorialQuest2Complete;
+        if (tq1 && tq2) updateData.eligibleForRealQuests = true;
+        if (Object.keys(updateData).length > 0) {
+          await prisma.bootcampLink.update({ where: { userId: assignment.user.id }, data: updateData });
+        }
+      }
+    }
+
+    return NextResponse.json({ message: 'Quest completed — XP awarded', success: true });
   }
 
   // reject — append QA note to submission reviewNotes (stored as JSON string) + record criteria


### PR DESCRIPTION
## Problem

When an admin approved a submission via `PATCH /api/admin/qa-queue/[assignmentId]`, the assignment moved to `review` status and was "forwarded to client review." This was a dead end for the core quest loop:

- No `QuestCompletion` record was created
- No XP was awarded
- `AdventurerProfile.totalQuestsCompleted` was never incremented
- Rank-ups never triggered for QA-approved quests

Although a company-side final approval endpoint existed (`PUT /api/quests/submissions`), the company had no obligation or notification to act. For BOOTCAMP/intern quests without an active company, the assignment remained stuck in `review` forever.

## Root Cause

`app/api/admin/qa-queue/[assignmentId]/route.ts:125-137` - the approve block set `status: 'review'` and stopped. It never called `updateUserXpAndSkills()` or created a `QuestCompletion` record.

## Fix

Modified the QA admin approval handler to directly complete the quest and award XP:

**Before:** assignment status -> `review`, no QuestCompletion, no XP
**After:** assignment status -> `completed` + `completedAt`, QuestCompletion upserted with xpEarned, `updateUserXpAndSkills()` called, lifecycle synced, tutorial tracking handled

### What this changes

- QA admin approval is now the terminal step - XP is awarded immediately on approval
- The `review` intermediary status is no longer used in this path
- The company "Approve & Award XP" button still works for OPEN track quests that bypass QA

### File changes

| File | Change |
|------|--------|
| `app/api/admin/qa-queue/[assignmentId]/route.ts` | Rewrote approve block: transaction with assignment->completed, QuestCompletion.upsert, lifecycle sync. Post-tx: updateUserXpAndSkills(), bootcamp tutorial tracking. Added syncQuestLifecycleStatus import. Widened assignment query to include userId and quest reward fields. |

## Audit / Verification

- `updateUserXpAndSkills()` handles: XP accrual, level calc, rank promotion, skill point increments, totalQuestsCompleted++, questCompletionRate recalc, guild score, streak, activity logging, achievements, rank-up notifications
- `QuestCompletion.upsert` uses composite unique key (questId, userId) - safe to call multiple times
- `syncQuestLifecycleStatus()` auto-derives quest status from all assignment statuses
- Bootcamp tutorial tracking matches same logic in PUT /api/quests/submissions

Closes #317