### PR TITLE
fix: calculate 'Total Earned' from actual Transaction records instead of gross quest reward (#334)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -113,8 +113,19 @@ export default async function DashboardPage() {
 
   const completedCount = completedAssignments.length;
 
-  const totalEarned = completedAssignments.reduce(
-    (sum, a) => sum + Number(a.quest.monetaryReward ?? 0),
+  // Calculate Total Earned from actual Transaction records (net after 15% platform fee + daily standup penalties)
+  // instead of gross quest.monetaryReward. This ensures the displayed amount matches what the adventurer actually earns/receives.
+  const transactions = await withDbRetry(() =>
+    prisma.transaction.findMany({
+      where: {
+        toUserId: userId,
+        status: { in: ['pending', 'completed'] }, // include booked (pending payout) + completed
+      },
+      select: { amount: true },
+    })
+  );
+  const totalEarned = transactions.reduce(
+    (sum, t) => sum + Number(t.amount ?? 0),
     0
   );
 


### PR DESCRIPTION
## Summary
Fixes #334 (E-rank). The adventurer dashboard was calculating "Total Earned" by summing `quest.monetaryReward` from `completedAssignments`. This value represents the **gross** reward posted on the quest.

However, the actual amount a user receives is lower due to:
- Daily standup penalties (up to 100%, calculated at approval time)
- 15% platform fee (recorded in the `Transaction` as `amount = final * 0.85`)

As a result, users were seeing an inflated number that did not match their actual earnings or bank payouts (trust and tax reporting issue).

## Problem
- `app/dashboard/page.tsx` was directly summing `quest.monetaryReward`.
- This ignored real deductions (penalties + platform fee).
- The displayed "Total Earned" was misleading for users.

## Solution
- Changed the calculation to sum actual `Transaction.amount` for the user (`toUserId`), including both `pending` and `completed` transactions.
- This uses the real net amount (after all deductions) that is already recorded in the system at the time of approval.
- Kept the existing `completedAssignments` loading for count and "Earnings History" list (no other behavior change).

The "Total Earned" stat now correctly reflects what the user has actually earned/booked.

## Changes
- `app/dashboard/page.tsx` (updated the `totalEarned` calculation logic)

## Verification
- `npm run type-check` passes cleanly.
- Minimal and focused change.
- Follows existing architecture (using `Transaction` as the source of truth for actual payouts).

## Notes
- Other parts of the codebase that intentionally use gross `monetaryReward` (such as company spending views) were left unchanged, as they are out of scope for this fix.