### PR TITLE
fix: prefer-const lint error breaking Vercel build

### DIFF
--- a/app/api/admin/qa-queue/route.ts
+++ b/app/api/admin/qa-queue/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
   });
 
   // Check for existing payments on completed assignments to prevent double-pay
-  let paymentMap: Record<string, boolean> = {};
+  const paymentMap: Record<string, boolean> = {};
   if (status === 'completed' && assignments.length > 0) {
     const existingPayments = await prisma.transaction.findMany({
       where: {


### PR DESCRIPTION
All deployments have been failing since PR #351 merged. Root cause: ESLint `prefer-const` error in `app/api/admin/qa-queue/route.ts` line 48 — `let paymentMap` is never reassigned (only mutated), so it must be `const`.

One character fix, unblocks all builds immediately.