### PR TITLE
fix: call syncQuestLifecycleStatus in PATCH /api/quests/assignments/[id] (#322)

### DIFF
--- a/app/api/quests/assignments/[id]/route.ts
+++ b/app/api/quests/assignments/[id]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db';
 import { getAuthUser } from '@/lib/api-auth';
 import { AssignmentStatus } from '@prisma/client';
 import { z } from 'zod';
+import { syncQuestLifecycleStatus } from '@/lib/quest-lifecycle';
 
 const VALID_ADVENTURER_TRANSITIONS: Partial<Record<AssignmentStatus, AssignmentStatus[]>> = {
   assigned: ['started'],
@@ -67,7 +68,7 @@ export async function PATCH(
 
   const assignment = await prisma.questAssignment.findUnique({
     where: { id },
-    include: { quest: { select: { companyId: true } } },
+    include: { quest: { select: { companyId: true, id: true } } },
   });
   if (!assignment) return NextResponse.json({ error: 'Assignment not found' }, { status: 404 });
 
@@ -101,6 +102,8 @@ export async function PATCH(
       ...(status === 'completed' && { completedAt: new Date() }),
     },
   });
+
+  await syncQuestLifecycleStatus(prisma, assignment.quest.id);
 
   return NextResponse.json({ assignment: updated, success: true });
 }


### PR DESCRIPTION
## Summary
Fixes #322 (D-rank). The `PATCH /api/quests/assignments/[id]` endpoint (used by the "Start Quest" button and `MyQuestCard` for status transitions) was updating the assignment status but **never calling `syncQuestLifecycleStatus()`**. 

As a result, on multi-participant quests, when assignments transitioned (e.g., `assigned` → `started`), the parent quest's lifecycle status (available/full slots, etc.) was never recalculated. This could cause the quest to remain in an incorrect state (e.g., staying `available` even after all slots were filled), allowing extra applicants and showing wrong status on the company dashboard.

## Problem
- The old `PUT` path (via `assignment-service`) correctly called `syncQuestLifecycleStatus()`.
- The `PATCH` path (used for common adventurer actions) did not.
- This created inconsistency and potential slot-limit bypass on group quests.

## Solution
- Added the missing import for `syncQuestLifecycleStatus`.
- Updated the initial query to also select `quest.id`.
- Added `await syncQuestLifecycleStatus(prisma, assignment.quest.id)` immediately after the `questAssignment.update()` call.

This ensures the quest lifecycle is always kept in sync on every assignment status transition via the `PATCH` endpoint.

## Changes
- `app/api/quests/assignments/[id]/route.ts` (minimal and focused change)

## Verification
- `npm run type-check` passes cleanly (pre-existing unrelated errors in other files were not touched).
- Only this one file was modified.
- Behavior now matches other paths that already call `syncQuestLifecycleStatus()`.

## Notes
- This is a small but important consistency fix.
- It prevents silent slot-limit bypass and incorrect quest status on the company side.
- No other functionality or behavior was changed.