### PR TITLE
feat: implement pagination across global quest dashboards

### DIFF
--- a/app/admin/quests/page.tsx
+++ b/app/admin/quests/page.tsx
@@ -88,6 +88,7 @@ export default function AdminQuestsPage() {
   const router = useRouter();
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
+  const [offset, setOffset] = useState(0);
   const [noteQuest, setNoteQuest] = useState<QuestItem | null>(null);
   const [newNoteText, setNewNoteText] = useState('');
   const [savingNote, setSavingNote] = useState(false);
@@ -97,7 +98,7 @@ export default function AdminQuestsPage() {
 
   const shouldFetch = status === 'authenticated' && session?.user?.role === 'admin';
   const questsEndpoint = useMemo(() => {
-    const params = new URLSearchParams({ limit: '100' });
+    const params = new URLSearchParams({ limit: '12', offset: offset.toString() });
     if (filterStatus !== 'all') {
       params.set('status', filterStatus);
     }
@@ -105,7 +106,7 @@ export default function AdminQuestsPage() {
       params.set('search', search.trim());
     }
     return `/api/admin/quests?${params.toString()}`;
-  }, [filterStatus, search]);
+  }, [filterStatus, search, offset]);
 
   const {
     data,
@@ -370,7 +371,7 @@ export default function AdminQuestsPage() {
             <Input
               placeholder="Search quests..."
               value={search}
-              onChange={(event) => setSearch(event.target.value)}
+              onChange={(event) => { setSearch(event.target.value); setOffset(0); }}
               onKeyDown={(event) => {
                 if (event.key === 'Enter') {
                   void refetch();
@@ -379,7 +380,7 @@ export default function AdminQuestsPage() {
               className="pl-9"
             />
           </div>
-          <Select value={filterStatus} onValueChange={setFilterStatus}>
+          <Select value={filterStatus} onValueChange={(v) => { setFilterStatus(v); setOffset(0); }}>
             <SelectTrigger className="w-full sm:w-[180px]">
               <Filter className="mr-2 h-4 w-4" />
               <SelectValue />
@@ -415,16 +416,18 @@ export default function AdminQuestsPage() {
         {quests.length === 0 ? (
           <Card className="p-12 text-center">
             <Target className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-            <h3 className="text-lg font-semibold">No quests found</h3>
+            <h3 className="text-lg font-semibold">{offset === 0 ? 'No quests found' : 'No more quests'}</h3>
             <p className="mb-6 mt-1 text-muted-foreground">
-              Create the first quest for your interns to pick up.
+              {offset === 0 ? 'Create the first quest for your interns to pick up.' : 'You have reached the end of the list.'}
             </p>
-            <Button asChild>
-              <Link href="/dashboard/company/create-quest">
-                <Plus className="h-4 w-4" />
-                Create Quest
-              </Link>
-            </Button>
+            {offset === 0 && (
+              <Button asChild>
+                <Link href="/dashboard/company/create-quest">
+                  <Plus className="h-4 w-4" />
+                  Create Quest
+                </Link>
+              </Button>
+            )}
           </Card>
         ) : (
           <div className="space-y-3">
@@ -585,6 +588,33 @@ export default function AdminQuestsPage() {
                 </CardContent>
               </Card>
             ))}
+          </div>
+        )}
+        
+        {(quests.length > 0 || offset > 0) && (
+          <div className="mt-8 flex justify-center gap-4 pb-8">
+            <Button
+              variant="outline"
+              disabled={offset === 0}
+              onClick={() => {
+                setOffset((p) => Math.max(0, p - 12));
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }}
+              className="bg-white"
+            >
+              Previous Page
+            </Button>
+            <Button
+              variant="outline"
+              disabled={quests.length < 12}
+              onClick={() => {
+                setOffset((p) => p + 12);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }}
+              className="bg-white"
+            >
+              Next Page
+            </Button>
           </div>
         )}
       </div>

--- a/app/dashboard/company/quests/page.tsx
+++ b/app/dashboard/company/quests/page.tsx
@@ -53,10 +53,16 @@ export default function CompanyQuestsPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState('');
+  const [offset, setOffset] = useState(0);
   const shouldFetch =
     status === 'authenticated' && (session?.user?.role === 'company' || session?.user?.role === 'admin');
+    
+  const apiUrl = useMemo(() => {
+    return `/api/company/quests?limit=12&offset=${offset}`;
+  }, [offset]);
+
   const { data, loading, error } = useApiFetch<{ quests: Quest[]; success: boolean }>(
-    '/api/company/quests?limit=80',
+    apiUrl,
     { skip: !shouldFetch }
   );
   const quests = (Array.isArray(data) ? data : []) as Quest[];
@@ -179,7 +185,7 @@ export default function CompanyQuestsPage() {
           <Input
             placeholder="Search by title, category, or status"
             value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
+            onChange={(event) => { setSearchTerm(event.target.value); setOffset(0); }}
             className="pl-9"
           />
         </div>
@@ -188,14 +194,18 @@ export default function CompanyQuestsPage() {
       {filteredQuests.length === 0 ? (
         <GuildPanel className="p-12 text-center">
           <Target className="mx-auto mb-4 h-14 w-14 text-slate-400" />
-          <h3 className="text-xl font-semibold text-slate-900">No quests found</h3>
-          <p className="mt-2 text-sm text-slate-500">Create your first quest to start attracting adventurers.</p>
-          <Button className="mt-4" asChild>
-            <Link href="/dashboard/company/create-quest">
-              <Plus className="h-4 w-4" />
-              Create Quest
-            </Link>
-          </Button>
+          <h3 className="text-xl font-semibold text-slate-900">{offset === 0 ? 'No quests found' : 'No more quests'}</h3>
+          <p className="mt-2 text-sm text-slate-500">
+            {offset === 0 ? 'Create your first quest to start attracting adventurers.' : 'You have reached the end of the list.'}
+          </p>
+          {offset === 0 && (
+            <Button className="mt-4" asChild>
+              <Link href="/dashboard/company/create-quest">
+                <Plus className="h-4 w-4" />
+                Create Quest
+              </Link>
+            </Button>
+          )}
         </GuildPanel>
       ) : (
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -257,6 +267,33 @@ export default function CompanyQuestsPage() {
             </GuildCard>
           ))}
         </section>
+      )}
+      
+      {(quests.length > 0 || offset > 0) && (
+        <div className="mt-8 flex justify-center gap-4 pb-8">
+          <Button
+            variant="outline"
+            disabled={offset === 0}
+            onClick={() => {
+              setOffset((p) => Math.max(0, p - 12));
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }}
+            className="bg-white"
+          >
+            Previous Page
+          </Button>
+          <Button
+            variant="outline"
+            disabled={quests.length < 12}
+            onClick={() => {
+              setOffset((p) => p + 12);
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }}
+            className="bg-white"
+          >
+            Next Page
+          </Button>
+        </div>
       )}
     </GuildPage>
   );

--- a/app/dashboard/quests/page.tsx
+++ b/app/dashboard/quests/page.tsx
@@ -111,20 +111,21 @@ export default function QuestsPage() {
   const [partyFilter, setPartyFilter] = useState<PartyFilter>('all');
   const [joiningPartyId, setJoiningPartyId] = useState<string | null>(null);
   const [isBootcamp, setIsBootcamp] = useState(false);
+  const [offset, setOffset] = useState(0);
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
   const isAdmin = session?.user?.role === 'admin';
   const shouldFetch = status === 'authenticated' && session?.user?.role !== 'company';
 
   const apiUrl = useMemo(() => {
-    const params = new URLSearchParams({ status: 'available', limit: '60' });
+    const params = new URLSearchParams({ status: 'available', limit: '12', offset: offset.toString() });
     if (debouncedSearchTerm) params.set('search', debouncedSearchTerm);
     if (difficulty !== 'all') params.set('difficulty', difficulty);
     if (track !== 'all') params.set('track', track);
     if (category !== 'all') params.set('category', category);
     if (sort !== 'newest') params.set('sort', sort);
     return `/api/quests?${params.toString()}`;
-  }, [debouncedSearchTerm, difficulty, track, category, sort]);
+  }, [debouncedSearchTerm, difficulty, track, category, sort, offset]);
 
   const { data, loading, error, refetch } = useApiFetch<Quest[]>(apiUrl, { skip: !shouldFetch });
   const quests = (Array.isArray(data) ? data : []) ?? EMPTY_QUESTS;
@@ -155,12 +156,12 @@ export default function QuestsPage() {
   });
 
   const activeFilters: { key: string; label: string; clear: () => void }[] = [
-    ...(searchTerm ? [{ key: 'search', label: `"${searchTerm}"`, clear: () => setSearchTerm('') }] : []),
-    ...(difficulty !== 'all' ? [{ key: 'difficulty', label: `${difficulty}-Rank`, clear: () => setDifficulty('all') }] : []),
-    ...(track !== 'all' ? [{ key: 'track', label: TRACK_OPTIONS.find((t) => t.value === track)?.label ?? track, clear: () => setTrack('all') }] : []),
-    ...(category !== 'all' ? [{ key: 'category', label: QUEST_CATEGORIES.find((c) => c.value === category)?.label ?? category, clear: () => setCategory('all') }] : []),
-    ...(sort !== 'newest' ? [{ key: 'sort', label: SORT_OPTIONS.find((s) => s.value === sort)?.label ?? sort, clear: () => setSort('newest') }] : []),
-    ...(partyFilter !== 'all' ? [{ key: 'party', label: partyFilter === 'solo' ? 'Solo' : 'Squad', clear: () => setPartyFilter('all') }] : []),
+    ...(searchTerm ? [{ key: 'search', label: `"${searchTerm}"`, clear: () => { setSearchTerm(''); setOffset(0); } }] : []),
+    ...(difficulty !== 'all' ? [{ key: 'difficulty', label: `${difficulty}-Rank`, clear: () => { setDifficulty('all'); setOffset(0); } }] : []),
+    ...(track !== 'all' ? [{ key: 'track', label: TRACK_OPTIONS.find((t) => t.value === track)?.label ?? track, clear: () => { setTrack('all'); setOffset(0); } }] : []),
+    ...(category !== 'all' ? [{ key: 'category', label: QUEST_CATEGORIES.find((c) => c.value === category)?.label ?? category, clear: () => { setCategory('all'); setOffset(0); } }] : []),
+    ...(sort !== 'newest' ? [{ key: 'sort', label: SORT_OPTIONS.find((s) => s.value === sort)?.label ?? sort, clear: () => { setSort('newest'); setOffset(0); } }] : []),
+    ...(partyFilter !== 'all' ? [{ key: 'party', label: partyFilter === 'solo' ? 'Solo' : 'Squad', clear: () => { setPartyFilter('all'); setOffset(0); } }] : []),
   ];
 
   function getInitials(name: string | null | undefined) {
@@ -195,7 +196,7 @@ export default function QuestsPage() {
 
   function clearAllFilters() {
     setSearchTerm(''); setDifficulty('all'); setTrack('all');
-    setCategory('all'); setSort('newest'); setPartyFilter('all');
+    setCategory('all'); setSort('newest'); setPartyFilter('all'); setOffset(0);
   }
 
   if (status === 'loading' || loading) {
@@ -246,11 +247,11 @@ export default function QuestsPage() {
             <Input
               placeholder="Search quests, skills, company…"
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              onChange={(e) => { setSearchTerm(e.target.value); setOffset(0); }}
               className="h-8 text-sm flex-1 min-w-[140px] sm:min-w-[180px]"
             />
 
-            <Select value={difficulty} onValueChange={setDifficulty}>
+            <Select value={difficulty} onValueChange={(v) => { setDifficulty(v); setOffset(0); }}>
               <SelectTrigger className="h-8 text-xs w-24 sm:w-32">
                 <SelectValue placeholder="Difficulty" />
               </SelectTrigger>
@@ -262,7 +263,7 @@ export default function QuestsPage() {
               </SelectContent>
             </Select>
 
-            <Select value={track} onValueChange={setTrack}>
+            <Select value={track} onValueChange={(v) => { setTrack(v); setOffset(0); }}>
               <SelectTrigger className="h-8 text-xs w-28">
                 <SelectValue placeholder="Track" />
               </SelectTrigger>
@@ -274,7 +275,7 @@ export default function QuestsPage() {
               </SelectContent>
             </Select>
 
-            <Select value={category} onValueChange={setCategory}>
+            <Select value={category} onValueChange={(v) => { setCategory(v); setOffset(0); }}>
               <SelectTrigger className="h-8 text-xs w-36">
                 <SelectValue placeholder="Category" />
               </SelectTrigger>
@@ -286,7 +287,7 @@ export default function QuestsPage() {
               </SelectContent>
             </Select>
 
-            <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
+            <Select value={sort} onValueChange={(v) => { setSort(v as SortOption); setOffset(0); }}>
               <SelectTrigger className="h-8 text-xs w-32">
                 <SelectValue placeholder="Sort" />
               </SelectTrigger>
@@ -305,7 +306,7 @@ export default function QuestsPage() {
                 {(['all', 'solo', 'squad'] as const).map((v) => (
                   <button
                     key={v}
-                    onClick={() => setPartyFilter(v)}
+                    onClick={() => { setPartyFilter(v); setOffset(0); }}
                     className={`rounded-md px-3 py-1 text-xs font-medium transition-colors capitalize ${
                       partyFilter === v
                         ? 'bg-white text-slate-900 shadow-sm'
@@ -344,10 +345,14 @@ export default function QuestsPage() {
         {/* ── Quest grid ── */}
         {filteredQuests.length === 0 ? (
           <div className="rounded-2xl border-2 border-dashed border-slate-200 bg-white/60 py-16 text-center">
-            <p className="text-sm font-medium text-slate-500">No quests found.</p>
-            <Button size="sm" variant="outline" className="mt-4" onClick={clearAllFilters}>
-              Clear Filters
-            </Button>
+            <p className="text-sm font-medium text-slate-500">
+              {offset === 0 ? 'No quests found.' : 'No more quests.'}
+            </p>
+            {offset === 0 && (
+              <Button size="sm" variant="outline" className="mt-4" onClick={clearAllFilters}>
+                Clear Filters
+              </Button>
+            )}
           </div>
         ) : (
           <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
@@ -365,6 +370,33 @@ export default function QuestsPage() {
               />
             ))}
           </section>
+        )}
+        
+        {(quests.length > 0 || offset > 0) && (
+          <div className="mt-8 flex justify-center gap-4 pb-8">
+            <Button
+              variant="outline"
+              disabled={offset === 0}
+              onClick={() => {
+                setOffset((p) => Math.max(0, p - 12));
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }}
+              className="bg-white"
+            >
+              Previous Page
+            </Button>
+            <Button
+              variant="outline"
+              disabled={quests.length < 12}
+              onClick={() => {
+                setOffset((p) => p + 12);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }}
+              className="bg-white"
+            >
+              Next Page
+            </Button>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
# Missing Pagination on Global Quest Dashboards (#424)

**Closes #424**

## Problem
Previously, the Admin Quests dashboard, Adventurer Quests dashboard, and Company Quests dashboard lacked pagination mechanics on the frontend UI. The pages initialized their API fetch URLs with hardcoded offsets or no offset state, and there were no "Next Page" or "Previous Page" buttons to navigate beyond the first chunk of data.

## Changes Made
1. **Admin Quests UI (`app/admin/quests/page.tsx`)**:
   - Added `offset` tracking via React state and updated the `useApiFetch` request to include dynamic limit and offset query parameters.
   - Added "Previous Page" and "Next Page" navigation buttons.
   - Handled empty states where clicking "Next Page" into an empty data set would cause the navigation controls to disappear.
   - Ensured pagination buttons smoothly scroll the user back to the top of the list on click.

2. **Adventurer Quests UI (`app/dashboard/quests/page.tsx`)**:
   - Replicated the dynamic offset fetching, empty state pagination control fixes, and smooth scrolling for the main adventurer quest list.

3. **Company Quests UI (`app/dashboard/company/quests/page.tsx`)**:
   - Replicated the dynamic offset fetching, empty state pagination control fixes, and smooth scrolling for the company quest management dashboard.

## Testing Notes
- Seeded the database with 110 dummy quests to test full pagination flows.
- Tested Next/Previous page clicks to ensure they correctly shift the offset by 12 quests.
- Tested clicking "Next Page" at the end of the available data to ensure the empty state ("No more quests") renders properly while keeping the "Previous Page" button visible and active.
- Verified that page transitions auto-scroll the user back to the top of the list seamlessly.
