### PR TITLE
fix: await fetchQueue before re-enabling buttons in QA queue to prevent double-approve (#337)

### DIFF
--- a/app/admin/qa-queue/page.tsx
+++ b/app/admin/qa-queue/page.tsx
@@ -107,8 +107,8 @@ export default function QAQueuePage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'approve', criteriaResults: buildCriteriaResults(item) }),
     });
+    await fetchQueue();
     setSubmitting(false);
-    fetchQueue();
   };
 
   const handleReject = async () => {
@@ -119,10 +119,10 @@ export default function QAQueuePage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim(), criteriaResults: buildCriteriaResults(rejectTarget) }),
     });
+    await fetchQueue();
     setSubmitting(false);
     setRejectTarget(null);
     setRejectNotes('');
-    fetchQueue();
   };
 
   if (status === 'loading' || loading) {


### PR DESCRIPTION
## Summary
Fixes #337 (E-rank). In the Admin QA Queue, `handleApprove` and `handleReject` functions were calling `fetchQueue()` **without `await`** after the PATCH request. As a result, `setSubmitting(false)` was executed immediately, re-enabling the Approve and Reject buttons while the queue data was still stale. This allowed a fast admin to accidentally double-approve or double-reject the same submission before the list was refreshed.

## Problem
- After approving or rejecting a submission, the queue was being refetched in the background without waiting for it to complete.
- The submit state was being reset too early, causing the action buttons to become clickable again while the old data was still displayed.
- This created a race condition where the same submission could be approved or rejected multiple times.

## Solution
- Added `await` before `fetchQueue()` in both `handleApprove` and `handleReject` functions.
- Now `setSubmitting(false)` (and resetting the reject modal state) only happens **after** the queue has been successfully refreshed.
- This ensures the buttons remain disabled until the latest data is loaded.

## Changes
- `app/admin/qa-queue/page.tsx` (only 2 small lines changed)

## Verification
- `npm run type-check` passes cleanly.
- Follows the exact async pattern used elsewhere in the codebase with `fetchWithAuth`.
- Minimal and focused fix with no behavior change for normal flows.

## Notes
- This fix directly prevents the double-approve/double-reject race condition described in the issue.
- The change is small, safe, and aligns with existing code patterns.