### PR TITLE
fix: include 'pending_admin_review' and 'needs_rework' in active quests query on dashboard (#323)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -43,7 +43,7 @@ export default async function DashboardPage() {
         prisma.questAssignment.findMany({
           where: {
             userId,
-            status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'review'] },
+            status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'needs_rework', 'review'] },
           },
           include: {
             quest: {


### PR DESCRIPTION
Cherry-picked from manthansingh26's PR #368.

Adventurers whose quest is in `pending_admin_review` or `needs_rework` were not seeing them in the Dashboard "active quests" section — only `assigned`, `started`, `in_progress`, `submitted`, and `review` were included.

**Fix:** Add `pending_admin_review` and `needs_rework` to the status filter in `app/dashboard/page.tsx`.

Closes #323

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>