### PR TITLE
fix: await fetchQueue before re-enabling QA buttons — prevents double-approve (#337)

### DIFF
--- a/app/admin/qa-queue/page.tsx
+++ b/app/admin/qa-queue/page.tsx
@@ -106,8 +106,8 @@ export default function QAQueuePage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'approve' }),
     });
+    await fetchQueue();
     setSubmitting(false);
-    fetchQueue();
   };
 
   const handleReject = async () => {
@@ -118,10 +118,10 @@ export default function QAQueuePage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'reject', notes: rejectNotes.trim() }),
     });
+    await fetchQueue();
     setSubmitting(false);
     setRejectTarget(null);
     setRejectNotes('');
-    fetchQueue();
   };
 
   const openPaymentModal = (item: QueueItem) => {


### PR DESCRIPTION
Cherry-picked from manthansingh26's PR #369.

In the admin QA queue, `handleApprove` and `handleReject` called `fetchQueue()` without `await`, then immediately called `setSubmitting(false)`. This re-enabled the Approve/Reject buttons before the queue had refreshed, allowing a second click before the item disappeared from the list.

**Fix:** `await fetchQueue()` before `setSubmitting(false)` in both handlers. Buttons stay disabled until the queue is refreshed and the completed item is gone.

Closes #337

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>