### PR TITLE
fix: use fetchWithAuth instead of bare fetch in QuestSubmissionDialog to prevent silent failure on expired session (#325)

### DIFF
--- a/components/quest-submission-dialog.tsx
+++ b/components/quest-submission-dialog.tsx
@@ -26,6 +26,7 @@ import {
   type FieldValue,
   type FieldValues,
 } from "@/lib/quest-field-templates";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 interface QuestSubmissionDialogProps {
   questTitle: string;
@@ -100,7 +101,7 @@ export function QuestSubmissionDialog({ questTitle, assignmentId, questId }: Que
       const structuredText = submissionFields.length > 0 ? fieldValuesToText(submissionFields, values) : "";
       const submissionContent = [structuredText, notes.trim()].filter(Boolean).join("\n\n") || notes.trim();
 
-      const response = await fetch("/api/quests/submissions", {
+      const response = await fetchWithAuth("/api/quests/submissions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
Fixes #325 (E-rank). The `QuestSubmissionDialog` component was using a bare `fetch()` call for the submissions POST request. This caused submissions to silently fail (with no error handling or redirect) whenever the user's session had expired.

## Problem
- The dialog was making an authenticated API call using plain `fetch()` instead of the app's standard `fetchWithAuth` helper.
- When the session expired, the request would fail silently without proper authentication handling.
- This led to a poor user experience where submissions would appear to do nothing on session expiry.

## Solution
- Imported the existing `fetchWithAuth` helper (already used consistently across 50+ places in the codebase).
- Replaced the bare `fetch()` call with `fetchWithAuth()` for the submissions POST request.
- This ensures that session handling, authentication, and error/redirect behavior work correctly.

## Changes
- `components/quest-submission-dialog.tsx` (only 2 small changes: 1 import + 1 fetch replacement)

## Verification
- `npm run type-check` passes cleanly.
- Follows the exact same pattern used throughout the application (e.g., in dashboard, my-quests, admin flows, etc.).
- No behavior change for normal (authenticated) submissions; only fixes the silent failure case on expired sessions.

## Notes
- The context GET fetch was intentionally left unchanged as it deals with less sensitive/public-ish data and was out of scope for this minimal fix.
- This is a small, focused, and safe change that aligns with existing code patterns.