### PR TITLE
fix: prevent quest slot overbooking

### DIFF
--- a/app/api/quests/[id]/assignments/route.ts
+++ b/app/api/quests/[id]/assignments/route.ts
@@ -119,7 +119,7 @@ export async function PUT(
           const filledCount = await tx.questAssignment.count({
             where: {
               questId: params.id,
-              status: { in: ['started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed'] },
+              status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed'] },
             },
           });
           if (filledCount >= quest.maxParticipants) {

--- a/lib/quest-lifecycle.ts
+++ b/lib/quest-lifecycle.ts
@@ -2,9 +2,10 @@ import { AssignmentStatus, Prisma, PrismaClient, QuestStatus } from '@prisma/cli
 
 const REVIEW_STATUSES: AssignmentStatus[] = ['submitted', 'review', 'pending_admin_review'];
 
-// Statuses that mean a company has accepted the adventurer (slot is filled)
+// Statuses that count as a filled slot (claimed or accepted).
+// 'assigned' is included so a claimed-but-not-started slot still blocks others from over-booking.
 const FILLED_STATUSES: AssignmentStatus[] = [
-  'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed',
+  'assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed',
 ];
 
 function deriveQuestStatus(

--- a/lib/services/assignment-service.ts
+++ b/lib/services/assignment-service.ts
@@ -91,11 +91,11 @@ export async function applyToQuest(questId: string, user: SessionUser, tx: Prism
           const filledCount = await tx.questAssignment.count({
             where: {
               questId,
-              status: { in: ['started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed'] },
+              status: { in: ['assigned', 'started', 'in_progress', 'submitted', 'pending_admin_review', 'review', 'needs_rework', 'completed'] },
             },
           });
           if (filledCount >= quest.maxParticipants) {
-            throw new Error('Maximum participants reached for this quest');
+            throw new Error('This quest is full — all slots have been claimed');
           }
         }
 
@@ -118,7 +118,7 @@ export async function applyToQuest(questId: string, user: SessionUser, tx: Prism
     return { data: assignment, error: null, status: 200 };
   } catch (error) {
     const msg = error instanceof Error ? error.message : '';
-    if (msg === 'Maximum participants reached for this quest') {
+    if (msg === 'This quest is full — all slots have been claimed') {
       return { data: null, error: msg, status: 400 };
     }
     console.error('Error applying to quest:', error);


### PR DESCRIPTION
## Summary
- `assigned` status was excluded from slot counts in quest lifecycle and the claim endpoint, so quest appeared `available` even when all slots were claimed
- Multiple students could claim a 1-slot quest simultaneously — the over-booking wasn't caught until someone clicked Start Quest
- Students hitting the quest after it was (correctly) full got a confusing "Maximum participants reached" error that appeared to happen during submission

## What changed
- `lib/quest-lifecycle.ts` — added `assigned` to `FILLED_STATUSES` so quest transitions to `in_progress` as soon as all slots are claimed, not just started
- `lib/services/assignment-service.ts` — slot check in `applyToQuest()` now counts `assigned` assignments; improved error message to "This quest is full — all slots have been claimed"
- `app/api/quests/[id]/assignments/route.ts` — same fix applied to the company accept endpoint slot guard for consistency

## Test plan
- [ ] All 45 existing tests pass (`npm test`)
- [ ] Claim a quest with 1 slot — a second student trying to claim should see "This quest is full — all slots have been claimed"
- [ ] Quest status flips to `in_progress` immediately when all slots are claimed (not after first Start Quest click)
- [ ] Student with existing `assigned` status on an over-booked quest can still click Start Quest and submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)