### PR TITLE
fix: public quests hero stats now show real platform data (#237)

### DIFF
--- a/app/quests/page.tsx
+++ b/app/quests/page.tsx
@@ -226,7 +226,7 @@ export default function QuestsPage() {
         });
       })
       .catch(() => {
-        setPlatformStats({ adventurers: 0, companies: 0, completedQuests: 0, openQuests: 0 });
+        // Leave platformStats as null so "—" displays instead of misleading zeros
       });
   }, []);
 

--- a/app/quests/page.tsx
+++ b/app/quests/page.tsx
@@ -138,6 +138,12 @@ export default function QuestsPage() {
   } | null>(null);
   const [categories, setCategories] = useState<string[]>([]);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [platformStats, setPlatformStats] = useState<{
+    adventurers: number;
+    companies: number;
+    completedQuests: number;
+    openQuests: number;
+  } | null>(null);
 
   const fetchQuests = useCallback(async () => {
     try {
@@ -205,6 +211,24 @@ export default function QuestsPage() {
   useEffect(() => {
     fetchQuests();
   }, [fetchQuests]);
+
+  // Pull real live platform stats (same source as landing) for the hero cards.
+  // This fixes the misleading "page only / visible only" numbers in the prominent stats.
+  useEffect(() => {
+    fetch('/api/public/stats')
+      .then((r) => r.json())
+      .then((data) => {
+        setPlatformStats({
+          adventurers: data.adventurers ?? 0,
+          companies: data.companies ?? 0,
+          completedQuests: data.completedQuests ?? 0,
+          openQuests: data.openQuests ?? 0,
+        });
+      })
+      .catch(() => {
+        setPlatformStats({ adventurers: 0, companies: 0, completedQuests: 0, openQuests: 0 });
+      });
+  }, []);
 
   const resetFilters = () => {
     setSearchQuery('');
@@ -274,28 +298,28 @@ export default function QuestsPage() {
 
             <div className="grid gap-4 sm:grid-cols-2">
               <StatCard
-                value={String(totalQuests || '12+')}
-                label="Quests in this track"
+                value={platformStats ? platformStats.adventurers.toLocaleString() : '—'}
+                label="Adventurers"
                 tone="orange"
-                detail={activeTrack.shortLabel}
+                detail="Live on Guild"
               />
               <StatCard
-                value={String(totalApplicantsVisible || '200+')}
-                label="Applications on visible quests"
+                value={platformStats ? platformStats.companies.toLocaleString() : '—'}
+                label="Partner companies"
                 tone="slate"
-                detail="Live demand"
+                detail="Active"
               />
               <StatCard
-                value={`${totalXpVisible || 1000}+`}
-                label="XP across this page"
+                value={platformStats ? platformStats.completedQuests.toLocaleString() : '—'}
+                label="Quests completed"
                 tone="amber"
-                detail="Reputation fuel"
+                detail="All time"
               />
               <StatCard
-                value={String(paidQuestCount || quests.length || '8')}
-                label="Paid quests visible"
+                value={platformStats ? platformStats.openQuests.toLocaleString() : '—'}
+                label="Open quests"
                 tone="emerald"
-                detail="Cash + XP"
+                detail="Right now"
               />
             </div>
           </div>


### PR DESCRIPTION
Cherry-picked from manthansingh26's PR #371, with one additional fix.

The hero stat cards on `/quests` were showing misleading page-local counts with fake fallback numbers (`'12+'`, `'200+'`). This replaces them with real platform-wide data from `/api/public/stats` (same source as the landing page).

**Stats now shown:**
- Adventurers (live on Guild)
- Partner companies (active)
- Quests completed (all time)
- Open quests (right now)

**Additional fix (not in original PR):** The `catch` block was setting stats to `{0,0,0,0}` on API failure, which would show "0 Adventurers". Fixed to leave `platformStats` as `null` so the "—" placeholder shows instead of misleading zeros.

Closes #237

Co-authored-by: manthansingh26 <manthansingh2601@gmail.com>