### PR TITLE
fix: secure admin endpoints and lifecycle sync (#316 #330 #342)

### DIFF
--- a/app/api/admin/missed-updates/route.ts
+++ b/app/api/admin/missed-updates/route.ts
@@ -1,19 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { getAuthUser } from '@/lib/api-auth';
+import { requireAuth } from '@/lib/api-auth';
 
 export async function GET(request: NextRequest) {
-  const user = await getAuthUser(request);
-  if (!user || (user.role !== 'admin' && user.role !== 'company')) {
+  const user = await requireAuth(request, 'admin');
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
   }
 
   try {
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    // Build the query to find started/in-progress quest assignments that have missed a 24-hour update window.
-    // That means status is in ['started', 'in_progress', 'needs_rework'] and:
-    // (lastUpdateAt < oneDayAgo OR (lastUpdateAt IS NULL AND startedAt < oneDayAgo))
     const where: any = {
       status: { in: ['started', 'in_progress', 'needs_rework'] },
       startedAt: { not: null },
@@ -27,11 +24,6 @@ export async function GET(request: NextRequest) {
         }
       ]
     };
-
-    // If company role, filter assignments by company's quests
-    if (user.role === 'company') {
-      where.quest = { companyId: user.id };
-    }
 
     const assignments = await prisma.questAssignment.findMany({
       where,
@@ -49,7 +41,6 @@ export async function GET(request: NextRequest) {
             email: true,
             adventurerProfile: {
               select: {
-                phoneNumber: true,
                 guildScore: true,
               },
             },
@@ -74,7 +65,6 @@ export async function GET(request: NextRequest) {
         studentId: ass.user.id,
         studentName: ass.user.name || 'Unknown',
         studentEmail: ass.user.email,
-        studentPhone: ass.user.adventurerProfile?.phoneNumber || '',
         guildScore: ass.user.adventurerProfile?.guildScore ?? 100,
         lastUpdateAt: ass.lastUpdateAt,
         startedAt: ass.startedAt,

--- a/app/api/admin/qa-queue/[assignmentId]/route.ts
+++ b/app/api/admin/qa-queue/[assignmentId]/route.ts
@@ -246,27 +246,28 @@ export async function PATCH(
   };
   const updatedNotes = [...existingNotes, newNote];
 
-  await prisma.$transaction([
-    prisma.questAssignment.update({
+  await prisma.$transaction(async (tx) => {
+    await tx.questAssignment.update({
       where: { id: assignmentId },
       data: { status: 'needs_rework' },
-    }),
-    prisma.quest.update({
+    });
+    await tx.quest.update({
       where: { id: assignment.quest.id },
       data: { revisionCount: { increment: 1 } },
-    }),
-    ...(latestSubmission
-      ? [prisma.questSubmission.update({
-          where: { id: latestSubmission.id },
-          data: {
-            reviewNotes: updatedNotes,
-            reviewerId: adminId,
-            reviewedAt: new Date(),
-            ...(criteriaJson !== undefined ? { criteriaResults: criteriaJson } : {}),
-          },
-        })]
-      : []),
-  ]);
+    });
+    if (latestSubmission) {
+      await tx.questSubmission.update({
+        where: { id: latestSubmission.id },
+        data: {
+          reviewNotes: updatedNotes,
+          reviewerId: adminId,
+          reviewedAt: new Date(),
+          ...(criteriaJson !== undefined ? { criteriaResults: criteriaJson } : {}),
+        },
+      });
+    }
+    await syncQuestLifecycleStatus(tx, assignment.quest.id);
+  });
 
   return NextResponse.json({ message: 'Submission rejected — returned to student for revision', success: true });
 }

--- a/app/api/errors/log/route.ts
+++ b/app/api/errors/log/route.ts
@@ -21,14 +21,12 @@ export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('authorization') || '';
   const providedKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
 
-  if (process.env.NODE_ENV === 'production') {
-    if (!env.ERROR_LOG_API_KEY || providedKey !== env.ERROR_LOG_API_KEY) {
+  if (!env.ERROR_LOG_API_KEY || providedKey !== env.ERROR_LOG_API_KEY) {
       return NextResponse.json(
         { success: false, error: 'Unauthorized' },
         { status: 401 }
       );
     }
-  }
 
   try {
     const errorLog = await request.json();


### PR DESCRIPTION
## Fixes

### #342 - /api/errors/log authentication
- ERROR_LOG_API_KEY is now required in all environments, not only production
- Keeps existing rate limiting, field caps, timestamp validation, and severity whitelist

### #330 - Admin QA reject lifecycle sync
- Replaced array-form transaction in admin QA reject path with callback-form transaction
- Calls syncQuestLifecycleStatus(tx, assignment.quest.id) after moving assignment to 
eeds_rework
- Prevents quest status from staying stuck in review after admin rejection

### #316 - Missed-updates PII exposure
- Changed /api/admin/missed-updates to admin-only via equireAuth(request, 'admin')
- Removed company role access
- Removed phoneNumber from Prisma select and removed studentPhone from response

### Security Impact
- Blocks unauthenticated error log flooding
- Prevents company-role access to student missed-update data
- Removes student phone PII from the missed-updates response