### PR TITLE
feat: dismissible announcement banner on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Hero from '@/components/ui/animated-shader-hero';
+import AnnouncementBanner from '@/components/landing/AnnouncementBanner';
 import RankJourney from '@/components/landing/RankJourney';
 import TrustStrip from '@/components/landing/LogoMarquee';
 import HowItWorks from '@/components/landing/HowItWorks';
@@ -26,6 +27,9 @@ export default function HomePage() {
 
   return (
     <>
+      {/* Announcement banner — dismissible, auto-expires */}
+      <AnnouncementBanner />
+
       {/* Hero — broader service scope, not just code */}
       <div className="relative">
         <Hero

--- a/components/landing/AnnouncementBanner.tsx
+++ b/components/landing/AnnouncementBanner.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { X, Zap } from 'lucide-react';
+
+// ─── Edit this to change the announcement ───────────────────────────────────
+const ANNOUNCEMENT = {
+  id: 'bharatcode-collab-jun16',          // change this ID to force banner to reappear
+  badge: '🤝 New collab',
+  text: 'BharatCode is giving our students free compute + AI tools.',
+  cta: 'Join the live session · 16 Jun, 9:45 PM',
+  ctaHref: 'https://bharatcode.ai',
+  expiresAt: '2026-06-17T00:00:00+05:30', // auto-hides after this date
+};
+// ────────────────────────────────────────────────────────────────────────────
+
+export default function AnnouncementBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Don't show if already dismissed or expired
+    const dismissed = localStorage.getItem(`banner-${ANNOUNCEMENT.id}`);
+    const expired = new Date() > new Date(ANNOUNCEMENT.expiresAt);
+    if (!dismissed && !expired) setVisible(true);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(`banner-${ANNOUNCEMENT.id}`, '1');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="relative z-50 w-full bg-slate-900 border-b border-white/8">
+      <div className="mx-auto flex max-w-5xl items-center gap-3 px-4 py-2.5 sm:px-6">
+        {/* Badge */}
+        <span className="hidden shrink-0 items-center gap-1.5 rounded-full bg-orange-400/15 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-orange-400 sm:flex">
+          <Zap className="size-3" />
+          {ANNOUNCEMENT.badge}
+        </span>
+
+        {/* Text */}
+        <p className="flex-1 text-[13px] text-white/70">
+          <span className="font-medium text-white/90">{ANNOUNCEMENT.text}</span>
+          {' '}
+          <Link
+            href={ANNOUNCEMENT.ctaHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-semibold text-orange-400 underline-offset-2 hover:underline"
+            onClick={dismiss}
+          >
+            {ANNOUNCEMENT.cta} →
+          </Link>
+        </p>
+
+        {/* Dismiss */}
+        <button
+          onClick={dismiss}
+          aria-label="Dismiss announcement"
+          className="shrink-0 rounded p-1 text-white/30 transition-colors hover:bg-white/8 hover:text-white/70"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this does

Adds a slim, dismissible announcement banner at the top of the landing page — above the hero — for time-sensitive updates like collabs, events, and launches.

**First use:** BharatCode collaboration announcement + live session (16 Jun, 9:45 PM)

## How it works

- Single `ANNOUNCEMENT` object at the top of the file — change text, link, badge, and `expiresAt` in one place
- Auto-hides after `expiresAt` (no manual removal needed for time-boxed events)
- Dismissal persisted in `localStorage` keyed by `id` — change the `id` to force it to reappear for new announcements
- Matches dark landing page aesthetic (slate-900 bar, orange-400 accent, white/70 text)
- Responsive — badge hidden on mobile to save space

## To update the announcement next time

Edit `components/landing/AnnouncementBanner.tsx`, lines 8–15:

```ts
const ANNOUNCEMENT = {
  id: 'new-unique-id',          // change to force reappear
  badge: '🚀 New',
  text: 'Your announcement text here.',
  cta: 'CTA label',
  ctaHref: 'https://...',
  expiresAt: '2026-06-20T00:00:00+05:30',
};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)