### PR TITLE
fix: use fresh DB rank (not stale JWT) for quest access/gating after rank-up (#335)

### DIFF
--- a/app/api/errors/log/route.ts
+++ b/app/api/errors/log/route.ts
@@ -1,11 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { env } from '@/lib/env';
+import { rateLimitMiddleware } from '@/lib/rate-limit';
 
 /**
  * API endpoint for logging client-side errors
  * POST /api/errors/log
+ *
+ * Security:
+ * - Requires Authorization: Bearer <ERROR_LOG_API_KEY>
+ * - Field length caps to prevent DB bloat / injection
+ * - Severity whitelist
+ * - IP-based rate limiting (100 req / hour)
  */
 export async function POST(request: NextRequest) {
+  // Rate limiting: 100 requests per hour per IP (stricter than general API)
+  const rateLimitResponse = rateLimitMiddleware(request, {
+    windowMs: 60 * 60 * 1000,
+    maxRequests: 100,
+  });
+  if (rateLimitResponse) return rateLimitResponse;
+
+  // Authentication: static API key (separate from other secrets, set per-deployment)
+  const authHeader = request.headers.get('authorization') || '';
+  const providedKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+
+  if (process.env.NODE_ENV === 'production') {
+    if (!env.ERROR_LOG_API_KEY || providedKey !== env.ERROR_LOG_API_KEY) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+  }
+
   try {
     const errorLog = await request.json();
 
@@ -17,29 +45,41 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // In production, you would:
-    // 1. Store in a database
-    // 2. Send to error tracking service (Sentry, LogRocket, etc.)
-    // 3. Send alerts for critical errors
-    // 4. Aggregate for analytics
+    // Cap lengths to prevent DB flooding and excessive storage
+    const cappedMessage = String(errorLog.message).slice(0, 2000);
+    const cappedUrl = errorLog.url ? String(errorLog.url).slice(0, 500) : undefined;
+    const cappedUserAgent = errorLog.userAgent ? String(errorLog.userAgent).slice(0, 500) : undefined;
 
-    // For now, log to server console
+    // Whitelist severity
+    const validSeverities = ['error', 'warning', 'info'];
+    const severity = validSeverities.includes(errorLog.severity) ? errorLog.severity : 'error';
+
+    // Parse timestamp safely
+    const timestamp = new Date(errorLog.timestamp);
+    if (isNaN(timestamp.getTime())) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid timestamp' },
+        { status: 400 }
+      );
+    }
+
+    // Log to server console (with caps applied)
     console.error('Client Error Logged:', {
-      severity: errorLog.severity,
-      message: errorLog.message,
-      url: errorLog.url,
+      severity,
+      message: cappedMessage,
+      url: cappedUrl,
       timestamp: errorLog.timestamp,
-      userAgent: errorLog.userAgent,
+      userAgent: cappedUserAgent,
     });
 
-    // Store in database
+    // Store in database (capped + validated)
     await prisma.errorLog.create({
       data: {
-        message: errorLog.message,
-        severity: errorLog.severity || 'error',
-        url: errorLog.url,
-        userAgent: errorLog.userAgent,
-        timestamp: new Date(errorLog.timestamp),
+        message: cappedMessage,
+        severity,
+        url: cappedUrl,
+        userAgent: cappedUserAgent,
+        timestamp,
       },
     });
 
@@ -49,7 +89,7 @@ export async function POST(request: NextRequest) {
     // }
 
     // TODO: Send alerts for critical errors
-    // if (errorLog.severity === 'critical') {
+    // if (severity === 'critical') {
     //   await sendAlertToAdmin(errorLog);
     // }
 

--- a/app/api/quests/[id]/route.ts
+++ b/app/api/quests/[id]/route.ts
@@ -142,11 +142,19 @@ export async function GET(
           }
         : null;
 
-    // Rank-based access gating (mirrors the quest list endpoint) so the
-    // detail page can disable the claim button for rank-locked quests.
+    // Rank-based access gating using fresh DB rank (not stale JWT) so the
+    // detail page can correctly show/disable the claim button after a rank-up.
+    let effectiveRank = user?.rank as UserRank | undefined;
+    if (user?.role === 'adventurer' && user.id) {
+      const dbUser = await prisma.user.findUnique({
+        where: { id: user.id },
+        select: { rank: true },
+      });
+      if (dbUser?.rank) effectiveRank = dbUser.rank;
+    }
     const accessStatus =
-      user?.role === 'adventurer'
-        ? getQuestAccessStatus(user.rank as UserRank, quest.requiredRank)
+      effectiveRank
+        ? getQuestAccessStatus(effectiveRank, quest.requiredRank)
         : { canAccess: true, isVisible: true, lockedUntil: undefined };
 
     const normalizedQuest = {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -43,6 +43,9 @@ const envSchema = z.object({
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
 
+  // Optional: Error logging endpoint API key (for /api/errors/log - static key for client error reporting)
+  ERROR_LOG_API_KEY: z.string().min(16).optional(),
+
   // Node Environment
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 });

--- a/lib/services/assignment-service.ts
+++ b/lib/services/assignment-service.ts
@@ -28,14 +28,25 @@ export async function applyToQuest(questId: string, user: SessionUser, tx: Prism
       return { data: null, error: 'Quest not available', status: 400 };
     }
 
-    // Check rank gating: user must have minimum rank to accept quest
-    // Admins bypass rank checks, but adventurers must meet requirement
+    // Check rank gating using *current* DB rank (not stale JWT).
+    // This fixes the bug where after a rank-up on quest approval, the JWT is stale
+    // until the user manually refreshes their session.
     if (user.role === 'adventurer') {
-      const canAccept = canUserAcceptQuest(user.rank as UserRank, quest.requiredRank);
+      let currentRank = user.rank as UserRank;
+      if (user.id) {
+        const dbUser = await tx.user.findUnique({
+          where: { id: user.id },
+          select: { rank: true },
+        });
+        if (dbUser?.rank) {
+          currentRank = dbUser.rank;
+        }
+      }
+      const canAccept = canUserAcceptQuest(currentRank, quest.requiredRank);
       if (!canAccept) {
         return {
           data: null,
-          error: `You must reach Rank ${quest.requiredRank} to accept this quest. Current rank: ${user.rank}`,
+          error: `You must reach Rank ${quest.requiredRank} to accept this quest. Current rank: ${currentRank}`,
           status: 403,
         };
       }

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -110,10 +110,22 @@ export async function getQuests(searchParams: URLSearchParams, user: SessionUser
   });
 
 
-  // Add access control metadata for adventurers
+  // Add access control metadata for adventurers.
+  // Use fresh DB rank (not JWT) to avoid stale rank after quest completion / rank up.
+  let effectiveUserRank: UserRank | null = null;
+  if (user && user.role === 'adventurer' && user.id) {
+    const dbUser = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { rank: true },
+    });
+    if (dbUser?.rank) {
+      effectiveUserRank = dbUser.rank;
+    }
+  }
+
   const enrichedQuests = quests.map((quest) => {
-    if (user && user.role === 'adventurer') {
-      const accessStatus = getQuestAccessStatus(user.rank as UserRank, quest.requiredRank);
+    if (user && user.role === 'adventurer' && effectiveUserRank) {
+      const accessStatus = getQuestAccessStatus(effectiveUserRank, quest.requiredRank);
       return {
         ...quest,
         canAccess: accessStatus.canAccess,


### PR DESCRIPTION
Rebased version of #362 (manthansingh26's fix) — cherry-picked cleanly onto current main.

## Summary
Fixes #335. Rank gating was reading user rank from the JWT token, which goes stale after a rank-up. Users who just ranked up (e.g., F → E) were getting "Rank too low" errors until they logged out and back in.

## Fix
All rank-gating and quest access checks now fetch the latest rank from the database instead of trusting the JWT payload.

## Changes
- `app/api/quests/[id]/route.ts` — fresh DB rank lookup
- `app/api/errors/log/route.ts` — security hardening (auth + field caps + severity whitelist)
- `lib/env.ts` — adds ERROR_LOG_API_KEY
- `lib/services/assignment-service.ts` — DB rank for gating
- `lib/services/quest-service.ts` — DB rank for access check

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>