### PR TITLE
fix: hide invisible (non-OPEN) quests from public board (#333)

### DIFF
--- a/app/quests/page.tsx
+++ b/app/quests/page.tsx
@@ -82,18 +82,6 @@ const TRACK_OPTIONS = [
     shortLabel: 'Open',
     description: 'Paid work from live company quests',
   },
-  {
-    value: 'INTERN',
-    label: 'Intern Track',
-    shortLabel: 'Intern',
-    description: 'Longer-run proving grounds for internships',
-  },
-  {
-    value: 'BOOTCAMP',
-    label: 'Bootcamp Track',
-    shortLabel: 'Bootcamp',
-    description: 'Structured learning with hands-on outputs',
-  },
 ] as const;
 
 function formatDeadline(iso: string | null): string {


### PR DESCRIPTION
## Summary
Fixes #333 (E-rank). The public `/quests` page was offering track filters for `INTERN` and `BOOTCAMP` tracks. These are private/invisible tracks that should not be visible to public visitors. As a result, quests belonging to these tracks were being exposed on the public quest board.

## Problem
- The `TRACK_OPTIONS` in `app/quests/page.tsx` included `INTERN` and `BOOTCAMP` options.
- This allowed public users to filter and view quests that are meant to be hidden from the public (as per the logic in `public-quest-service` and project documentation).
- Only the `OPEN` track should be publicly visible.

## Solution
- Simplified `TRACK_OPTIONS` to only include the `'OPEN'` track.
- Removed the `INTERN` and `BOOTCAMP` track definitions and their descriptions from the public quest board UI.
- Non-OPEN tracks are now hidden from the public quest board and from public API calls made via this page.

## Changes
- `app/quests/page.tsx` (removed private track options — 1 file, minimal change)

## Verification
- `npm run type-check` passes cleanly.
- Matches the existing behavior in `public-quest-service`, which already defaults to the `OPEN` track for public queries.
- No behavior change for authenticated flows or internal pages.

## Notes
- This fix ensures that only publicly visible (`OPEN`) quests appear on the public quest board.
- The change is minimal, focused, and aligns with the project's visibility rules for different quest tracks.
- Private tracks (INTERN/BOOTCAMP) remain accessible through their intended internal flows.