### PR TITLE
fix: re-enable disabled quest templates via UI

### DIFF
--- a/app/admin/quest-templates/page.tsx
+++ b/app/admin/quest-templates/page.tsx
@@ -144,6 +144,17 @@ export default function QuestTemplatesPage() {
     else toast.error(data.error || 'Failed');
   };
 
+  const enable = async (id: string) => {
+    const res = await fetchWithAuth(`/api/admin/quest-field-templates`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, isActive: true })
+    });
+    const data = await res.json();
+    if (data.success) { toast.success('Template enabled'); fetchTemplates(); }
+    else toast.error(data.error || 'Failed');
+  };
+
   if (status === 'loading' || loading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-950">
@@ -281,9 +292,13 @@ export default function QuestTemplatesPage() {
                 </div>
                 <div className="flex shrink-0 gap-2">
                   <Button size="sm" variant="outline" className="border-slate-700" onClick={() => loadIntoForm(t)}>Edit</Button>
-                  {t.isActive && (
+                  {t.isActive ? (
                     <Button size="sm" variant="ghost" className="text-red-400 hover:bg-red-950/40" onClick={() => disable(t.id)}>
                       Disable
+                    </Button>
+                  ) : (
+                    <Button size="sm" variant="ghost" className="text-emerald-400 hover:bg-emerald-950/40" onClick={() => enable(t.id)}>
+                      Enable
                     </Button>
                   )}
                 </div>

--- a/app/api/admin/quest-field-templates/route.ts
+++ b/app/api/admin/quest-field-templates/route.ts
@@ -117,3 +117,25 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to delete template', success: false }, { status: 500 });
   }
 }
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const authUser = await requireAuth(request, 'admin');
+    if (!authUser) return NextResponse.json({ error: 'Unauthorized', success: false }, { status: 401 });
+
+    const body = await request.json();
+    const { id, isActive } = body;
+    if (!id || typeof isActive !== 'boolean') {
+      return NextResponse.json({ error: 'id and isActive are required', success: false }, { status: 400 });
+    }
+
+    const updated = await prisma.questFieldTemplate.update({
+      where: { id },
+      data: { isActive },
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error patching template:', error);
+    return NextResponse.json({ error: 'Failed to update template status', success: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
# Fix: Disabled Quest Templates Cannot Be Re-enabled via UI (#415)

**Closes #415**

## Bug Fixed
Previously, an admin could disable a quest template from the UI, but there was no corresponding button to turn it back on. Admins had to rely on a workaround (editing and saving the template).

## Changes Made
1. **API Update (`/api/admin/quest-field-templates/route.ts`)**: 
   - Added a new `PATCH` handler to allow directly toggling the `isActive` boolean state of a template without needing to send the entire template payload.
2. **UI Update (`/admin/quest-templates/page.tsx`)**:
   - Implemented an `enable` function that calls the new `PATCH` endpoint.
   - Added a dynamic ternary check to render an "Enable" button if `t.isActive === false`.

## Testing Notes
- Tested disabling an active template and ensuring it gets removed from the quest creation flow.
- Tested clicking "Enable" on a disabled template; verified it successfully toggles the state to active, refetches the UI, and makes the template available for quest creation again.
