### PR TITLE
fix/review-statuses-missing-pending-admin-review-329

### DIFF
--- a/lib/quest-lifecycle.ts
+++ b/lib/quest-lifecycle.ts
@@ -1,6 +1,6 @@
 import { AssignmentStatus, Prisma, PrismaClient, QuestStatus } from '@prisma/client';
 
-const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'review'];
+const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'pending_admin_review', 'review'];
 
 // Statuses that mean a company has accepted the adventurer (slot is filled)
 const FILLED_STATUSES: AssignmentStatus[] = [


### PR DESCRIPTION
## Summary
Fixes #329. The `REVIEW_STATUSES` constant in `lib/quest-lifecycle.ts` was missing the `'pending_admin_review'` status. 

For BOOTCAMP and INTERN track quests, when a submission is made, the assignment status is correctly set to `'pending_admin_review'`. However, because this status was not included in `REVIEW_STATUSES`, the `deriveQuestStatus()` function never treated it as a review state. As a result, the parent quest remained stuck in `'in_progress'` instead of moving to `'review'`.

## Problem
- `REVIEW_STATUSES` only contained `['submitted', 'review']`.
- After a bootcamp or intern submission, the quest status did not update to `'review'`, even though the assignment was correctly in `'pending_admin_review'`.
- This caused inconsistency between assignment status and quest status, leading to misleading information for companies and QA flows.

## Solution
- Added `'pending_admin_review'` to the `REVIEW_STATUSES` array.
- This is a minimal one-line fix that aligns with the existing `FILLED_STATUSES` (which already included this status) and other status-handling logic in the codebase.

## Changes
- `lib/quest-lifecycle.ts` (only 1 line change)

## Verification
- `npm run type-check` passes cleanly.
- No behavior change for OPEN-track quests.
- Directly fixes the BOOTCAMP/INTERN submission flow and ensures correct quest status visibility.

## Notes
- This fix ensures that after a bootcamp or intern submission, the quest properly moves to `'review'` status.
- The change is minimal, follows existing patterns, and has zero risk to other flows.