### PR TITLE
Fix #425: Enforce string length constraints on profile inputs

### DIFF
--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -57,7 +57,11 @@ export async function PATCH(request: NextRequest) {
 
     // Build user update payload (only allowed fields)
     const userUpdate: Record<string, string | null> = {};
-    if (typeof body.name === 'string') userUpdate.name = body.name.trim() || null;
+    
+    if (typeof body.name === 'string') {
+      if (body.name.length > 100) return NextResponse.json({ error: 'Name cannot exceed 100 characters', success: false }, { status: 400 });
+      userUpdate.name = body.name.trim() || null;
+    }
     if (typeof body.username === 'string') {
       const username = body.username.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
       if (username.length < 3 || username.length > 30) {
@@ -69,13 +73,34 @@ export async function PATCH(request: NextRequest) {
       }
       userUpdate.username = username;
     }
-    if (typeof body.bio === 'string') userUpdate.bio = body.bio.trim() || null;
-    if (typeof body.location === 'string') userUpdate.location = body.location.trim() || null;
-    if (typeof body.website === 'string') userUpdate.website = body.website.trim() || null;
-    if (typeof body.github === 'string') userUpdate.github = body.github.trim() || null;
-    if (typeof body.linkedin === 'string') userUpdate.linkedin = body.linkedin.trim() || null;
-    if (typeof body.discord === 'string') userUpdate.discord = body.discord.trim() || null;
-    if (typeof body.phone === 'string') userUpdate.phone = body.phone.trim() || null;
+    if (typeof body.bio === 'string') {
+      if (body.bio.length > 500) return NextResponse.json({ error: 'Bio cannot exceed 500 characters', success: false }, { status: 400 });
+      userUpdate.bio = body.bio.trim() || null;
+    }
+    if (typeof body.location === 'string') {
+      if (body.location.length > 100) return NextResponse.json({ error: 'Location cannot exceed 100 characters', success: false }, { status: 400 });
+      userUpdate.location = body.location.trim() || null;
+    }
+    if (typeof body.website === 'string') {
+      if (body.website.length > 255) return NextResponse.json({ error: 'Website cannot exceed 255 characters', success: false }, { status: 400 });
+      userUpdate.website = body.website.trim() || null;
+    }
+    if (typeof body.github === 'string') {
+      if (body.github.length > 255) return NextResponse.json({ error: 'GitHub URL cannot exceed 255 characters', success: false }, { status: 400 });
+      userUpdate.github = body.github.trim() || null;
+    }
+    if (typeof body.linkedin === 'string') {
+      if (body.linkedin.length > 255) return NextResponse.json({ error: 'LinkedIn URL cannot exceed 255 characters', success: false }, { status: 400 });
+      userUpdate.linkedin = body.linkedin.trim() || null;
+    }
+    if (typeof body.discord === 'string') {
+      if (body.discord.length > 255) return NextResponse.json({ error: 'Discord handle cannot exceed 255 characters', success: false }, { status: 400 });
+      userUpdate.discord = body.discord.trim() || null;
+    }
+    if (typeof body.phone === 'string') {
+      if (body.phone.length > 50) return NextResponse.json({ error: 'Phone cannot exceed 50 characters', success: false }, { status: 400 });
+      userUpdate.phone = body.phone.trim() || null;
+    }
 
     if (Object.keys(userUpdate).length === 0) {
       return NextResponse.json({ error: 'No valid fields to update', success: false }, { status: 400 });
@@ -90,9 +115,18 @@ export async function PATCH(request: NextRequest) {
     // If company role, also update company profile fields
     if ((authUser.role === 'company') && (body.companyName || body.companyWebsite || body.companyDescription)) {
       const profileUpdate: Record<string, string | null> = {};
-      if (typeof body.companyName === 'string') profileUpdate.companyName = body.companyName.trim();
-      if (typeof body.companyWebsite === 'string') profileUpdate.companyWebsite = body.companyWebsite.trim() || null;
-      if (typeof body.companyDescription === 'string') profileUpdate.companyDescription = body.companyDescription.trim() || null;
+      if (typeof body.companyName === 'string') {
+        if (body.companyName.length > 100) return NextResponse.json({ error: 'Company Name cannot exceed 100 characters', success: false }, { status: 400 });
+        profileUpdate.companyName = body.companyName.trim();
+      }
+      if (typeof body.companyWebsite === 'string') {
+        if (body.companyWebsite.length > 255) return NextResponse.json({ error: 'Company Website cannot exceed 255 characters', success: false }, { status: 400 });
+        profileUpdate.companyWebsite = body.companyWebsite.trim() || null;
+      }
+      if (typeof body.companyDescription === 'string') {
+        if (body.companyDescription.length > 500) return NextResponse.json({ error: 'Company Description cannot exceed 500 characters', success: false }, { status: 400 });
+        profileUpdate.companyDescription = body.companyDescription.trim() || null;
+      }
 
       if (Object.keys(profileUpdate).length > 0) {
         await prisma.companyProfile.update({


### PR DESCRIPTION
# Enforce String Length Constraints on Profile Inputs (#425)

**Closes #425**

## Changes Made

1. **Input Length Validation:**
   - Added strict length checks to `app/api/users/me/route.ts` for all string-based profile updates before saving to the database.
   - Enforced limits: **Name** (100), **Bio** (500), **Location** (100), **Links/URLs** (255), and **Phone** (50).
   - Applied identical limits to Company Profile fields (**Company Name**: 100, **Description**: 500, **Website**: 255).
2. **Resource Exhaustion Prevention:**
   - The API now short-circuits and returns a `400 Bad Request` with a clear, user-friendly error message if any field exceeds the limit.
   - Prevents multi-megabyte strings from being parsed, processed, and stored in basic text fields, protecting database performance and bandwidth.

## Testing Notes
- **Payload Validation:** Successfully tested by attempting to submit an oversized string for the bio field; the API immediately rejected the request with a 400 error without passing the data to Prisma.
- **Valid Updates:** Normal-length profile updates continue to succeed and trim whitespace correctly.
