### PR TITLE
fix: remove webhook secret body fallback to prevent log exposure and bypass (#326)

### DIFF
--- a/app/api/onboard/route.ts
+++ b/app/api/onboard/route.ts
@@ -12,7 +12,6 @@ interface OnboardPayload {
   cohort?: string;
   bootcampTrack: (typeof VALID_BOOTCAMP_TRACKS)[number];
   bootcampWeek?: number;
-  webhookSecret?: string; // legacy: allow secret in body
   initialPassword?: string; // optional: provided by bootcamp system for initial login
 }
 
@@ -27,9 +26,9 @@ export async function POST(request: NextRequest) {
   try {
     const body: OnboardPayload = await request.json();
 
-    // 1. Validate webhook secret (Authorization: Bearer ... OR body.webhookSecret)
+    // 1. Validate webhook secret (Authorization: Bearer <secret> only — body fallback removed for security)
     const expectedSecret = process.env.BOOTCAMP_WEBHOOK_SECRET;
-    const providedSecret = readBearerToken(request) ?? body.webhookSecret ?? null;
+    const providedSecret = readBearerToken(request);
     if (!expectedSecret || !providedSecret || providedSecret !== expectedSecret) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
Fixes #326 (C-rank, Security). The onboarding webhook endpoint (`/api/onboard`) accepted the webhook secret from the JSON request body as a fallback (`body.webhookSecret`). This allowed the secret to be sent in the request body instead of (or along with) the `Authorization: Bearer` header, exposing it in logs, browser DevTools, proxies, and monitoring tools.

## Problem
- The secret could be sent in the request body, which is logged by load balancers, proxies, Vercel, Sentry, and visible in browser developer tools.
- An attacker with access to logs could extract the secret and use it to bulk-enroll arbitrary users.
- This created a serious security and privacy risk.

## Solution
- Removed `webhookSecret` from the `OnboardPayload` interface.
- Removed the `?? body.webhookSecret ?? null` fallback completely.
- The endpoint now **strictly requires** the secret only via the `Authorization: Bearer <secret>` header using the existing `readBearerToken` helper.
- Updated comments for clarity.

## Changes
- `app/api/onboard/route.ts` (minimal and focused changes)

## Verification
- `npm run type-check` passes cleanly (pre-existing unrelated errors in other files were not touched).
- The webhook secret can no longer be sent in the request body.
- The endpoint now enforces the use of the `Authorization` header only.

## Notes
- This is a small but important security fix.
- It eliminates the log exposure and bypass vector described in the issue.
- No legacy body support is retained.
- No other functionality was affected.