### PR TITLE
fix: persistent rate limiting via Upstash Redis + protect register/forgot-password (#338)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { sendEmail } from '@/lib/mail';
 import { createHash, randomBytes } from 'crypto';
+import { strictRateLimit } from '@/lib/rate-limit';
 
 export async function POST(request: NextRequest) {
+  // Defense-in-depth rate limiting for auth-sensitive endpoint
+  const rateLimitResponse = await strictRateLimit(request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
     const { email } = await request.json();
     const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs';
 import { z } from 'zod';
 import { Prisma } from '@prisma/client';
 import { generateReferralCode, REFEREE_SIGNUP_XP } from '@/lib/referral-utils';
+import { strictRateLimit } from '@/lib/rate-limit';
 
 const registerSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
@@ -16,6 +17,10 @@ const registerSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  // Defense-in-depth: rate limit even if middleware is bypassed (direct API calls, etc.)
+  const rateLimitResponse = await strictRateLimit(request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
     const body = await request.json();
 

--- a/app/api/errors/log/route.ts
+++ b/app/api/errors/log/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { env } from '@/lib/env';
-import { rateLimitMiddleware } from '@/lib/rate-limit';
+import { strictRateLimit } from '@/lib/rate-limit';
 
 /**
  * API endpoint for logging client-side errors
@@ -11,14 +11,10 @@ import { rateLimitMiddleware } from '@/lib/rate-limit';
  * - Requires Authorization: Bearer <ERROR_LOG_API_KEY>
  * - Field length caps to prevent DB bloat / injection
  * - Severity whitelist
- * - IP-based rate limiting (100 req / hour)
+ * - IP-based rate limiting (20 req / 15 min via strictRateLimit)
  */
 export async function POST(request: NextRequest) {
-  // Rate limiting: 100 requests per hour per IP (stricter than general API)
-  const rateLimitResponse = rateLimitMiddleware(request, {
-    windowMs: 60 * 60 * 1000,
-    maxRequests: 100,
-  });
+  const rateLimitResponse = await strictRateLimit(request);
   if (rateLimitResponse) return rateLimitResponse;
 
   // Authentication: static API key (separate from other secrets, set per-deployment)

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,67 +1,52 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+import { env } from './env';
 
-type RateLimitStore = Map<string, { count: number; resetAt: number }>;
+// Upstash Redis rate limiters (persistent across Vercel cold starts / serverless instances).
+// Falls back gracefully (no limiting) in development or if Upstash env vars are not configured.
+// See docs/DEPLOYMENT.md for setup.
 
-// In-memory store (use Upstash Redis in production)
-const globalStore = globalThis as unknown as {
-  rateLimitStore?: RateLimitStore;
-};
+let strictRatelimit: Ratelimit | null = null;
+let apiRatelimit: Ratelimit | null = null;
 
-const store: RateLimitStore = globalStore.rateLimitStore ?? new Map<string, { count: number; resetAt: number }>();
-if (!globalStore.rateLimitStore) {
-  globalStore.rateLimitStore = store;
+if (env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN) {
+  const redis = Redis.fromEnv();
+  strictRatelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(20, '15 m'),
+    analytics: true,
+  });
+  apiRatelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(60, '1 m'),
+    analytics: true,
+  });
 }
 
-export interface RateLimitOptions {
-  windowMs: number;
-  maxRequests: number;
-  keyGenerator?: (req: NextRequest) => string;
+function getIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  return forwardedFor?.split(',')[0]?.trim() || request.headers.get('x-real-ip') || 'unknown';
 }
 
-export function isRateLimited(
+async function checkRateLimit(
   request: NextRequest,
-  options: RateLimitOptions
-): boolean {
+  ratelimit: Ratelimit | null,
+  identifier?: string
+): Promise<NextResponse | null> {
   if (process.env.NODE_ENV === 'development') {
-    return false;
+    return null;
   }
-  const {
-    windowMs = 60 * 1000,
-    maxRequests = 60,
-    keyGenerator = (req) => {
-      const forwardedFor = req.headers.get('x-forwarded-for');
-      const ip = forwardedFor?.split(',')[0]?.trim() || req.headers.get('x-real-ip') || 'unknown';
-      return ip;
-    },
-  } = options;
-
-  const key = keyGenerator(request);
-  const now = Date.now();
-  const entry = store.get(key);
-
-  if (!entry || now > entry.resetAt) {
-    store.set(key, { count: 1, resetAt: now + windowMs });
-    return false;
+  if (!ratelimit) {
+    // No Redis configured — rate limiting disabled (common in local dev).
+    // In production you must set UPSTASH_REDIS_REST_URL + TOKEN (see DEPLOYMENT.md).
+    return null;
   }
 
-  entry.count += 1;
-  store.set(key, entry);
+  const ip = identifier || getIp(request);
+  const { success } = await ratelimit.limit(ip);
 
-  // Clean up old entries periodically
-  if (store.size > 1000) {
-    for (const [k, v] of store.entries()) {
-      if (now > v.resetAt) store.delete(k);
-    }
-  }
-
-  return entry.count > maxRequests;
-}
-
-export function rateLimitMiddleware(
-  request: NextRequest,
-  options: RateLimitOptions
-): NextResponse | null {
-  if (isRateLimited(request, options)) {
+  if (!success) {
     return NextResponse.json(
       { error: 'Too many requests. Please try again later.' },
       { status: 429 }
@@ -70,12 +55,11 @@ export function rateLimitMiddleware(
   return null;
 }
 
-// Pre-configured limiters for common use cases
-export const authRateLimit = (req: NextRequest) =>
-  rateLimitMiddleware(req, { windowMs: 15 * 60 * 1000, maxRequests: 10 });
+// Public API — now async (required for Upstash Redis calls)
+export const strictRateLimit = (req: NextRequest) => checkRateLimit(req, strictRatelimit);
+export const apiRateLimit = (req: NextRequest) => checkRateLimit(req, apiRatelimit);
 
-export const apiRateLimit = (req: NextRequest) =>
-  rateLimitMiddleware(req, { windowMs: 60 * 1000, maxRequests: 60 });
-
-export const strictRateLimit = (req: NextRequest) =>
-  rateLimitMiddleware(req, { windowMs: 15 * 60 * 1000, maxRequests: 20 });
+// Optional: for custom per-endpoint limits (e.g. very strict on register)
+export async function strictRateLimitForKey(request: NextRequest, key: string) {
+  return checkRateLimit(request, strictRatelimit, key);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,11 +40,11 @@ export async function middleware(request: NextRequest) {
 
   // Apply strict rate limiting to auth routes only
   if (isAuthRoute) {
-    const rateLimitResponse = strictRateLimit(request);
+    const rateLimitResponse = await strictRateLimit(request);
     if (rateLimitResponse) return rateLimitResponse;
   } else if (pathname.startsWith('/api/')) {
     // Apply general rate limiting to non-auth API routes
-    const rateLimitResponse = apiRateLimit(request);
+    const rateLimitResponse = await apiRateLimit(request);
     if (rateLimitResponse) return rateLimitResponse;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
         "@sentry/nextjs": "^10.51.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/og": "^0.11.1",
         "autoprefixer": "^10.4.20",
@@ -8941,6 +8943,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "2.0.1",
@@ -22823,6 +22858,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.25.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
     "@sentry/nextjs": "^10.51.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/og": "^0.11.1",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
Rebased version of #356 (manthansingh26's fix) with one additional fix.

## Summary
Fixes #338. The in-memory `Map`-based rate limiter was resetting on every Vercel cold start — effectively disabled in production.

## Changes
- `lib/rate-limit.ts` — replaced in-memory limiter with `@upstash/ratelimit` (sliding window). Graceful no-op when Redis env vars not set.
- `middleware.ts` — `await` the async rate limit checks
- `app/api/auth/register/route.ts` — added rate limiting (was unprotected)
- `app/api/auth/forgot-password/route.ts` — added rate limiting
- `app/api/errors/log/route.ts` — updated to use new async `strictRateLimit` API (the old sync `rateLimitMiddleware` was removed)

## Required Vercel env vars (add before this goes live)
```
UPSTASH_REDIS_REST_URL=...
UPSTASH_REDIS_REST_TOKEN=...
```
Without these, rate limiting is a silent no-op (same as current production behaviour). Set them in Vercel → Project Settings → Environment Variables.

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>