### PR TITLE
Fix #422: Bound admin sidebar height and add scrollbar

### DIFF
--- a/components/admin/AdminRail.tsx
+++ b/components/admin/AdminRail.tsx
@@ -81,9 +81,9 @@ export function AdminRail() {
   const { data: session } = useSession();
 
   return (
-    <aside className="w-full shrink-0 lg:sticky lg:top-4 lg:h-fit lg:w-72">
-      <div className="guild-panel overflow-hidden border-slate-900 bg-slate-950 text-slate-100">
-        <div className="border-b border-slate-800 px-5 py-6">
+    <aside className="w-full shrink-0 lg:sticky lg:top-4 lg:h-[calc(100vh-2rem)] lg:w-72">
+      <div className="guild-panel flex h-full flex-col overflow-hidden border-slate-900 bg-slate-950 text-slate-100">
+        <div className="shrink-0 border-b border-slate-800 px-5 py-6">
           <div className="flex items-center gap-3">
             <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-orange-500/15 text-orange-300">
               <Shield className="h-5 w-5" />
@@ -100,7 +100,7 @@ export function AdminRail() {
           </p>
         </div>
 
-        <nav className="flex gap-2 overflow-x-auto p-3 lg:flex-col lg:overflow-visible">
+        <nav className="flex gap-2 overflow-x-auto p-3 lg:flex-1 lg:flex-col lg:overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-700">
           {adminLinks.map((item) => {
             const active = item.exact
               ? pathname === item.href
@@ -140,7 +140,7 @@ export function AdminRail() {
         </nav>
 
         {/* User info + logout */}
-        <div className="border-t border-slate-800 px-5 py-4">
+        <div className="shrink-0 border-t border-slate-800 px-5 py-4">
           <div className="flex items-center gap-3 mb-3">
             <div className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-800 text-slate-300 text-sm font-bold shrink-0">
               {session?.user?.name?.[0]?.toUpperCase() ?? 'A'}


### PR DESCRIPTION
**Title:** Fix: Bound Admin Sidebar Height and Add Independent Scrolling (Fixes #422)

**Description:**
This PR resolves an issue on the Admin Dashboard (`/admin`) where the left-side navigation rail (`AdminRail`) was growing infinitely tall, permanently cutting off the bottom links and the logout button on standard desktop displays.

**Changes Made:**
- **Viewport Constraints:** Replaced `lg:h-fit` with `lg:h-[calc(100vh-2rem)]` on the `aside` container to strictly bound the sidebar height to the viewport.
- **Flex Column Layout:** Converted the `.guild-panel` interior into a `flex flex-col h-full` layout.
- **Sticky Header & Footer:** Added `shrink-0` to both the top header (Guild Console) and the bottom footer (Admin Profile) to keep them permanently locked in place.
- **Independent Scrolling:** Applied `lg:flex-1` and `lg:overflow-y-auto` to the middle `<nav>` section, allowing the links to scroll independently when they overflow the screen height.
- **Contrasting Scrollbar:** Added custom WebKit arbitrary variants to style the scrollbar (visible `slate-700` thumb on a transparent track) to ensure it contrasts cleanly against the dark background.

**Acceptance Criteria Met:**
- [x] Top header and bottom footer are permanently locked to the top/bottom.
- [x] Middle section scrolls vertically with a visible scrollbar.
- [x] Sidebar bottom content is no longer cut off.

**Fixes:** #422 