### PR TITLE
fix: use fetchWithAuth in QuestSubmissionDialog — prevents silent failure on expired session (#325)

### DIFF
--- a/components/quest-submission-dialog.tsx
+++ b/components/quest-submission-dialog.tsx
@@ -26,6 +26,7 @@ import {
   type FieldValue,
   type FieldValues,
 } from "@/lib/quest-field-templates";
+import { fetchWithAuth } from "@/lib/fetch-with-auth";
 
 interface QuestSubmissionDialogProps {
   questTitle: string;
@@ -100,7 +101,7 @@ export function QuestSubmissionDialog({ questTitle, assignmentId, questId }: Que
       const structuredText = submissionFields.length > 0 ? fieldValuesToText(submissionFields, values) : "";
       const submissionContent = [structuredText, notes.trim()].filter(Boolean).join("\n\n") || notes.trim();
 
-      const response = await fetch("/api/quests/submissions", {
+      const response = await fetchWithAuth("/api/quests/submissions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
Cherry-picked from manthansingh26's PR #370.

`QuestSubmissionDialog` used a bare `fetch()` to POST to `/api/quests/submissions`. On an expired session, the server returns 401 and the submission silently fails — the user sees nothing, their work is lost, and they don't know to log in again.

**Fix:** Replace `fetch()` with `fetchWithAuth()` which detects the 401 and redirects to `/login?callbackUrl=...` so the user can re-authenticate and return to the quest.

Closes #325

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>