### PR TITLE
fix: persist password reset token before sending email (#341)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -27,8 +27,14 @@ export async function POST(request: NextRequest) {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
     const resetLink = `${appUrl}/reset-password?token=${token}`;
 
-    // Send email FIRST — only save the token to DB if email succeeds.
-    // This prevents dangling tokens when the mail service is down.
+    // Persist token FIRST, then send email.
+    // This ensures the link is valid as soon as the email is sent (no race where user clicks before DB write).
+    // If email fails, token expires in 24h and user can retry.
+    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
+    await prisma.passwordResetToken.create({
+      data: { userId: user.id, token: tokenHash, expiresAt },
+    });
+
     await sendEmail({
       to: normalizedEmail,
       subject: 'Reset your password — Guild',
@@ -43,12 +49,6 @@ export async function POST(request: NextRequest) {
           <p style="color:#94a3b8;font-size:11px;word-break:break-all">Or copy this link: ${resetLink}</p>
         </div>
       `,
-    });
-
-    // Email sent — now persist the token
-    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } });
-    await prisma.passwordResetToken.create({
-      data: { userId: user.id, token: tokenHash, expiresAt },
     });
 
     return NextResponse.json({ message: 'If an account exists, a reset link has been sent.' });


### PR DESCRIPTION
## Summary
Fixes #341 (MEDIUM). The forgot-password flow was sending the reset email **before** persisting the `PasswordResetToken` record in the database. This could cause the reset link to be delivered to the user even if the token was never successfully saved (due to a race condition or database failure after sending the email).

## Problem
- The code first sent the email and only then created the token record in the database.
- If the email was successfully sent but the database write failed (or any error occurred between these two steps), the user would receive a reset link containing a token that did not exist in the database.
- This resulted in a broken reset flow with no clear recovery path for the user.

## Solution
- Reordered the logic: First delete any existing tokens and create the new hashed token record in the database.
- Only after the token is successfully persisted, send the reset email.
- Updated the inline comments to clearly document the correct and safer order.

## Changes
- `app/api/auth/forgot-password/route.ts` (minimal reordering + comment update)

## Verification
- `npm run type-check` passes cleanly.
- Follows the existing `deleteMany + create` pattern already used in the file for managing single active reset tokens per user.
- No behavior change for normal flows; only improves reliability and prevents broken reset links.

## Notes
- This follows the correct "write first, notify second" pattern for one-time tokens.
- The `reset-password` validation logic remains unchanged and continues to work correctly.
- This is a small, focused, and safe improvement to the authentication flow.