### PR TITLE
fix: secure email change requires password re-verification (#332)

### DIFF
--- a/app/api/user/update-email/route.ts
+++ b/app/api/user/update-email/route.ts
@@ -1,0 +1,180 @@
+// app/api/user/update-email/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import nodemailer from 'nodemailer';
+
+const supabase = createClient(
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+function generateVerificationToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { currentPassword, newEmail } = body;
+
+    if (!currentPassword || !newEmail) {
+      return NextResponse.json(
+        { error: 'Missing required fields: currentPassword and newEmail' },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidEmail(newEmail)) {
+      return NextResponse.json(
+        { error: 'Invalid email format' },
+        { status: 400 }
+      );
+    }
+
+    const { data: authUser, error: authError } = await supabase.auth.admin.getUserById(session.user.id);
+    if (authError || !authUser.user) {
+      throw new Error('Failed to retrieve user');
+    }
+
+    const oldEmail = authUser.user.email;
+
+    if (newEmail.toLowerCase() === oldEmail?.toLowerCase()) {
+      return NextResponse.json(
+        { error: 'New email must be different from current email' },
+        { status: 400 }
+      );
+    }
+
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: oldEmail!,
+      password: currentPassword
+    });
+
+    if (signInError) {
+      console.error('Password verification failed:', signInError.message);
+      return NextResponse.json(
+        { error: 'Incorrect password' },
+        { status: 403 }
+      );
+    }
+
+    await supabase.auth.signOut();
+
+    const { data: pendingRequests } = await supabase
+      .from('email_change_requests')
+      .select('id')
+      .eq('user_id', session.user.id)
+      .eq('status', 'pending')
+      .gt('expires_at', new Date().toISOString());
+
+    if (pendingRequests && pendingRequests.length > 0) {
+      return NextResponse.json(
+        { error: 'A pending email change request already exists. Please complete the verification first.' },
+        { status: 409 }
+      );
+    }
+
+    const verificationToken = generateVerificationToken();
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    const { error: insertError } = await supabase
+      .from('email_change_requests')
+      .insert([{
+        user_id: session.user.id,
+        old_email: oldEmail!,
+        new_email: newEmail,
+        current_password_hash: 'verified',
+        verification_token: verificationToken,
+        status: 'pending',
+        expires_at: expiresAt.toISOString()
+      }]);
+
+    if (insertError) {
+      console.error('Failed to create email change request:', insertError);
+      return NextResponse.json(
+        { error: 'Failed to initiate email change' },
+        { status: 500 }
+      );
+    }
+
+    try {
+      const verificationLink = `${env.NEXT_PUBLIC_APP_URL || request.headers.get('origin')}/api/user/verify-email-change?token=${verificationToken}`;
+
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST || 'smtp.gmail.com',
+        port: parseInt(process.env.SMTP_PORT || '587'),
+        secure: process.env.SMTP_PORT === '465',
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
+        tls: { rejectUnauthorized: false }
+      });
+
+      await transporter.sendMail({
+        from: `"The Adventurers Guild" <${process.env.SMTP_USER}>`,
+        to: oldEmail!,
+        subject: 'Confirm Your Email Change Request',
+        html: `
+          <!DOCTYPE html>
+          <html>
+          <head><title>Email Change Confirmation</title></head>
+          <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #667eea, #764ba2); color: white; padding: 30px; border-radius: 12px; text-align: center;">
+              <h1 style="margin: 0;">🛡️ Email Change Request</h1>
+            </div>
+            <div style="background: #fff3cd; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #ffc107;">
+              <p style="margin: 0; color: #856404;"><strong>Security Notice:</strong> Someone (hopefully you) requested to change the email address for this account.</p>
+            </div>
+            <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+              <p><strong>Current Email:</strong> ${oldEmail}</p>
+              <p><strong>New Email:</strong> ${newEmail}</p>
+            </div>
+            <div style="text-align: center; margin: 30px 0;">
+              <a href="${verificationLink}" style="background: #667eea; color: white; padding: 14px 32px; border-radius: 6px; text-decoration: none; font-size: 16px; display: inline-block;">Confirm Email Change</a>
+            </div>
+            <p style="text-align: center; color: #666; font-size: 14px;">
+              If you did not request this change, please ignore this email. The request will expire in 24 hours.
+            </p>
+            <p style="text-align: center; color: #999; font-size: 12px; margin-top: 30px;">
+              This link expires in 24 hours. If you need to change your email again, you'll need to request a new verification.
+            </p>
+          </body>
+          </html>
+        `
+      });
+    } catch (emailError) {
+      console.error('Failed to send verification email:', emailError);
+    }
+
+    return NextResponse.json({
+      message: 'Verification email sent to your current email address',
+      success: true
+    }, { status: 200 });
+
+  } catch (error) {
+    console.error('Email change request error:', error);
+    return NextResponse.json(
+      { error: 'Failed to process email change request' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/user/verify-email-change/route.ts
+++ b/app/api/user/verify-email-change/route.ts
@@ -1,0 +1,155 @@
+// app/api/user/verify-email-change/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import nodemailer from 'nodemailer';
+import { createNotification } from '@/lib/notification-utils';
+
+const supabase = createClient(
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const token = searchParams.get('token');
+
+    if (!token) {
+      return new NextResponse(
+        `<html><body style="font-family: Arial; text-align: center; padding: 50px;"><h1 style="color: red;">Missing verification token</h1><p>Please use the link from your email.</p></body></html>`,
+        { status: 400, headers: { 'Content-Type': 'text/html' } }
+      );
+    }
+
+    const { data: requestRecord, error: fetchError } = await supabase
+      .from('email_change_requests')
+      .select('*')
+      .eq('verification_token', token)
+      .eq('status', 'pending')
+      .single();
+
+    if (fetchError || !requestRecord) {
+      return new NextResponse(
+        `<html><body style="font-family: Arial; text-align: center; padding: 50px;"><h1 style="color: red;">Invalid or expired verification link</h1><p>This link is no longer valid. Please request a new email change.</p></body></html>`,
+        { status: 400, headers: { 'Content-Type': 'text/html' } }
+      );
+    }
+
+    const expiresAt = new Date(requestRecord.expires_at);
+    if (expiresAt < new Date()) {
+      await supabase
+        .from('email_change_requests')
+        .update({ status: 'expired' })
+        .eq('id', requestRecord.id);
+
+      return new NextResponse(
+        `<html><body style="font-family: Arial; text-align: center; padding: 50px;"><h1 style="color: red;">Verification link expired</h1><p>This link expired on ${expiresAt.toLocaleString()}. Please request a new email change.</p></body></html>`,
+        { status: 400, headers: { 'Content-Type': 'text/html' } }
+      );
+    }
+
+    const userId = requestRecord.user_id;
+    const oldEmail = requestRecord.old_email;
+    const newEmail = requestRecord.new_email;
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(userId, {
+      email: newEmail
+    });
+
+    if (updateAuthError) {
+      console.error('Failed to update email in auth:', updateAuthError);
+      return new NextResponse(
+        `<html><body style="font-family: Arial; text-align: center; padding: 50px;"><h1 style="color: red;">Failed to update email</h1><p>An error occurred while changing your email. Please try again or contact support.</p></body></html>`,
+        { status: 500, headers: { 'Content-Type': 'text/html' } }
+      );
+    }
+
+    await supabase
+      .from('email_change_requests')
+      .update({
+        status: 'confirmed',
+        confirmed_at: new Date().toISOString()
+      })
+      .eq('id', requestRecord.id);
+
+    await supabase
+      .from('email_change_requests')
+      .update({ status: 'cancelled' })
+      .eq('user_id', userId)
+      .eq('status', 'pending')
+      .neq('id', requestRecord.id);
+
+    try {
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST || 'smtp.gmail.com',
+        port: parseInt(process.env.SMTP_PORT || '587'),
+        secure: process.env.SMTP_PORT === '465',
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
+        tls: { rejectUnauthorized: false }
+      });
+
+      await transporter.sendMail({
+        from: `"The Adventurers Guild" <${process.env.SMTP_USER}>`,
+        to: newEmail,
+        subject: 'Email Changed Successfully - The Adventurers Guild',
+        html: `
+          <!DOCTYPE html>
+          <html>
+          <head><title>Email Changed Successfully</title></head>
+          <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #667eea, #764ba2); color: white; padding: 30px; border-radius: 12px; text-align: center;">
+              <h1 style="margin: 0;">✅ Email Changed Successfully</h1>
+            </div>
+            <div style="background: #d4edda; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #28a745;">
+              <p style="margin: 0; color: #155724;"><strong>Your email address has been updated.</strong></p>
+            </div>
+            <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+              <p><strong>Old Email:</strong> ${oldEmail}</p>
+              <p><strong>New Email:</strong> ${newEmail}</p>
+              <p><strong>Changed At:</strong> ${new Date().toLocaleString()}</p>
+            </div>
+            <p style="text-align: center; color: #666; font-size: 14px;">
+              If you did not make this change, please contact support immediately.
+            </p>
+          </body>
+          </html>
+        `
+      });
+    } catch (emailError) {
+      console.error('Failed to send confirmation email:', emailError);
+    }
+
+    try {
+      await createNotification(
+        userId,
+        'Email Changed Successfully',
+        `Your email has been changed from ${oldEmail} to ${newEmail}.`,
+        'email_change_confirmed',
+        { oldEmail, newEmail }
+      );
+    } catch (notifError) {
+      console.error('Failed to create notification:', notifError);
+    }
+
+    return new NextResponse(
+      `<html><body style="font-family: Arial; text-align: center; padding: 50px;">
+        <h1 style="color: green;">✅ Email Changed Successfully!</h1>
+        <p>Your email has been updated from <strong>${oldEmail}</strong> to <strong>${newEmail}</strong>.</p>
+        <p>A confirmation email has been sent to your new address.</p>
+        <p style="margin-top: 30px;"><a href="${env.NEXT_PUBLIC_APP_URL || '/'}">Return to Home</a></p>
+      </body></html>`,
+      { status: 200, headers: { 'Content-Type': 'text/html' } }
+    );
+
+  } catch (error) {
+    console.error('Email verification error:', error);
+    return new NextResponse(
+      `<html><body style="font-family: Arial; text-align: center; padding: 50px;"><h1 style="color: red;">An error occurred</h1><p>Please try again or contact support.</p></body></html>`,
+      { status: 500, headers: { 'Content-Type': 'text/html' } }
+    );
+  }
+}

--- a/lib/notification-utils.ts
+++ b/lib/notification-utils.ts
@@ -220,3 +220,48 @@ export async function sendTeamInviteNotification(
     { teamName, inviterName }
   );
 }
+
+// Send email change requested notification
+export async function sendEmailChangeRequestedNotification(
+  userId: string,
+  oldEmail: string,
+  newEmail: string
+): Promise<void> {
+  await createNotification(
+    userId,
+    'Email Change Requested',
+    `A request to change your email from ${oldEmail} to ${newEmail} has been submitted. Check your email to confirm.`,
+    'email_change_requested',
+    { oldEmail, newEmail }
+  );
+}
+
+// Send email change confirmed notification
+export async function sendEmailChangeConfirmedNotification(
+  userId: string,
+  oldEmail: string,
+  newEmail: string
+): Promise<void> {
+  await createNotification(
+    userId,
+    'Email Changed Successfully',
+    `Your email has been changed from ${oldEmail} to ${newEmail}.`,
+    'email_change_confirmed',
+    { oldEmail, newEmail }
+  );
+}
+
+// Send email change cancelled notification
+export async function sendEmailChangeCancelledNotification(
+  userId: string,
+  oldEmail: string,
+  newEmail: string
+): Promise<void> {
+  await createNotification(
+    userId,
+    'Email Change Cancelled',
+    `The pending email change from ${oldEmail} to ${newEmail} has been cancelled.`,
+    'email_change_cancelled',
+    { oldEmail, newEmail }
+  );
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -12,7 +12,7 @@ create type quest_category as enum ('frontend', 'backend', 'fullstack', 'mobile'
 create type assignment_status as enum ('assigned', 'started', 'in_progress', 'submitted', 'review', 'completed', 'cancelled');
 create type submission_status as enum ('pending', 'under_review', 'approved', 'needs_rework', 'rejected');
 create type team_role as enum ('owner', 'admin', 'member');
-create type notification_type as enum ('quest_assigned', 'quest_updated', 'quest_completed', 'quest_reviewed', 'new_message', 'rank_up', 'skill_unlocked', 'team_invite', 'payment_received', 'system_message');
+create type notification_type as enum ('quest_assigned', 'quest_updated', 'quest_completed', 'quest_reviewed', 'new_message', 'rank_up', 'skill_unlocked', 'team_invite', 'payment_received', 'system_message', 'email_change_requested', 'email_change_confirmed', 'email_change_cancelled');
 create type verification_type as enum ('company', 'identity', 'skill', 'portfolio');
 create type verification_status as enum ('pending', 'approved', 'rejected', 'in_review');
 
@@ -221,6 +221,24 @@ create table if not exists public.quest_completions (
     quality_score integer check (quality_score >= 1 and quality_score <= 10),
     unique(quest_id, user_id)
 );
+
+-- Email change requests for secure email updates
+create table if not exists public.email_change_requests (
+    id uuid default uuid_generate_v4() primary key,
+    user_id uuid references public.users on delete cascade not null,
+    old_email text not null,
+    new_email text not null,
+    current_password_hash text not null,
+    verification_token text not null unique,
+    status text check (status in ('pending', 'confirmed', 'expired', 'cancelled')) default 'pending',
+    expires_at timestamp with time zone not null,
+    created_at timestamp with time zone default timezone('utc'::text, now()),
+    confirmed_at timestamp with time zone
+);
+
+create index if not exists idx_email_change_requests_user_id on public.email_change_requests(user_id);
+create index if not exists idx_email_change_requests_token on public.email_change_requests(verification_token);
+create index if not exists idx_email_change_requests_status on public.email_change_requests(status);
 
 -- Enable Row Level Security (RLS) for all tables
 alter table public.users enable row level security;


### PR DESCRIPTION
## Issue: #332 - Email change requires no re-auth or old-email confirmation

### Security Fix

The email change flow had a critical vulnerability: any authenticated session could change the account email immediately without:
- No confirmation sent to the **old** email address
- No **password re-verification**
- No cooldown period

### What was built

**/api/user/update-email (POST)** - Request email change
- Requires currentPassword + 
ewEmail in request body
- Re-authenticates user via Supabase signInWithPassword (verifies current password)
- Validates new email format and ensures it differs from current
- Checks for pending email change requests (one-at-a-time enforcement)
- Generates random erification_token, stores in email_change_requests table with 24h expiry
- Sends verification email to the **old** email address with confirmation link
- Returns 200 with verification sent message

**/api/user/verify-email-change (GET)** - Confirm email change via token
- Accepts ?token=xxx from the verification email link
- Validates token exists, is pending, and not expired
- Calls Supabase uth.admin.updateUserById() to actually change the email
- Marks the request as confirmed, cancels other pending requests
- Sends confirmation email to the **new** email address
- Creates an email_change_confirmed notification
- Returns an HTML success page

**Schema changes:**
- Added email_change_requests table with erification_token, status, expires_at fields
- Added 3 new notification types: email_change_requested, email_change_confirmed, email_change_cancelled
- Added 3 notification utility functions

### Attack scenario prevented

Before: Attacker steals session token -> changes email to their own -> owns account permanently
After: Attacker must also know the current password AND have access to the old email inbox