### PR TITLE
fix: resolve blank pages caused by useApiFetch JSON unwrapping

### DIFF
--- a/app/admin/quests/page.tsx
+++ b/app/admin/quests/page.tsx
@@ -117,7 +117,7 @@ export default function AdminQuestsPage() {
     skip: !shouldFetch,
   });
 
-  const quests = data?.quests ?? EMPTY_QUESTS;
+  const quests = (Array.isArray(data) ? data : []) as QuestItem[];
 
   useEffect(() => {
     if (status === 'unauthenticated') {

--- a/app/dashboard/company/analytics/page.tsx
+++ b/app/dashboard/company/analytics/page.tsx
@@ -17,7 +17,7 @@ export default function CompanyAnalyticsPage() {
   const { data, loading } = useApiFetch<{ success: boolean; stats: CompanyStats; error?: string }>(
     '/api/analytics?type=company'
   );
-  const stats = data?.stats ?? null;
+  const stats = data ? (data as unknown as CompanyStats) : null;
 
   if (loading) {
     return (

--- a/app/dashboard/company/profile/page.tsx
+++ b/app/dashboard/company/profile/page.tsx
@@ -74,7 +74,7 @@ export default function CompanyProfilePage() {
     }
   }, [status, session, router, profileData]);
 
-  const quests = data?.quests || [];
+  const quests = (Array.isArray(data) ? data : []) as Array<{ status: string }>;
   const questCount = quests.length;
 
   const completedCount = quests.filter((quest) => quest.status === 'completed').length;

--- a/app/dashboard/company/quests/page.tsx
+++ b/app/dashboard/company/quests/page.tsx
@@ -59,7 +59,7 @@ export default function CompanyQuestsPage() {
     '/api/company/quests?limit=80',
     { skip: !shouldFetch }
   );
-  const quests = data?.quests ?? EMPTY_QUESTS;
+  const quests = (Array.isArray(data) ? data : []) as Quest[];
 
   useEffect(() => {
     if (status === 'unauthenticated') {


### PR DESCRIPTION
# Fix Blank Pages from useApiFetch Unwrapping (#413)

**Closes #413**

## Bug Fixed
Resolved a frontend rendering bug that caused multiple company dashboards and the admin quests dashboard to crash or display "0 quests". The `useApiFetch` hook automatically unwraps JSON payload responses, but components were incorrectly trying to access wrapper keys like `data.quests` or `data.stats` (which evaluate to `undefined` after unwrapping).

## Changes Made
Updated the impacted pages to correctly cast the unwrapped `data` payload directly:
- **Admin Quests** (`/admin/quests/page.tsx`)
- **Company Quests** (`/dashboard/company/quests/page.tsx`)
- **Company Profile Metrics** (`/dashboard/company/profile/page.tsx`)
- **Company Analytics** (`/dashboard/company/analytics/page.tsx`)

## Testing Notes
- The Admin Quests dashboard now successfully renders the full grid of quests instead of an empty array.
- Company Analytics correctly renders KPI metrics (Total Quests, Applicants, Completion Rate) without crashing.
- Company Profile metrics accurately calculate active and completed counts.
