### PR TITLE
feat: database safety net — guard script, nightly backups, CI-only prod migrations

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,43 @@
+name: DB Backup (nightly)
+
+on:
+  schedule:
+    - cron: "30 21 * * *" # 03:00 IST nightly
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install PostgreSQL 17 client
+        run: |
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+
+      - name: Dump production database
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL_UNPOOLED }}
+        run: |
+          pg_dump "$DATABASE_URL" --no-owner --no-privileges -Fc -f backup.dump
+          ls -lh backup.dump
+
+      - name: Encrypt dump (AES-256, artifacts on a public repo are readable)
+        env:
+          PASSPHRASE: ${{ secrets.BACKUP_PASSPHRASE }}
+        run: |
+          openssl enc -aes-256-cbc -pbkdf2 -salt -in backup.dump -out backup.dump.enc -pass env:PASSPHRASE
+          rm backup.dump
+
+      - name: Upload encrypted backup artifact (30-day retention)
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ github.run_number }}
+          path: backup.dump.enc
+          retention-days: 30
+
+      # Restore procedure (see docs/DATABASE_SAFETY.md):
+      #   openssl enc -d -aes-256-cbc -pbkdf2 -in backup.dump.enc -out backup.dump -pass pass:<BACKUP_PASSPHRASE>
+      #   pg_restore --no-owner --no-privileges -d "$TARGET_DATABASE_URL" backup.dump

--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -1,0 +1,59 @@
+name: Prisma Migrate Deploy (production)
+
+# The ONLY sanctioned path for production schema changes.
+# `prisma migrate deploy` applies pending committed migrations and NEVER
+# resets or drops data (unlike `prisma migrate dev`, which wiped production
+# on 2026-07-09). See docs/DATABASE_SAFETY.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "prisma/migrations/**"
+  workflow_dispatch:
+
+concurrency:
+  group: prod-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Backup before migrating (safety net)
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL_UNPOOLED }}
+          PASSPHRASE: ${{ secrets.BACKUP_PASSPHRASE }}
+        run: |
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc > /dev/null
+          sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client-17
+          pg_dump "$DATABASE_URL" --no-owner --no-privileges -Fc -f pre-migrate.dump || echo "::warning::pre-migrate dump failed — continuing"
+          if [ -f pre-migrate.dump ]; then
+            openssl enc -aes-256-cbc -pbkdf2 -salt -in pre-migrate.dump -out pre-migrate.dump.enc -pass env:PASSPHRASE
+            rm pre-migrate.dump
+          fi
+
+      - name: Upload pre-migration backup
+        if: hashFiles('pre-migrate.dump.enc') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-migrate-backup-${{ github.run_number }}
+          path: pre-migrate.dump.enc
+          retention-days: 30
+
+      - name: Apply pending migrations
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL_UNPOOLED }}
+        run: npx prisma migrate deploy

--- a/docs/DATABASE_SAFETY.md
+++ b/docs/DATABASE_SAFETY.md
@@ -1,0 +1,55 @@
+# Database Safety Rules
+
+> **Why this exists:** On 2026-07-09, `prisma migrate dev` was run with
+> `DATABASE_URL` pointing at the production database. Prisma detected schema
+> drift and **reset the database — all production data was dropped.** The
+> point-in-time-restore window (6h) had passed before anyone noticed.
+> These rules make that mistake impossible to repeat.
+
+## The Golden Rules
+
+1. **Local `DATABASE_URL` always points at the Neon `development` branch — never production.**
+2. **`prisma migrate dev`, `prisma db push`, `prisma migrate reset`, and seeding run ONLY against the development branch.** The `db:*` npm scripts enforce this via `scripts/db-guard.js`.
+3. **Production schema changes ship exclusively through CI**: merge a PR containing the migration → `.github/workflows/db-migrate-deploy.yml` runs `prisma migrate deploy` (which applies committed migrations and **never resets data**), taking an encrypted backup first.
+4. **Migrations must be additive**: no `DROP TABLE`, no `DROP COLUMN`, no type-narrowing on live tables without an explicit team discussion and a fresh backup.
+5. **Never paste the production connection string into a local `.env`,** a script, or a chat. It lives in exactly two places: Vercel env vars (runtime) and GitHub Actions secrets (CI).
+
+## Environments
+
+| Environment | Neon branch | Who uses it | Schema changes via |
+|---|---|---|---|
+| Production | `production` (default) | Vercel runtime, CI | `prisma migrate deploy` (CI only) |
+| Development | `development` | Local dev, `prisma migrate dev` | freely |
+
+To refresh the development branch with current prod data/schema: Neon Console → branches → `development` → "Reset from parent".
+
+## Backups
+
+- **Nightly**: `.github/workflows/db-backup.yml` takes an encrypted `pg_dump` at 03:00 IST, stored as a GitHub Actions artifact for 30 days.
+- **Pre-migration**: `db-migrate-deploy.yml` dumps prod before applying any migration.
+- Artifacts are AES-256 encrypted (`BACKUP_PASSPHRASE` secret) because artifacts on a public repo are downloadable.
+
+### Restore procedure
+
+```bash
+# 1. Download the artifact from the Actions run, then:
+openssl enc -d -aes-256-cbc -pbkdf2 -in backup.dump.enc -out backup.dump -pass pass:<BACKUP_PASSPHRASE>
+
+# 2. Restore into a FRESH Neon branch first — verify before touching production:
+pg_restore --no-owner --no-privileges -d "<branch-connection-string>" backup.dump
+```
+
+## Required GitHub secrets
+
+| Secret | Purpose |
+|---|---|
+| `PROD_DATABASE_URL_UNPOOLED` | pg_dump + migrate deploy (direct connection) |
+| `PROD_DATABASE_URL` | reserved for tooling needing the pooled URL |
+| `BACKUP_PASSPHRASE` | encrypts/decrypts backup artifacts |
+
+## If you think you just broke production
+
+1. **Stop. Do not run anything else.** Every write shrinks the restore window.
+2. Neon Console → project → **Restore** → pick a timestamp *before* the incident (works only within the history-retention window — act within minutes, not hours).
+3. Otherwise, restore last night's backup artifact (procedure above).
+4. Tell the team immediately. Speed matters more than blame.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     "test:phase-gate": "npm run type-check && npm run lint && npm run test:e2e",
     "deploy:vercel": "vercel --prod",
     "postinstall": "prisma generate",
-    "db:push": "prisma db push",
-    "db:seed": "npx tsx prisma/seed.ts"
+    "db:push": "node scripts/db-guard.js && prisma db push",
+    "db:seed": "node scripts/db-guard.js && npx tsx prisma/seed.ts",
+    "db:guard": "node scripts/db-guard.js",
+    "db:migrate": "node scripts/db-guard.js && prisma migrate dev",
+    "db:studio": "prisma studio"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/db-guard.js
+++ b/scripts/db-guard.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Blocks destructive Prisma commands from running against the production database.
+ *
+ * Production schema changes must go through CI (`prisma migrate deploy` in
+ * .github/workflows/db-migrate-deploy.yml). Local development uses the Neon
+ * "development" branch. See docs/DATABASE_SAFETY.md.
+ */
+const PROD_ENDPOINT = "ep-dry-dew-a11hidob";
+
+const urls = [
+  process.env.DATABASE_URL,
+  process.env.DATABASE_URL_UNPOOLED,
+  process.env.DIRECT_URL,
+].filter(Boolean);
+
+const offending = urls.find((u) => u.includes(PROD_ENDPOINT));
+
+if (offending) {
+  console.error("");
+  console.error("🚫 BLOCKED: your DATABASE_URL points at the PRODUCTION database.");
+  console.error("");
+  console.error("   `prisma migrate dev`, `db push`, `migrate reset`, and `db seed`");
+  console.error("   must NEVER run against production. On 2026-07-09 this exact");
+  console.error("   mistake wiped all production data.");
+  console.error("");
+  console.error("   → Local dev: point DATABASE_URL at the Neon 'development' branch.");
+  console.error("   → Prod schema changes: merge a migration to main; CI runs");
+  console.error("     `prisma migrate deploy` (which never resets data).");
+  console.error("");
+  console.error("   See docs/DATABASE_SAFETY.md");
+  console.error("");
+  process.exit(1);
+}


### PR DESCRIPTION
## Context

On **2026-07-09 at 05:06 UTC**, `prisma migrate dev` was run with `DATABASE_URL` pointing at production. Prisma detected schema drift and **reset the database — all production data was lost**. The Neon restore window (6h) had passed before discovery. See `docs/DATABASE_SAFETY.md` for the full incident rules.

## What this adds (layered defense)

1. **`scripts/db-guard.js`** — hard-blocks `db:push` / `db:migrate` / `db:seed` npm scripts whenever `DATABASE_URL` contains the production endpoint. Tested: blocks prod ✅, allows dev branch ✅
2. **`.github/workflows/db-backup.yml`** — nightly (03:00 IST) `pg_dump` of prod, AES-256 encrypted, stored as a 30-day GitHub artifact
3. **`.github/workflows/db-migrate-deploy.yml`** — the ONLY sanctioned path to prod schema changes: takes a backup, then `prisma migrate deploy` (applies committed migrations, never resets)
4. **`docs/DATABASE_SAFETY.md`** — golden rules, environment table, restore procedure, incident playbook

## Infra changes made alongside (outside this PR)

- Neon `development` branch created (`br-billowing-salad-a12gp2lp`) — local dev now points there
- Local `.env` no longer contains the production connection string

## Required before workflows go green

GitHub secrets: `PROD_DATABASE_URL_UNPOOLED`, `PROD_DATABASE_URL`, `BACKUP_PASSPHRASE`

## No runtime impact

No app code touched — scripts, workflows, and docs only. Existing features unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #431