### PR TITLE
fix: leaderboard tie-breaker + re-enable quest review status in dropdown

### DIFF
--- a/app/admin/quests/page.tsx
+++ b/app/admin/quests/page.tsx
@@ -502,6 +502,7 @@ export default function AdminQuestsPage() {
                           <SelectItem value="draft">Draft</SelectItem>
                           <SelectItem value="available">Available</SelectItem>
                           <SelectItem value="in_progress">In Progress</SelectItem>
+                          <SelectItem value="review">Under Review</SelectItem>
                           <SelectItem value="completed">Completed</SelectItem>
                           <SelectItem value="cancelled">Cancelled</SelectItem>
                         </SelectContent>

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -165,10 +165,7 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      orderBy: {
-        [sort]: order,
-        id: 'asc',
-      },
+      orderBy: [{ [sort]: order }, { id: 'asc' }],
       take: limit,
     });
 

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -167,6 +167,7 @@ export async function GET(request: NextRequest) {
       },
       orderBy: {
         [sort]: order,
+        id: 'asc',
       },
       take: limit,
     });


### PR DESCRIPTION
Fixes #414, #415

Extracted from #418 after carefully verifying which of its six claimed fixes are still actually needed against current main (see comments on #418/#419 for the full trace). These two are genuinely missing and safe:

- **#414** — `app/api/rankings/route.ts`: adds `id: 'asc'` as a secondary sort key. Without it, adventurers tied on the primary sort field (XP/level/skillPoints) jitter position on every refresh since Postgres doesn't guarantee stable ordering for ties.
- **#415** — `app/admin/quests/page.tsx`: the per-quest status edit dropdown was missing `review` as a selectable option, so a quest stuck in `review` status could never be moved back to `available`/`in_progress` via the UI (the top filter dropdown already had it — just not the actual edit control).

The other four fixes #418 described (#416 QA queue sync, #413 useApiFetch unwrapping, #327 ownership check) turned out to already be resolved by more complete work merged since #418's branch was created — its versions of those files are based on stale, since-rewritten code and would have regressed them if reapplied. Details in the #418 thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)