### PR TITLE
fix: include 'pending_admin_review' and 'needs_rework' in active quests query on dashboard (#323)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -43,7 +43,7 @@ export default async function DashboardPage() {
         prisma.questAssignment.findMany({
           where: {
             userId,
-            status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'review'] },
+            status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'needs_rework', 'review'] },
           },
           include: {
             quest: {


### PR DESCRIPTION
## Summary
Fixes #323 (E-rank). The adventurer dashboard's "Active Quests" section was not showing quests with status `pending_admin_review` and `needs_rework`. These statuses are part of the normal active/bootcamp flow, so relevant quests were missing from the main dashboard.

## Problem
- The `pendingAssignments` query in `app/dashboard/page.tsx` was using an incomplete status filter.
- Statuses like `pending_admin_review` and `needs_rework` were missing from the list, even though they are correctly handled in other parts of the application (`my-quests/page.tsx`, company views, etc.).
- As a result, users could not see all their active/in-pipeline quests on the primary dashboard.

## Solution
- Updated the Prisma `where` clause in `app/dashboard/page.tsx` to include the missing statuses (`pending_admin_review` and `needs_rework`).
- This makes the dashboard consistent with other parts of the application that already use the complete `ACTIVE_STATUSES` list.

## Changes
- `app/dashboard/page.tsx` (only 1 line change)

## Verification
- `npm run type-check` passes cleanly.
- Follows the exact same pattern already used in `my-quests/page.tsx` and other status filters in the codebase.
- No behavior change for already-listed statuses; now correctly includes the previously missing ones.

## Notes
- This is a minimal and focused fix.
- The change ensures that quests in `pending_admin_review` and `needs_rework` states now properly appear in the dashboard's active quests section.