### PR TITLE
fix: resolve 6 bugs (#414, #416, #415, #413, #327, #261)

### DIFF
--- a/app/api/payments/razorpay/contact/route.ts
+++ b/app/api/payments/razorpay/contact/route.ts
@@ -74,15 +74,11 @@ export async function POST(req: NextRequest) {
         // Create or retrieve Razorpay Contact
         let contactId = adventurer.razorpayContactId;
         if (!contactId) {
-          // TODO: Add phone field to User model and pass real value from profile.
-          // For now, using a placeholder. This is acceptable for MVP but should be fixed.
-          const placeholderPhone = '9999999999';
-          console.warn(`[Razorpay] Using placeholder phone number for user ${adventurer.userId}. Please implement phone collection.`);
-
+          const phone = adventurer.user.phone || '9999999999';
           const contact = await createRazorpayContact({
             name,
             email: adventurer.user.email,
-            contact: placeholderPhone,
+            contact: phone,
             referenceId: adventurer.userId,
           });
           contactId = contact.id;

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -75,6 +75,7 @@ export async function PATCH(request: NextRequest) {
     if (typeof body.github === 'string') userUpdate.github = body.github.trim() || null;
     if (typeof body.linkedin === 'string') userUpdate.linkedin = body.linkedin.trim() || null;
     if (typeof body.discord === 'string') userUpdate.discord = body.discord.trim() || null;
+    if (typeof body.phone === 'string') userUpdate.phone = body.phone.trim() || null;
 
     if (Object.keys(userUpdate).length === 0) {
       return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });

--- a/prisma/migrations/20260710150000_add_phone_field/migration.sql
+++ b/prisma/migrations/20260710150000_add_phone_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "phone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,7 @@ model User {
   github           String?
   linkedin         String?
   avatar           String?
+  phone            String? @map("phone")
   mentorEligible   Boolean   @default(false) @map("mentor_eligible")
   mentorTier       Int?      @map("mentor_tier") // 1 = junior (D-Rank+), 2 = senior (staff)
   mentorBadgeCount Int       @default(0) @map("mentor_badge_count")


### PR DESCRIPTION
Fixes #414, #416, #415, #413, #327, #261

## Fixes

### #414 — Leaderboard sorting jitters when refreshing
- \^Gpp/api/rankings/route.ts\: Added \id: 'asc'\ as secondary \orderBy\ for adventurer rankings
- Ensures stable sort order when users have equal XP/level/skillPoints

### #416 / #330 — Admin QA queue approve/reject fails silently
- \^Gpp/api/admin/qa-queue/[assignmentId]/route.ts\: Added \syncQuestLifecycleStatus()\ call after approve action
- Fixed reject path: replaced \eturn;\ early exits with conditional \if\ blocks so rejection always completes regardless of whether quest is TUTORIAL or user has bootcampLink

### #415 — Disabled quest templates cannot be re-enabled via UI
- \^Gpp/admin/quests/page.tsx\: Added missing \eview\ status option to admin quests dropdown
- Admins can now transition quests out of \eview\ status back to \^Gvailable\

### #413 — Blank pages caused by \useApiFetch\ auto-unwrapping
- \lib/hooks/useApiFetch.ts\: Added \unwrap\ option to \ApiOptions\ interface
- When \unwrap: false\, stores raw API response; when \unwrap: true\ (default), unwraps \data.data\
- Prevents blank pages when APIs return \{ success: true, data: [...] }\ without nested \data\ key

### #327 — Company quest edit ownership check is client-side only — quest data leaks
- \^Gpp/api/quests/[id]/route.ts\: Sanitize \subQuests\ for non-admin/non-owner users to prevent sensitive data exposure
- \^Gpp/api/company/quests/route.ts\ PUT: Added admin bypass — admins can now edit any quest (previously blocked because \quest.companyId !== companyId\ always failed for admins)
- \^Gpp/api/company/quests/route.ts\ DELETE: Same admin bypass — admins can now cancel any quest

### #261 — Razorpay contact route uses placeholder phone number
- \prisma/schema.prisma\: Added \phone String?\ field to User model
- \^Gpp/api/payments/razorpay/contact/route.ts\: Replaced hardcoded \'9999999999'\ with \^Gdventurer.user.phone || '9999999999'\ — uses real phone if available
- \^Gpp/api/users/me/route.ts\: Added \phone\ to allowed user update fields

## Testing
- \
pm run type-check\ — PASS (all changes compile; only pre-existing errors in \__tests__/\)
- \
pm run lint\ — PASS (no new warnings/errors from these changes)
- E2E tests require Neon database — skipped locally

## Files Changed
- \^Gpp/api/rankings/route.ts\ — Added \id: 'asc'\ tie-breaker
- \^Gpp/api/admin/qa-queue/[assignmentId]/route.ts\ — Added syncQuestLifecycleStatus + fixed reject early returns
- \^Gpp/admin/quests/page.tsx\ — Added \eview\ status to dropdown
- \lib/hooks/useApiFetch.ts\ — Added \unwrap\ option
- \^Gpp/api/quests/[id]/route.ts\ — Sanitize subQuests for non-admin/non-owner
- \^Gpp/api/company/quests/route.ts\ — Admin bypass for PUT/DELETE
- \prisma/schema.prisma\ — Added phone field
- \^Gpp/api/payments/razorpay/contact/route.ts\ — Use real phone
- \^Gpp/api/users/me/route.ts\ — Allow phone updates