### PR TITLE
fix: pin pg_dump version, hard-fail migrate-deploy on backup failure

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -16,12 +16,18 @@ jobs:
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc > /dev/null
           sudo apt-get update -qq
           sudo apt-get install -y -qq postgresql-client-17
+          # Ubuntu runners ship an older pg_dump by default; `pg_dump` on PATH can still
+          # resolve to it even after installing -17 (update-alternatives only migrates
+          # some binaries). Call the versioned binary explicitly so this never silently
+          # regresses to a client too old for the server (see docs/DATABASE_SAFETY.md).
+          echo "PG_DUMP=/usr/lib/postgresql/17/bin/pg_dump" >> "$GITHUB_ENV"
 
       - name: Dump production database
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL_UNPOOLED }}
         run: |
-          pg_dump "$DATABASE_URL" --no-owner --no-privileges -Fc -f backup.dump
+          "$PG_DUMP" --version
+          "$PG_DUMP" "$DATABASE_URL" --no-owner --no-privileges -Fc -f backup.dump
           ls -lh backup.dump
 
       - name: Encrypt dump (AES-256, artifacts on a public repo are readable)

--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -32,21 +32,27 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Backup before migrating (safety net)
+        # Hard-fails the job if the dump fails — a migration must NEVER proceed
+        # without a fresh backup to fall back on. This step failing silently is
+        # exactly what happened before this workflow existed.
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL_UNPOOLED }}
           PASSPHRASE: ${{ secrets.BACKUP_PASSPHRASE }}
         run: |
+          set -euo pipefail
           sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc > /dev/null
           sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client-17
-          pg_dump "$DATABASE_URL" --no-owner --no-privileges -Fc -f pre-migrate.dump || echo "::warning::pre-migrate dump failed — continuing"
-          if [ -f pre-migrate.dump ]; then
-            openssl enc -aes-256-cbc -pbkdf2 -salt -in pre-migrate.dump -out pre-migrate.dump.enc -pass env:PASSPHRASE
-            rm pre-migrate.dump
-          fi
+          # Ubuntu runners ship an older default pg_dump; installing -17 via apt does
+          # not repoint the `pg_dump` symlink (update-alternatives only migrates some
+          # binaries). Call the versioned binary explicitly — see docs/DATABASE_SAFETY.md.
+          PG_DUMP=/usr/lib/postgresql/17/bin/pg_dump
+          "$PG_DUMP" --version
+          "$PG_DUMP" "$DATABASE_URL" --no-owner --no-privileges -Fc -f pre-migrate.dump
+          openssl enc -aes-256-cbc -pbkdf2 -salt -in pre-migrate.dump -out pre-migrate.dump.enc -pass env:PASSPHRASE
+          rm pre-migrate.dump
 
       - name: Upload pre-migration backup
-        if: hashFiles('pre-migrate.dump.enc') != ''
         uses: actions/upload-artifact@v4
         with:
           name: pre-migrate-backup-${{ github.run_number }}


### PR DESCRIPTION
Fixes #431

## What happened
The first real run of `db-migrate-deploy.yml` (triggered by #419's phone-field migration merging) revealed a gap in the safety net built in #430: the pre-migration backup step **failed silently** and the migration proceeded anyway.

Root cause: Ubuntu's runner ships a default `pg_dump` 16.14. Installing `postgresql-client-17` via apt does not repoint the `pg_dump` symlink — only `psql` got migrated by `update-alternatives` in that run. So `pg_dump` kept resolving to 16.14 against a Postgres 17.10 server: *"aborting because of server version mismatch"*.

The workflow had `|| echo "::warning"... continuing` around the dump — so it swallowed the failure and ran `prisma migrate deploy` with **zero backup in place**. The migration itself was safe (additive nullable column, verified before merge), but the safety net didn't actually catch for it.

## Fix
- Call the versioned binary explicitly: `/usr/lib/postgresql/17/bin/pg_dump` instead of relying on PATH
- Print `pg_dump --version` in the logs so this is visible going forward
- **Remove the silent continue** in `db-migrate-deploy.yml` — a failed backup now hard-stops the job (`set -euo pipefail`) before any schema change touches prod
- Same version pin applied to the nightly `db-backup.yml`

## Verification
Will manually trigger both workflows via `workflow_dispatch` after merge to confirm a real encrypted backup succeeds end-to-end before relying on the nightly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)