### PR TITLE
fix: add rank-based access gating to quest detail API for claim rank lock (#340)

### DIFF
--- a/app/api/quests/[id]/route.ts
+++ b/app/api/quests/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getAuthUser } from '@/lib/api-auth';
+import { getQuestAccessStatus } from "@/lib/quest-access";
+import { UserRank } from '@prisma/client';
 
 export async function GET(
   req: NextRequest,
@@ -140,10 +142,26 @@ export async function GET(
           }
         : null;
 
+    // Rank-based access gating (mirrors the quest list endpoint) so the
+    // detail page can disable the claim button for rank-locked quests.
+    // Use fresh DB rank (not stale JWT) for claim rank lock after rank-up.
+    const accessStatus = user?.role === 'adventurer'
+      ? getQuestAccessStatus(
+          ((await prisma.user.findUnique({
+            where: { id: user.id },
+            select: { rank: true },
+          }))?.rank || user.rank) as UserRank,
+          quest.requiredRank
+        )
+      : { canAccess: true, isVisible: true, lockedUntil: undefined };
+
     const normalizedQuest = {
       ...quest,
       company: sanitizedCompany,
       assignments,
+      canAccess: accessStatus.canAccess,
+      isVisible: accessStatus.isVisible,
+      lockedUntil: accessStatus.lockedUntil,
     };
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
Fixes #340 (E-rank). The quest detail page (`/dashboard/quests/[id]`) was not receiving `canAccess`, `isVisible`, and `lockedUntil` fields from the `/api/quests/[id]` endpoint. Because of this, the rank lock logic and "Claim Quest" button state were broken — the button remained enabled even when the user did not meet the required rank.

## Problem
- The quest detail API was not returning rank-based access status (unlike the quest list endpoint).
- As a result, users could see and interact with the "Claim Quest" button even if their rank was insufficient.
- This broke the intended rank-locking behavior on the claim flow.

## Solution
- Added rank-based access gating in the quest detail API after track enforcement.
- Used fresh database rank (via `prisma.user.findUnique`) instead of stale JWT data (consistent with the #335 fix).
- Returned `canAccess`, `isVisible`, and `lockedUntil` in the response so the client-side UI can properly show rank lock status and disable the claim button when needed.
- The logic mirrors the existing implementation in the quest list endpoint.

## Changes
- `app/api/quests/[id]/route.ts` (minimal and focused addition)

## Verification
- `npm run type-check` passes cleanly.
- Follows existing patterns from the quest list endpoint and the #335 stale-rank fix.
- No behavior change for other flows.

## Notes
- This fix ensures that rank-based locking now works correctly on the quest detail and claim flow.
- The change is small, safe, and consistent with how rank gating is handled elsewhere in the application.