### PR TITLE
feat: WhatsApp float, open quests, admin rank controls, clean leaderboard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,8 @@
       "Bash(mkdir -p /Users/abi/Documents/Adventurers-Guild/app/admin/qa-queue/[assignmentId])",
       "Bash(git -C /Users/abi/Documents/Adventurers-Guild add -A)",
       "Bash(npx playwright *)",
-      "Bash(RESEND_API_KEY=test npx ts-node scripts/recruit-vit-students.ts)"
+      "Bash(RESEND_API_KEY=test npx ts-node scripts/recruit-vit-students.ts)",
+      "Bash(npx tsc *)"
     ],
     "additionalDirectories": [
       "/Users/abi/Documents/Adventurers-Guild/app/api/parties/[id]/members"

--- a/app/admin/quests/page.tsx
+++ b/app/admin/quests/page.tsx
@@ -61,6 +61,7 @@ interface QuestItem {
   description: string;
   status: string;
   difficulty: string;
+  requiredRank: string | null;
   questType: string;
   questCategory: string;
   xpReward: number;
@@ -91,6 +92,8 @@ export default function AdminQuestsPage() {
   const [newNoteText, setNewNoteText] = useState('');
   const [savingNote, setSavingNote] = useState(false);
   const [changingStatusId, setChangingStatusId] = useState<string | null>(null);
+  const [changingRankId, setChangingRankId] = useState<string | null>(null);
+  const [clearingDeadlineId, setClearingDeadlineId] = useState<string | null>(null);
 
   const shouldFetch = status === 'authenticated' && session?.user?.role === 'admin';
   const questsEndpoint = useMemo(() => {
@@ -170,6 +173,54 @@ export default function AdminQuestsPage() {
       toast.error('Something went wrong');
     } finally {
       setChangingStatusId(null);
+    }
+  };
+
+  const handleRankChange = async (questId: string, newRank: string) => {
+    setChangingRankId(questId);
+    try {
+      const response = await fetchWithAuth('/api/admin/quests', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questId, requiredRank: newRank }),
+      });
+      const payload = await response.json();
+      if (payload.success) {
+        mutateQuests((current) =>
+          current.map((q) => (q.id === questId ? { ...q, requiredRank: newRank } : q))
+        );
+        toast.success(`Required rank set to ${newRank}`);
+      } else {
+        toast.error(payload.error || 'Failed to update rank');
+      }
+    } catch {
+      toast.error('Something went wrong');
+    } finally {
+      setChangingRankId(null);
+    }
+  };
+
+  const handleClearDeadline = async (questId: string) => {
+    setClearingDeadlineId(questId);
+    try {
+      const response = await fetchWithAuth('/api/admin/quests', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questId, deadline: null }),
+      });
+      const payload = await response.json();
+      if (payload.success) {
+        mutateQuests((current) =>
+          current.map((q) => (q.id === questId ? { ...q, deadline: null } : q))
+        );
+        toast.success('Deadline cleared');
+      } else {
+        toast.error(payload.error || 'Failed to clear deadline');
+      }
+    } catch {
+      toast.error('Something went wrong');
+    } finally {
+      setClearingDeadlineId(null);
     }
   };
 
@@ -431,18 +482,19 @@ export default function AdminQuestsPage() {
                     </div>
 
                     <div className="flex shrink-0 flex-wrap gap-2 sm:flex-col">
+                      {/* Status */}
                       <Select
                         value={quest.status}
                         onValueChange={(value) => handleStatusChange(quest.id, value)}
                         disabled={changingStatusId === quest.id}
                       >
-                        <SelectTrigger className="h-8 w-[120px] sm:w-[140px] text-xs">
+                        <SelectTrigger className="h-8 w-[130px] text-xs">
                           {changingStatusId === quest.id ? (
                             <Loader2 className="h-3 w-3 animate-spin" />
                           ) : (
                             <>
                               <ChevronDown className="mr-1 h-3 w-3" />
-                              Change status
+                              Status
                             </>
                           )}
                         </SelectTrigger>
@@ -455,6 +507,30 @@ export default function AdminQuestsPage() {
                         </SelectContent>
                       </Select>
 
+                      {/* Required rank */}
+                      <Select
+                        value={quest.requiredRank ?? quest.difficulty ?? 'F'}
+                        onValueChange={(value) => handleRankChange(quest.id, value)}
+                        disabled={changingRankId === quest.id}
+                      >
+                        <SelectTrigger className="h-8 w-[130px] text-xs">
+                          {changingRankId === quest.id ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <>
+                              <ChevronDown className="mr-1 h-3 w-3" />
+                              Min rank: {quest.requiredRank ?? quest.difficulty ?? 'F'}
+                            </>
+                          )}
+                        </SelectTrigger>
+                        <SelectContent>
+                          {['F', 'E', 'D', 'C', 'B', 'A', 'S'].map((r) => (
+                            <SelectItem key={r} value={r}>{r}-Rank</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+
+                      {/* Notes */}
                       <Button
                         variant="outline"
                         size="sm"
@@ -462,16 +538,36 @@ export default function AdminQuestsPage() {
                         onClick={() => openNoteDialog(quest)}
                       >
                         <StickyNote className="h-3 w-3" />
-                        Notes
+                        Notes {quest.adminNotes?.length ? `(${quest.adminNotes.length})` : ''}
                       </Button>
 
+                      {/* Edit */}
                       <Button variant="outline" size="sm" className="h-8 text-xs" asChild>
-                        <Link href={`/dashboard/company/quests/${quest.id}`}>
+                        <Link href={`/dashboard/company/quests/${quest.id}/edit`}>
                           <Edit className="h-3 w-3" />
-                          View
+                          Edit
                         </Link>
                       </Button>
 
+                      {/* Clear deadline */}
+                      {quest.deadline && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-8 text-xs text-amber-600 hover:border-amber-300 hover:text-amber-700"
+                          onClick={() => handleClearDeadline(quest.id)}
+                          disabled={clearingDeadlineId === quest.id}
+                        >
+                          {clearingDeadlineId === quest.id ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <CalendarClock className="h-3 w-3" />
+                          )}
+                          No Deadline
+                        </Button>
+                      )}
+
+                      {/* Cancel */}
                       {quest.status !== 'cancelled' && quest.status !== 'completed' && (
                         <Button
                           variant="outline"

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -137,6 +137,7 @@ export async function GET(request: NextRequest) {
     const rank = normalizeRank(searchParams.get('rank'));
     const where = {
       role: 'adventurer' as const,
+      isActive: true,
       OR: [
         { xp: { gt: 0 } },
         { skillPoints: { gt: 0 } },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Hero from '@/components/ui/animated-shader-hero';
 import AnnouncementBanner from '@/components/landing/AnnouncementBanner';
+import WhatsAppFloat from '@/components/landing/WhatsAppFloat';
 import RankJourney from '@/components/landing/RankJourney';
 import TrustStrip from '@/components/landing/LogoMarquee';
 import HowItWorks from '@/components/landing/HowItWorks';
@@ -80,6 +81,9 @@ export default function HomePage() {
 
       {/* #5 — Live quest board + top adventurers */}
       <QuestShowcase />
+
+      {/* Floating WhatsApp join button */}
+      <WhatsAppFloat />
     </>
   );
 }

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -164,13 +164,13 @@ export default function HowItWorks() {
                 <ArrowRight className="h-3.5 w-3.5" strokeWidth={2.5} />
               </Link>
               <a
-                href="https://chat.whatsapp.com/FFR8bOzvsJr3xHDnhGpB95"
+                href="https://chat.whatsapp.com/FFR8bOzvsJr3xHDnhGpB95?s=cl&p=i&ilr=0"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-3 inline-flex h-11 items-center gap-2 rounded-xl border border-slate-200 bg-white px-5 text-[13px] font-semibold text-slate-700 transition-all hover:border-green-300 hover:text-green-700 hover:shadow-sm"
+                className="mt-3 inline-flex h-11 items-center gap-2 rounded-xl border border-green-200 bg-green-50 px-5 text-[13px] font-semibold text-green-700 transition-all hover:bg-green-100 hover:shadow-sm"
               >
-                <MessageCircle className="h-4 w-4 text-green-500" />
-                Join our WhatsApp
+                <MessageCircle className="h-4 w-4 text-green-600" />
+                Join our WhatsApp Community
               </a>
             </div>
           </div>

--- a/components/landing/WhatsAppFloat.tsx
+++ b/components/landing/WhatsAppFloat.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+const WA_LINK = 'https://chat.whatsapp.com/FFR8bOzvsJr3xHDnhGpB95?s=cl&p=i&ilr=0';
+
+export default function WhatsAppFloat() {
+  return (
+    <a
+      href={WA_LINK}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-6 right-6 z-50 flex items-center gap-2.5 rounded-full bg-[#25D366] px-4 py-3 shadow-lg shadow-black/20 transition-all hover:scale-105 hover:shadow-xl hover:shadow-black/25 active:scale-95"
+      aria-label="Join our WhatsApp community"
+    >
+      {/* WhatsApp SVG icon */}
+      <svg viewBox="0 0 24 24" className="h-5 w-5 shrink-0 fill-white" xmlns="http://www.w3.org/2000/svg">
+        <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/>
+        <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.51 5.833L.057 23.18a.75.75 0 0 0 .923.923l5.347-1.453A11.94 11.94 0 0 0 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.75a9.73 9.73 0 0 1-4.964-1.357l-.356-.21-3.692 1.003 1.003-3.692-.21-.356A9.73 9.73 0 0 1 2.25 12C2.25 6.615 6.615 2.25 12 2.25S21.75 6.615 21.75 12 17.385 21.75 12 21.75z"/>
+      </svg>
+      <span className="text-[13px] font-semibold text-white">Join Community</span>
+    </a>
+  );
+}

--- a/docs/BUSINESS_ASSOCIATION_RESEARCH.md
+++ b/docs/BUSINESS_ASSOCIATION_RESEARCH.md
@@ -1,0 +1,590 @@
+# Business Association Research: SME Access Channels for Adventurers Guild
+
+**Date:** June 13, 2026
+**Purpose:** Identify and evaluate business associations, chambers, and networks for warm SME access to sell AI Automation Sprints
+
+---
+
+## Executive Summary
+
+Adventurers Guild's target customers are **D2C brands, regional FMCG distributors, and retail chains (2-5 stores)** — companies with 10-100 employees, founder-led decisions, and AI-curious mindsets. This research evaluates 18+ associations/networks across 6 categories, ranked by **directness of SME access**, **cost-effectiveness**, and **strategic fit** for AG's AI Sprint model.
+
+**Top 3 Recommendations:**
+1. **FICCI Young Leaders Forum** — Best warm access to 10-100 employee SMEs
+2. **TiE Chapters (local)** — Best for startup/D2C founder networking
+3. **Startup India BHASKAR** — Free, government-backed, direct SME directory
+
+---
+
+## Tier 1: Direct SME Access (Highest Strategic Fit)
+
+### 1. FICCI Young Leaders Forum (YLF)
+
+**What it is:**
+- Exclusive forum of young professionals and young achievers from diverse fields of business and industry
+- Part of FICCI (founded 1927), India's oldest and largest trade association
+- Has state chapters: Maharashtra, MP, Karnataka, Tamil Nadu, Telangana, Gujarat, UP, etc.
+- Runs annual "FICCI Young Leaders Summit" (held Nov 2025, July 2025)
+- Publishes studies (e.g., "India Startup Law & Policy Guidebook" Nov 2025)
+- Runs "FICCI Young Leaders Awards" annually
+
+**Membership Cost:**
+- Must be a FICCI member first (see FICCI membership below)
+- YLF is an internal division — no separate fee
+- Contact: +91-11-23738760-70, Federation House, New Delhi
+
+**Who you'll meet:**
+- Young business owners (10-200 employees)
+- Family business successors
+- Entrepreneurs in FMCG, retail, healthcare, professional services
+- Professionals transitioning to entrepreneurship
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Direct access to SME owners | These are EXACTLY your target customers (10-100 employees) |
+| FMCG sector chamber | FICCI has a dedicated FMCG sector — you can approach them directly |
+| State chapters | Local networking in Mumbai, Delhi, Bangalore, Pune, Hyderabad |
+| Annual summit | Speaking opportunity — present "AI Readiness for SMEs" as a session |
+| Studies & publications | Co-author a report on "AI Adoption in Indian SMEs" — positions AG as thought leader |
+| Awards program | Nominate yourself for "Young Leader in Technology/AI" — builds credibility |
+| B2B services | FICCI offers B2B networking services for members |
+
+**How to approach:**
+1. Apply for FICCI membership (see below)
+2. Request YLF membership through the FICCI Young Leaders Forum portal
+3. Attend the next Young Leaders Summit (check ficci.in/events)
+4. Propose a session on "AI Automation for Indian SMEs"
+5. Network with members from retail, FMCG, D2C sectors
+
+**Strategic Fit: ★★★★★ (5/5)**
+- This is the #1 recommendation. FICCI YLF members are business owners who are 10-200 employees — exactly your target.
+- The FMCG sector chamber gives you a direct line to regional FMCG brands and distributors.
+- State chapters mean you can network locally in your operating city.
+
+---
+
+### 2. CII (Confederation of Indian Industry)
+
+**What it is:**
+- India's oldest and largest industry association (partnered with Young Indians)
+- Has sectoral chambers: FMCG, Retail, Healthcare, IT, Education, etc.
+- Has regional chapters: East, North, South, West, North East
+- Runs CII Market Place (ciimarketplace.in) — B2B matchmaking
+- Has B2B Networking services
+- CII Centre of Excellence for SME Competitiveness (cii-competitiveness.in)
+- Partners with Young Indians (see below)
+
+**Membership Cost:**
+- Contact: membership@cii.in or visit cii.in/membership
+- Fees vary by membership type and company size
+- SME-focused membership likely lower tier
+
+**Who you'll meet:**
+- Senior industry leaders (larger companies than FICCI YLF)
+- SME owners through CII's MSME programs
+- Retail and FMCG sector members
+- Technology/IT service providers
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| CII Market Place | List AG as an AI automation service provider |
+| CII SME Centre | Direct access to 10-100 employee SMEs |
+| FMCG sector | Connect with regional FMCG brands |
+| Retail sector | Connect with retail chains (your target) |
+| Regional chapters | Local networking in your operating city |
+| B2B Networking | Formal matchmaking with SMEs needing automation |
+| Consulting Services | CII offers consulting — potential partnership |
+
+**How to approach:**
+1. Apply for CII membership through cii.in/membership
+2. Request membership in FMCG and Retail sectors
+3. Register on CII Market Place as a service provider
+4. Attend regional chapter events
+5. Connect with CII SME Centre for targeted outreach
+
+**Strategic Fit: ★★★★☆ (4/5)**
+- Strong fit but slightly more senior/corporate than FICCI YLF. Better for larger SMEs (50-200 employees).
+- CII Market Place is a unique B2B matchmaking tool.
+- The SME Centre is specifically designed for small/medium enterprises.
+
+---
+
+### 3. TiE (The Indus Entrepreneurs) — Local Chapters
+
+**What it is:**
+- World's largest global community of entrepreneurs (500,000+ community, 12,000+ members)
+- 63+ chapters in India (including new Siliguri & Raipur chapters)
+- Pillars: Networking, Mentoring, Investing, Education, Incubation
+- Programs: TiEcon (technology conference), TiE Global Summit, TiE Angels, TYE (Young Entrepreneurs)
+- Impact: $1 trillion wealth created, $50 billion invested, 2.5M jobs generated (KPMG/Deloitte verified)
+
+**Membership Tiers & Cost:**
+
+| Tier | Who | Cost (approx) | Fit for AG |
+|---|---|---|---|
+| **Associate** | Early-stage entrepreneurs, startup founders, SME owners | ~₹5,000-15,000/year | ★★★★★ Best fit |
+| **NxtGen** | Age 21-32, emerging founders | ~₹3,000-10,000/year | ★★★★☆ Good for networking |
+| **Scaleup** | Funded/Revenue traction (₹1 Cr+ revenue) | Higher tier | ★★★☆☆ For later |
+| **Charter** | By invitation, accomplished entrepreneurs | Highest tier | ★★☆☆☆ Too senior |
+
+**Who you'll meet:**
+- Startup founders (your D2C target)
+- Serial entrepreneurs (potential mentors/partners)
+- VCs and angel investors (TiE Angels)
+- Tech professionals and corporate intrapreneurs
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Local chapter events | Monthly meetups — pitch your AI Sprints |
+| TiEcon conference | Exhibit or speak — massive visibility |
+| TiE Angels | Potential funding + warm intros to portfolio companies |
+| Mentorship programs | Position AG as a mentor to early-stage founders |
+| Chapter networking | Direct access to founders in your city |
+| TiE U (University) | Access to student talent for your talent factory |
+| Global network | 60+ chapters worldwide for expansion |
+
+**How to approach:**
+1. Join as an **Associate Member** in your local TiE chapter (Mumbai/Delhi/Bangalore/Pune)
+2. Attend monthly chapter events — introduce yourself as "AI automation for SMEs"
+3. Volunteer to speak at a chapter event on "AI Readiness for Indian Businesses"
+4. Connect with TiE Angels for investor intros
+5. Consider TiE U for talent pipeline
+
+**Strategic Fit: ★★★★★ (5/5)**
+- TiE chapters are THE place for startup/D2C founder networking in India.
+- Your target customers (D2C founders, regional brand owners) are very likely TiE members.
+- Associate membership is affordable and gives you direct access to chapter events.
+
+---
+
+### 4. Startup India — BHASKAR Registry
+
+**What it is:**
+- Government of India's official startup registry
+- 600,000+ registered startups
+- Free to register
+- BHASKAR = Bharat Startup Knowledge Access Registry
+- Connects startups, mentors, investors, incubators, government bodies
+- Searchable database of all registered startups
+
+**Cost:**
+- **FREE** — Register at startupindia.gov.in/bhaskar
+
+**Who you'll find:**
+- DPIIT-recognized startups
+- D2C brands
+- Tech startups
+- SMEs seeking government recognition
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Free directory | Search for D2C/retail/FMCG startups in your city |
+| Direct outreach | Contact startups directly through the platform |
+| Government credibility | Being on the platform adds legitimacy |
+| MAARG mentorship | Register as a mentor — access to startup pipeline |
+| Startup India Investor Connect | Potential investor connections |
+| National Startup Awards | Submit AG for recognition — massive PR |
+
+**How to approach:**
+1. Register on BHASKAR as a service provider
+2. Register on MAARG as a mentor (AI automation specialist)
+3. Search for D2C/retail startups in your target cities
+4. Reach out with "free AI Readiness Assessment" offer
+5. Submit AG for National Startup Awards
+
+**Strategic Fit: ★★★★☆ (4/5)**
+- Free and direct access to 600K+ startups.
+- Less "warm" than FICCI/TiE but high volume.
+- Best used as a complementary channel alongside paid memberships.
+
+---
+
+## Tier 2: Industry-Specific Networks (Good Strategic Fit)
+
+### 5. NASSCOM
+
+**What it is:**
+- India's voice for the $315B technology industry
+- 3,000+ members (services, products, startups)
+- Focus areas: DeepTech, Talent, Diversity, Market & Industry
+- Runs FutureSkills PRIME (upskilling platform)
+- Hosts major events: LHIF (Life Sciences), People Summit, Bharat Mobility
+
+**Membership Cost:**
+| Revenue Tier | Annual Fee |
+|---|---|
+| Emerging (<₹5 Cr) | ₹25,000 + 18% GST |
+| Emerging (₹5-20 Cr) | ₹50,000 + 18% GST |
+| Emerging (₹20-50 Cr) | ₹85,000 + 18% GST |
+| Growth (₹50-200 Cr) | ₹2,00,000 + 18% GST |
+
+**Who you'll meet:**
+- IT/BPM companies
+- Tech startups
+- Venture capital firms
+- Academic institutions
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| FutureSkills PRIME | Co-create AI skill programs — positions AG as training partner |
+| Talent Council | Access to talent pool for your workforce |
+| Events | Speak at tech events — visibility |
+| Policy advocacy | Influence AI/tech policy |
+
+**How to approach:**
+1. Join as Emerging member (₹25,000/year if revenue <₹5 Cr)
+2. Engage with FutureSkills PRIME for co-creation
+3. Participate in Talent Council initiatives
+4. Speak at NASSCOM events
+
+**Strategic Fit: ★★★☆☆ (3/5)**
+- More IT-focused than your target (D2C/SME).
+- Good for talent pipeline and credibility, but not direct SME customer access.
+- Best as a secondary channel.
+
+---
+
+### 6. FICCI FMCG Sector Chamber
+
+**What it is:**
+- Dedicated FMCG sector within FICCI
+- Members include HUL, Nestle, ITC, Dabur, P&G, and regional FMCG brands
+- Runs studies, events, and policy advocacy for FMCG
+
+**How to access:**
+- Requires FICCI membership
+- Request to join FMCG sector chamber
+
+**Who you'll meet:**
+- Large FMCG brands (HUL, Nestle, ITC)
+- Regional/niche FMCG brands (your actual target)
+- FMCG distributors and wholesalers
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Regional FMCG brands | These are your actual target (50-200 employees, owner-led) |
+| FMCG distributors | Wholesalers who need digitization |
+| Industry studies | Co-author on "Digital Transformation in FMCG" |
+| Sector events | Speak at FMCG-specific events |
+
+**How to approach:**
+1. Join FICCI membership
+2. Request FMCG sector chamber membership
+3. Focus on regional/niche FMCG brands, not the big players
+4. Propose a study on "AI in FMCG Distribution"
+
+**Strategic Fit: ★★★☆☆ (3/5)**
+- Good for regional FMCG brands but not large FMCG giants.
+- Large FMCG brands have procurement committees — too slow.
+- Focus on the 50-200 employee regional brands.
+
+---
+
+### 7. FICCI Retail & Internal Trade Sector
+
+**What it is:**
+- Dedicated retail sector within FICCI
+- Members include retail chains, e-commerce, internal trade companies
+
+**How to access:**
+- Requires FICCI membership
+- Request to join Retail sector chamber
+
+**Who you'll meet:**
+- Retail chains (2-50 stores)
+- E-commerce companies
+- Internal trade/distribution companies
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Retail chains | EXACTLY your target (2-5 store chains) |
+| WhatsApp catalog bots | Your product for retail |
+| Inventory alerts | Your product for retail |
+| Customer follow-up automation | Your product for retail |
+
+**How to approach:**
+1. Join FICCI membership
+2. Request Retail sector chamber membership
+3. Attend retail-specific events
+4. Pitch "WhatsApp automation for retail chains"
+
+**Strategic Fit: ★★★★☆ (4/5)**
+- Very good fit for retail chains.
+- Your products (WhatsApp catalogs, inventory alerts) map directly to retail pain points.
+
+---
+
+### 8. CII Retail Sector
+
+**What it is:**
+- CII's dedicated retail sector chamber
+- Members include retail chains, e-commerce, consumer stores
+
+**How to access:**
+- Requires CII membership
+- Request to join Retail sector
+
+**Strategic Fit: ★★★★☆ (4/5)**
+- Similar to FICCI Retail but potentially more SME-focused.
+- Good complementary channel.
+
+---
+
+## Tier 3: Entrepreneur Communities & Coworking (Moderate Strategic Fit)
+
+### 9. 91Springboard
+
+**What it is:**
+- India's largest coworking network (45 hubs, 35,000+ desks, 9 cities)
+- Members include startups, freelancers, SMEs, enterprises
+- Cities: Bangalore, Delhi, Mumbai, Gurugram, Hyderabad, Chennai, Pune, Noida, Goa
+
+**Cost:**
+- Not a membership organization — pay for workspace
+- Virtual office: ~₹3,000-5,000/month
+- Dedicated desk: ~₹8,000-15,000/month
+- Private office: ~₹25,000-1,00,000+/month
+
+**Who you'll meet:**
+- Startup founders
+- Freelancers
+- Small teams (2-20 people)
+- Enterprise teams
+
+**Benefits for Adventurers Guild:**
+| Benefit | Strategic Value |
+|---|---|
+| Member perks | Networking events, learning sessions |
+| Physical presence | Meet SMEs in person |
+| Community | Organic conversations about business needs |
+| Referral program | Earn referrals from other members |
+
+**How to approach:**
+1. Get a virtual office or shared desk
+2. Attend community events
+3. Host an "AI for Business" workshop
+4. Network with members who need automation
+
+**Strategic Fit: ★★★☆☆ (3/5)**
+- Good for organic networking but not a formal association.
+- Best if you need a physical presence in your city.
+- Lower priority than FICCI/TiE.
+
+---
+
+### 10. EY Foundation — FTO (For The Next 100 Million)
+
+**What it is:**
+- EY's entrepreneurship program
+- Supports early-stage entrepreneurs
+- Runs EY Entrepreneur Of The Year (EY EOTY) awards
+
+**How to access:**
+- Apply for EY EOTY awards
+- Attend EY entrepreneurship events
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- More focused on large-scale entrepreneurship.
+- Good for credibility/awards but not direct SME access.
+
+---
+
+### 11. BW EY (Business World EY)
+
+**What it is:**
+- Business World's entrepreneurship initiatives
+- Runs BW NextGen, BW Startup awards
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- Media-focused. Good for PR but not direct customer access.
+
+---
+
+### 12. ASCEND (by NASSCOM Foundation)
+
+**What it is:**
+- NASSCOM Foundation's social entrepreneurship program
+- Focus on social impact, not commercial SMEs
+
+**Strategic Fit: ★☆☆☆☆ (1/5)**
+- Not relevant for AG's commercial model.
+
+---
+
+## Tier 4: Government & Incubator Networks (Low Strategic Fit)
+
+### 13. NIESBUD (National Institute for Entrepreneurship and Small Business Development)
+
+**What it is:**
+- Government of India institute for MSME development
+- Runs training, workshops, and incubation programs for small businesses
+
+**Cost:**
+- Free or low-cost programs
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- Good for credibility and training partnerships.
+- Not a direct customer acquisition channel.
+
+---
+
+### 14. CIIE.CO (IIM Ahmedabad)
+
+**What it is:**
+- IIM Ahmedabad's business incubator
+- One of India's top startup incubators
+- Supports early-stage startups
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- Good for talent pipeline and credibility.
+- Not a direct customer channel.
+
+---
+
+### 15. T-Hub (Hyderabad)
+
+**What it is:**
+- India's largest startup ecosystem platform
+- 10,000+ startups, 200+ corporates, 500+ investors
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- More startup-focused than SME-focused.
+- Good if you're expanding to Hyderabad.
+
+---
+
+### 16. Startup India Yatra / National Startup Awards
+
+**What it is:**
+- Government of India's startup recognition program
+- National Startup Awards for exceptional startups
+
+**Strategic Fit: ★★☆☆☆ (2/5)**
+- Good for AG's own credibility.
+- Not a direct customer acquisition channel.
+
+---
+
+## Tier 5: Online Platforms (Supplementary)
+
+### 17. Clutch.co / GoodFirms
+
+**What it is:**
+- B2B service directories
+- Companies search for service providers here
+
+**Cost:**
+- Free basic listing
+- Paid featured listings: $500-5,000/year
+
+**Strategic Fit: ★★★☆☆ (3/5)**
+- Good for inbound leads from companies searching for AI/automation providers.
+- Low effort, moderate return.
+- Best as a supplementary channel.
+
+---
+
+### 18. LinkedIn Groups
+
+**What it is:**
+- LinkedIn has 100+ India-focused business groups
+- Examples: "Indian SME Network", "D2C India", "Startup India", "AI in India"
+
+**Cost:**
+- Free
+
+**Strategic Fit: ★★★☆☆ (3/5)**
+- Free and direct access to SME owners.
+- Requires active engagement (not just posting).
+- Best as a supplementary channel.
+
+---
+
+## Summary Comparison Table
+
+| Association | Cost | SME Access | D2C/FMCG Fit | Warmth | Priority |
+|---|---|---|---|---|---|
+| **FICCI Young Leaders Forum** | FICCI membership | ★★★★★ | ★★★★★ | ★★★★★ | **#1** |
+| **TiE Chapters** | ₹5K-15K/year | ★★★★★ | ★★★★☆ | ★★★★★ | **#2** |
+| **Startup India BHASKAR** | FREE | ★★★★☆ | ★★★★☆ | ★★★☆☆ | **#3** |
+| **CII** | Varies | ★★★★☆ | ★★★★☆ | ★★★★☆ | **#4** |
+| **FICCI Retail Sector** | FICCI membership | ★★★★☆ | ★★★★★ | ★★★★☆ | **#5** |
+| **CII Retail Sector** | CII membership | ★★★★☆ | ★★★★☆ | ★★★★☆ | **#6** |
+| **NASSCOM** | ₹25K+/year | ★★★☆☆ | ★★☆☆☆ | ★★★☆☆ | **#7** |
+| **FICCI FMCG Sector** | FICCI membership | ★★★☆☆ | ★★★★☆ | ★★★☆☆ | **#8** |
+| **Clutch/GoodFirms** | Free-$5K | ★★★☆☆ | ★★★☆☆ | ★★☆☆☆ | **#9** |
+| **LinkedIn Groups** | FREE | ★★★☆☆ | ★★★☆☆ | ★★☆☆☆ | **#10** |
+| **91Springboard** | ₹3K-1L/month | ★★★☆☆ | ★★★☆☆ | ★★★☆☆ | **#11** |
+| **NASSCOM FutureSkills** | ₹25K+/year | ★★☆☆☆ | ★★☆☆☆ | ★★★☆☆ | **#12** |
+| **CIIE.CO / T-Hub** | Varies | ★★☆☆☆ | ★★☆☆☆ | ★★★☆☆ | **#13** |
+| **EY FTO** | Varies | ★★☆☆☆ | ★★☆☆☆ | ★★☆☆☆ | **#14** |
+| **NIESBUD** | Free | ★★☆☆☆ | ★★☆☆☆ | ★★☆☆☆ | **#15** |
+
+---
+
+## Recommended Action Plan
+
+### Phase 1 (Months 1-2): Quick Wins
+1. **Register on Startup India BHASKAR** (FREE) — start reaching out to D2C/retail startups
+2. **Join TiE local chapter** as Associate Member (₹5K-15K/year) — attend monthly events
+3. **Apply for FICCI membership** — request YLF membership immediately
+
+### Phase 2 (Months 3-4): Build Relationships
+4. **Attend FICCI Young Leaders Summit** — propose a session on "AI for SMEs"
+5. **Join FICCI Retail Sector Chamber** — network with retail chain owners
+6. **Register on Clutch/GoodFirms** — start getting inbound leads
+7. **Join LinkedIn groups** — start engaging with D2C/SME communities
+
+### Phase 3 (Months 5-6): Scale
+8. **Join CII** — register on CII Market Place
+9. **Co-author a report** with FICCI on "AI Adoption in Indian SMEs"
+10. **Submit AG for National Startup Awards** — massive PR boost
+11. **Host "AI for Business" workshops** at coworking spaces
+
+### Phase 4 (Months 7-12): Deepen
+12. **Speak at TiEcon** or TiE Global Summit
+13. **Launch "AI Readiness Assessment" as a FICCI-sponsored tool**
+14. **Expand to additional FICCI/CII state chapters**
+15. **Partner with NASSCOM FutureSkills** for AI training certification
+
+---
+
+## Key Contacts & URLs
+
+| Association | URL | Contact |
+|---|---|---|
+| FICCI | ficci.in | +91-11-23738760-70 |
+| FICCI YLF | youngleadersforum.ficci.in | Through FICCI membership |
+| FICCI FMCG | ficci.in/sector/fmcg | Through FICCI membership |
+| FICCI Retail | ficci.in/sector/retail-internal-trade | Through FICCI membership |
+| CII | cii.in | membership@cii.in |
+| CII Retail | cii.in/sectors.aspx?SectorID=S000000033 | Through CII membership |
+| CII Market Place | ciimarketplace.in | Through CII membership |
+| TiE | tie.org | info@tie.org, +1 408-567-0700 |
+| TiE Mumbai | tie.org/our-chapters/ | Local chapter events |
+| TiE Delhi | tie.org/our-chapters/ | Local chapter events |
+| TiE Bangalore | tie.org/our-chapters/ | Local chapter events |
+| Startup India BHASKAR | startupindia.gov.in/bhaskar | Free registration |
+| Startup India MAARG | maarg.startupindia.gov.in | Free registration |
+| NASSCOM | nasscom.in | membership@nasscom.in |
+| Clutch | clutch.co | Free listing |
+| GoodFirms | goodfirms.co | Free listing |
+
+---
+
+## Final Recommendation
+
+**Focus 80% of your association effort on these three:**
+
+1. **FICCI Young Leaders Forum** — Best warm access to your exact target (10-100 employee SMEs, D2C, FMCG, retail)
+2. **TiE Chapters** — Best startup/D2C founder networking, most active community
+3. **Startup India BHASKAR** — Free, high-volume, direct outreach to 600K+ startups
+
+These three channels give you the best combination of **warm access**, **target relevance**, and **cost-effectiveness** for selling AI Automation Sprints to Indian SMEs.

--- a/docs/company-onboarding-kit.md
+++ b/docs/company-onboarding-kit.md
@@ -1,0 +1,73 @@
+# Guild — Company Onboarding Kit
+
+## Your async ops team. Free while in early access.
+
+Post any task. Get it done by motivated students building real portfolios.  
+You focus on what matters. Guild handles the rest.
+
+---
+
+## What can you outsource?
+
+Anything you'd otherwise give to a junior hire, intern, or freelancer.
+
+| Category | Example tasks |
+|----------|--------------|
+| **Content** | Blog posts, social media captions, video scripts, email newsletters, product descriptions |
+| **Research** | Market research, competitor analysis, prospect lists, industry reports, pricing benchmarks |
+| **Design** | Social media graphics, pitch deck slides, banner ads, brand asset creation |
+| **Data** | Data entry, spreadsheet cleanup, CRM updates, lead list building, database formatting |
+| **Tech** | QA testing, bug reports, documentation, code reviews, basic scripting |
+| **Marketing ops** | Outreach drafts, campaign assets, SEO keyword lists, content calendars |
+| **Admin** | Vendor comparisons, SOP writing, meeting notes, research summaries |
+
+**Rule of thumb:** If it takes under a week and doesn't require a live conversation — it's a good quest.
+
+---
+
+## How to post your first quest (5 minutes)
+
+1. **Sign up** at [guilds.work](https://guilds.work) as a Company account
+2. **Create a Quest** — fill in:
+   - What you need done (be specific — see examples below)
+   - What "done" looks like (your acceptance criteria)
+   - Deadline
+3. **Students apply and get assigned** — you review the shortlist
+4. **Work gets delivered** — you approve or request revisions
+5. **Done.** Zero cost during early access.
+
+---
+
+## Writing a quest that gets great results
+
+**Too vague ✗**
+> "Help with our social media"
+
+**Clear and specific ✓**
+> "Write 10 Instagram captions for our SaaS product launch. Tone: friendly, direct, no jargon. Each caption under 150 characters with a call to action. Deliver as a Google Doc."
+
+**The formula:** `[What] + [Format/volume] + [Tone/context] + [How to deliver]`
+
+---
+
+## What to expect
+
+- **Turnaround:** 3–7 days for most tasks
+- **Students:** Motivated undergrads and recent grads building real experience — they treat your work like a portfolio piece
+- **Revisions:** You can request one round of revisions before approving
+- **Updates:** You get progress updates via the platform — no need to chase anyone
+
+---
+
+## Early access model
+
+Guild is in early access. Right now: **free for all companies.**
+
+We're building our student network and proven track record. In exchange, you get real work done at zero cost. Early companies who see results will move to a paid tier when we launch — you'll get first-mover pricing.
+
+---
+
+## Get started
+
+Sign up → [guilds.work](https://guilds.work)  
+Questions → abid@guilds.work

--- a/docs/superpowers/plans/2026-06-11-quest-edit-admin-bypass-progress.md
+++ b/docs/superpowers/plans/2026-06-11-quest-edit-admin-bypass-progress.md
@@ -1,0 +1,201 @@
+# Quest Edit & Admin Bypass — Complete Context
+
+**Branch:** `fix/quest-edit-admin-bypass` (from `main`)
+**Started:** 2026-06-11
+**Status:** COMPLETE — 1 commit, build + lint pass, PR created
+
+---
+
+## THE PROBLEM (What Was Broken)
+
+Companies who posted a quest couldn't edit it. The root cause was a **stack of 3 overlapping bugs**, not one broken button:
+
+1. **Auth/session instability** — NextAuth JWT token resolution is fragile (multiple cookie mode fallbacks in middleware + api-auth). When token fails, every company mutation looks "broken" from the UI. This is a pre-existing issue, not introduced by this fix.
+
+2. **Admin authorization bug** — PUT/DELETE handlers in `app/api/company/quests/route.ts` used `companyId = authUser.id` with no admin bypass. Admins could reach company quest surfaces but always 403'd on edit/cancel because `quest.companyId !== authUser.id` (admin has no companyId).
+
+3. **Create/edit contract mismatch** — Quest creation supports `fieldTemplateId`, `briefData`, `acceptanceCriteria`, `partnerOrgName`, `track`, `source`. The edit screen didn't load or submit most of these fields. The PUT allowlist was out of sync with the actual schema (had non-schema fields, missing schema fields).
+
+---
+
+## ALL FILES AUDITED (Full list of ownership-check patterns)
+
+### Files with `companyId` ownership checks (all reviewed):
+| File | Lines | Status |
+|------|-------|--------|
+| `app/api/company/quests/route.ts` | 168, 223 | ✅ FIXED |
+| `app/api/quests/[id]/assignments/route.ts` | 30, 92 | ✅ Already correct (has admin bypass) |
+| `app/api/quests/[id]/revisions/route.ts` | 42, 115 | ✅ Already correct (has admin bypass) |
+| `app/api/quests/[id]/route.ts` | 122-123 | ✅ Already correct (has admin bypass) |
+| `app/api/payments/route.ts` | 169, 176 | ✅ Already correct (has admin bypass) |
+| `app/api/qa/reviews/route.ts` | 149 | ✅ Already correct (has admin bypass) |
+| `app/api/quests/submissions/route.ts` | 208-209 | ✅ Already correct (has admin bypass) |
+| `app/dashboard/company/quests/[id]/edit/page.tsx` | 104 | ✅ FIXED (added fields) |
+| `lib/services/quest-service.ts` | 93 | ✅ Already correct |
+| `lib/services/assignment-service.ts` | 158 | ✅ Already correct (has admin bypass) |
+| `components/PaymentProcessor.tsx` | 68 | Client-side check only, not a blocker |
+
+### Files with `user.role !== 'admin'` checks (all reviewed):
+| File | Lines | Status |
+|------|-------|--------|
+| `app/admin/layout.tsx` | 18 | ✅ Admin-only layout, correct |
+| `app/dashboard/company/quests/[id]/page.tsx` | 88 | ✅ Already correct (allows admin) |
+| `app/dashboard/company/quests/page.tsx` | 70 | ✅ Already correct (allows admin) |
+| `app/api/quests/assignments/route.ts` | 31 | ✅ Already correct (adventurer + admin) |
+| `app/api/quests/submissions/route.ts` | 119 | ✅ Already correct (has admin bypass) |
+| `app/api/parties/[id]/members/route.ts` | 79 | ✅ Already correct (has admin bypass) |
+
+### Key Finding:
+**Most files already have correct admin bypasses.** The only broken ones were in `app/api/company/quests/route.ts` (PUT/DELETE/GET) — the ownership check used `companyId = authUser.id` with no `isOwner` flag.
+
+---
+
+## WHAT WAS FIXED (1 commit)
+
+### Commit: `3062fac` — Company quest edit flow fixes
+
+**`app/api/company/quests/route.ts`** — 3 fixes:
+
+1. **GET** — Admin quest list:
+   - Before: `where = { companyId: authUser.id }` → admins got empty list
+   - After: `isOwner = authUser.role === 'company'`, `where = isOwner ? { companyId: ownerCompanyId } : {}`
+
+2. **PUT** — Admin bypass + allowlist sync:
+   - Before: `if (!quest || quest.companyId !== companyId)` → admins always 403
+   - After: `isOwner` flag, only check ownership when `role === 'company'`
+   - Before allowlist: `submissionInstructions`, `expectedDeliverables` (non-schema), missing `fieldTemplateId`, `briefData`, `acceptanceCriteria`, `parentQuestId`
+   - After allowlist: synced to Quest model exactly
+
+3. **DELETE** — Admin bypass:
+   - Before: `if (!quest || quest.companyId !== companyId)` → admins always 403
+   - After: `isOwner` flag, only check ownership when `role === 'company'`
+
+**`app/dashboard/company/quests/[id]/edit/page.tsx`** — 3 fixes:
+
+1. **State** — Added `partnerOrgName`, `track`, `source` to form state
+2. **Pre-fill** — Loading those fields from fetched quest data
+3. **UI** — Added Track/Source/Partner Org Name fields (3-column grid)
+4. **Submit** — Sending those fields in PUT body
+5. **Interface** — Added fields to `QuestData` interface
+
+**`lib/services/quest-service.ts:42`** — 1 fix:
+
+- Company visibility: `OR: [{ companyId: user.id }, { status: 'available', track: 'OPEN' }]`
+- → `OR: [{ companyId: user.id }, { companyId: null, status: 'available', track: 'OPEN' }]`
+- Explicit `companyId: null` for public quests prevents accidentally matching company-owned quests with wrong status
+
+---
+
+## SIMILAR PATTERNS FOUND (Already Correct)
+
+These files have the **same ownership-check smell** but were already correctly implemented with admin bypass:
+
+```typescript
+// app/api/quests/[id]/assignments/route.ts:30,92
+if (user.role !== 'admin' && quest.companyId !== user.id) { ... }
+// ✅ Correct — admin bypass present
+
+// app/api/quests/[id]/revisions/route.ts:42,115
+if (user.role !== 'admin' && quest.companyId !== user.id) { ... }
+// ✅ Correct — admin bypass present
+
+// app/api/payments/route.ts:169,176
+if (authUser.role !== 'admin' && quest.companyId !== authUser.id) { ... }
+// ✅ Correct — admin bypass present
+
+// app/api/qa/reviews/route.ts:149
+if (authUser.role !== 'admin' && existingSubmission.assignment.quest?.companyId !== authUser.id) { ... }
+// ✅ Correct — admin bypass present
+
+// app/api/quests/submissions/route.ts:208-209
+if (user.role !== 'admin' && ...) { ... }
+// ✅ Correct — admin bypass present
+```
+
+### The Pattern That Was Broken (in company/quests/route.ts):
+```typescript
+// BEFORE — broken:
+const companyId = authUser.id;
+if (!quest || quest.companyId !== companyId) { ... }
+// Admins have no companyId, so this always fails for them
+
+// AFTER — fixed:
+const isOwner = authUser.role === 'company';
+const ownerCompanyId = authUser.id;
+if (isOwner && quest.companyId !== ownerCompanyId) { ... }
+// Admins skip the ownership check entirely
+```
+
+---
+
+## WHAT REMAINS (Known Issues Not Fixed)
+
+### 1. Auth/session instability (pre-existing)
+- NextAuth JWT token resolution is fragile
+- Middleware has 5 fallback attempts for token retrieval
+- API routes have similar fallbacks
+- When token fails, every company mutation looks "broken"
+- **Not fixed in this PR** — requires separate investigation into NextAuth v4 + Next.js 15 edge runtime compatibility
+- **Affected files:** `lib/auth.ts`, `middleware.ts`, `lib/api-auth.ts`
+
+### 2. Company quest detail page ownership check (client-side only)
+- `app/dashboard/company/quests/[id]/page.tsx:88` — `session?.user?.role !== 'company' && session?.user?.role !== 'admin'`
+- ✅ Already correct — allows admin
+
+### 3. No admin UI for managing quests
+- Admins can now edit/cancel quests via API, but there's no dedicated admin UI for this
+- The `/dashboard/company/quests/[id]` page is accessible to admins but shows company-specific UI
+- **Not a bug, just a missing feature**
+
+---
+
+## PRs CREATED
+
+### PR #286 — Responsive mobile layout fixes
+- **Branch:** `fix/responsive-mobile-layout`
+- **URL:** https://github.com/LarytheLord/Adventurers-Guild/pull/286
+- **3 commits:** core layout, responsive grids, remaining fixes + cleanup
+- **Status:** Created, not yet merged
+
+### PR — Quest edit admin bypass
+- **Branch:** `fix/quest-edit-admin-bypass`
+- **URL:** https://github.com/LarytheLord/Adventurers-Guild/pull/new/fix/quest-edit-admin-bypass
+- **1 commit:** admin bypass + allowlist sync + visibility
+- **Status:** Created, not yet merged
+
+---
+
+## VERIFICATION
+
+- `npm run build` ✅ passes
+- `npm run lint` ✅ no errors (all warnings are pre-existing)
+- No changes to `main` branch
+- Both fix branches created from clean `main`
+
+---
+
+## HOW TO CONTINUE
+
+```bash
+# To review the quest edit fixes:
+git checkout fix/quest-edit-admin-bypass
+git diff main...HEAD
+
+# To review the responsive fixes:
+git checkout fix/responsive-mobile-layout
+git diff main...HEAD
+
+# To merge either PR:
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+---
+
+## KEY CONTEXT
+
+- **Framework:** Next.js 15 (App Router), React 18, TypeScript
+- **Auth:** NextAuth v4, JWT strategy, Credentials + GitHub + Google providers
+- **DB:** Neon PostgreSQL via Prisma 6
+- **Roles:** adventurer, company, admin
+- **Admin rules:** Admin has NO CompanyProfile, skip companyProfile.update for admin
+- **Design:** Orange-500 primary, 5-level grayscale, rank colors in RankBadge only

--- a/lib/quest-access.ts
+++ b/lib/quest-access.ts
@@ -68,29 +68,16 @@ export function getQuestAccessStatus(
   userRank: UserRank,
   questRequiredRank: UserRank | null | undefined
 ): QuestAccessStatus {
-  // Default: null or undefined requiredRank means accessible to all (legacy quests)
-  if (!questRequiredRank) {
-    return {
-      canAccess: true,
-      isVisible: true,
-    };
-  }
+  // Temporary: all quests open to all ranks during early platform growth
+  return { canAccess: true, isVisible: true };
 
-  const userOrder = RANK_ORDER[userRank];
-  const questOrder = RANK_ORDER[questRequiredRank];
-
-  // Can access if user rank >= quest required rank (higher order = stronger)
-  const canAccess = userOrder >= questOrder;
-
-  // Can see if user rank >= (quest required rank - 1)
-  // i.e., can see 1 rank above
-  const isVisible = userOrder >= questOrder - 1;
-
-  return {
-    canAccess,
-    isVisible,
-    ...(canAccess ? {} : { lockedUntil: questRequiredRank }),
-  };
+  // Original rank-gating logic (re-enable when platform has enough quest volume):
+  // if (!questRequiredRank) return { canAccess: true, isVisible: true };
+  // const userOrder = RANK_ORDER[userRank];
+  // const questOrder = RANK_ORDER[questRequiredRank];
+  // const canAccess = userOrder >= questOrder;
+  // const isVisible = userOrder >= questOrder - 1;
+  // return { canAccess, isVisible, ...(canAccess ? {} : { lockedUntil: questRequiredRank }) };
 }
 
 /**


### PR DESCRIPTION
## Changes

### 🟢 WhatsApp — better placement
- **Floating sticky button** (bottom-right, fixed position) visible on entire landing page at all scroll depths — green #25D366 with WhatsApp icon
- Updated invite link to full URL with tracking params on both the float and HowItWorks sidebar
- Existing sidebar button restyled to green to match (was white/grey)

### 🟢 Quest gating — open to all ranks
- `lib/quest-access.ts`: all quests now return `{canAccess: true, isVisible: true}` for all users temporarily during early growth phase
- Original rank-gating code is commented in place — one line to re-enable when quest volume grows
- DB: all `available`/`draft` quests set to `required_rank = 'F'`, all expired deadlines cleared

### 🟢 Admin quest management — new controls
- **Inline required-rank selector** on each quest card (change min rank without going to edit page)
- **Clear Deadline button** — appears only when a deadline exists, one click removes it
- **Edit button** now goes to `/dashboard/company/quests/[id]/edit` (direct edit, not view)
- Notes button shows count inline: `Notes (3)`

### 🟢 Leaderboard — real accounts only
- Rankings API: added `isActive: true` filter — deactivated accounts hidden
- DB: all seed/fake accounts (`@example.com`, `@adventurersguild.com`) set to `is_active = false`

### 🟢 Admin account
- DB: `abid@guilds.work` upgraded to A-rank, XP set to 5000

🤖 Generated with [Claude Code](https://claude.com/claude-code)