### PR TITLE
fix: calculate dashboard Total Earned from actual completed transactions (#334)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -32,7 +32,7 @@ export default async function DashboardPage() {
   const userId = session.user.id;
 
   // ── Core data ─────────────────────────────────────────────────────────────
-  const [user, pendingAssignments, completedAssignments, availableQuests] =
+  const [user, pendingAssignments, completedAssignments, availableQuests, earnedAgg] =
     await withDbRetry(() =>
       Promise.all([
         prisma.user.findUnique({
@@ -93,6 +93,11 @@ export default async function DashboardPage() {
           orderBy: { createdAt: 'desc' },
           take: 20,
         }),
+
+        prisma.transaction.aggregate({
+          _sum: { amount: true },
+          where: { toUserId: userId, status: 'completed' },
+        }),
       ])
     );
 
@@ -113,10 +118,7 @@ export default async function DashboardPage() {
 
   const completedCount = completedAssignments.length;
 
-  const totalEarned = completedAssignments.reduce(
-    (sum, a) => sum + Number(a.quest.monetaryReward ?? 0),
-    0
-  );
+  const totalEarned = Number(earnedAgg._sum.amount ?? 0);
 
   const rankValue = (r: string | null | undefined) => {
     if (!r) return 0;


### PR DESCRIPTION
## Summary
Fixes #334 (E-rank). The "Total Earned" StatCard on the adventurer dashboard was calculating earnings by summing `quest.monetaryReward` from `completedAssignments`. This value represents the **planned/gross** reward at the time of quest creation, not the **actual** amount the user received after penalties and platform fees.

## Problem
- Users were seeing inflated earnings that did not match the real money they received in their transactions or bank.
- The actual payout is lower due to:
  - Daily standup penalties (up to 100%)
  - 15% platform fee
- This created inconsistency with other parts of the application (my-payments, earnings history, admin revenue views) that correctly use the `Transaction` table.

## Solution
- Added a Prisma aggregate query to sum the `amount` from `Transaction` records where `toUserId` matches the current user and `status` is `'completed'`.
- Used this real sum for the "Total Earned" StatCard.
- Kept the existing `completedAssignments` fetch for the completed count and other UI elements.
- The displayed value now reflects actual money received/booked by the user.

## Changes
- `app/dashboard/page.tsx` (minimal changes inside the existing `withDbRetry` + `Promise.all` block)

## Verification
- `npm run type-check` passes cleanly.
- Follows existing patterns of using the `Transaction` table as the source of truth for actual payouts.
- No behavior change for other parts of the dashboard.

## Notes
- This fix ensures that the "Total Earned" stat now shows accurate, real-world earnings instead of planned rewards.
- The change is small, focused, and consistent with how earnings are handled elsewhere in the application.