### PR TITLE
fix: use fresh DB rank (not stale JWT) for quest access/gating after rank-up (#335)

### DIFF
--- a/lib/services/assignment-service.ts
+++ b/lib/services/assignment-service.ts
@@ -30,12 +30,18 @@ export async function applyToQuest(questId: string, user: SessionUser, tx: Prism
 
     // Check rank gating: user must have minimum rank to accept quest
     // Admins bypass rank checks, but adventurers must meet requirement
+    // Use fresh DB rank (not stale JWT token) to avoid gating issues after rank-up
     if (user.role === 'adventurer') {
-      const canAccept = canUserAcceptQuest(user.rank as UserRank, quest.requiredRank);
+      const fresh = await tx.user.findUnique({
+        where: { id: user.id },
+        select: { rank: true },
+      });
+      const currentRank = (fresh?.rank || user.rank) as UserRank;
+      const canAccept = canUserAcceptQuest(currentRank, quest.requiredRank);
       if (!canAccept) {
         return {
           data: null,
-          error: `You must reach Rank ${quest.requiredRank} to accept this quest. Current rank: ${user.rank}`,
+          error: `You must reach Rank ${quest.requiredRank} to accept this quest. Current rank: ${currentRank}`,
           status: 403,
         };
       }

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -111,9 +111,15 @@ export async function getQuests(searchParams: URLSearchParams, user: SessionUser
 
 
   // Add access control metadata for adventurers
-  const enrichedQuests = quests.map((quest) => {
+  // Use fresh DB rank (not stale JWT) for quest access/gating after rank-up
+  const enrichedQuests = await Promise.all(quests.map(async (quest) => {
     if (user && user.role === 'adventurer') {
-      const accessStatus = getQuestAccessStatus(user.rank as UserRank, quest.requiredRank);
+      const fresh = await prisma.user.findUnique({
+        where: { id: user.id },
+        select: { rank: true },
+      });
+      const currentRank = (fresh?.rank || user.rank) as UserRank;
+      const accessStatus = getQuestAccessStatus(currentRank, quest.requiredRank);
       return {
         ...quest,
         canAccess: accessStatus.canAccess,
@@ -127,7 +133,7 @@ export async function getQuests(searchParams: URLSearchParams, user: SessionUser
       canAccess: true,
       isVisible: true,
     };
-  });
+  }));
 
   return { data: enrichedQuests as Quest[], error: null, status: 200 };
 }


### PR DESCRIPTION
## Summary
Fixes #335 (D-rank). Rank gating and quest access checks were reading the user's rank directly from the JWT token. After a user completed a quest and their rank was updated, the JWT was not immediately refreshed. This caused users to sometimes get "Rank too low" errors or see incorrect quest visibility even after they had ranked up.

## Problem
- Functions like `canUserAcceptQuest` and `getQuestAccessStatus` were using `user.rank` directly from the JWT payload.
- After ranking up, the rank in the JWT remained stale until the user refreshed their session (usually by logging out and back in).
- This led to a confusing experience where users were blocked from claiming quests they had just become eligible for.

## Solution
- In `lib/services/assignment-service.ts` (claim/apply flow): Fetch the fresh rank from the database using `prisma.user.findUnique` before performing the rank check.
- In `lib/services/quest-service.ts` (quest listing and enrichment): Fetch the fresh rank from the database before calling `getQuestAccessStatus`.
- Updated error messages to show the accurate current rank from the database.
- No changes were made to the core logic functions — only the call sites were updated to use fresh data.

## Changes
- `lib/services/assignment-service.ts`
- `lib/services/quest-service.ts`

## Verification
- `npm run type-check` passes cleanly.
- Follows existing patterns of fetching fresh user data when needed for sensitive checks.
- Minimal and focused changes with no impact on other parts of the application.

## Notes
- This fix ensures that after a rank-up, users can immediately access and claim quests they are now eligible for.
- The change improves consistency and removes the need to re-login to see updated rank-based access.
- All changes are minimal, safe, and aligned with existing code patterns.