### PR TITLE
Fix #421: Implement standard competition ranking for leaderboards

### DIFF
--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -117,11 +117,24 @@ export async function GET(request: NextRequest) {
           if (delta !== 0) return delta;
           return a.createdAt.getTime() - b.createdAt.getTime();
         })
-        .slice(0, limit)
-        .map((company, index) => ({
+        .slice(0, limit);
+
+      let currentRank = 1;
+      let lastValue: any = null;
+
+      const rankedWithPosition = ranked.map((company, index) => {
+        // We use type assertion here since sort is guaranteed to be a key that holds a numeric value on the company object
+        const value = company[sort as keyof typeof company];
+        if (lastValue !== null && lastValue !== value) {
+          currentRank = index + 1;
+        }
+        lastValue = value;
+        
+        return {
           ...company,
-          position: index + 1,
-        }));
+          position: currentRank,
+        };
+      });
 
       return NextResponse.json({
         success: true,
@@ -129,7 +142,7 @@ export async function GET(request: NextRequest) {
         sort,
         order,
         total: companies.length,
-        rankings: ranked,
+        rankings: rankedWithPosition,
       });
     }
 
@@ -169,16 +182,26 @@ export async function GET(request: NextRequest) {
       take: limit,
     });
 
-    const rankings = adventurers.map((user, index) => ({
-      id: user.id,
-      name: user.name || user.email,
-      email: user.email,
-      rank: user.rank,
-      xp: user.xp,
-      level: user.level,
-      skillPoints: user.skillPoints,
-      position: index + 1,
-      adventurerProfiles: user.adventurerProfile
+    let currentRank = 1;
+    let lastValue: any = null;
+
+    const rankings = adventurers.map((user, index) => {
+      const value = user[sort as keyof typeof user];
+      if (lastValue !== null && lastValue !== value) {
+        currentRank = index + 1;
+      }
+      lastValue = value;
+
+      return {
+        id: user.id,
+        name: user.name || user.email,
+        email: user.email,
+        rank: user.rank,
+        xp: user.xp,
+        level: user.level,
+        skillPoints: user.skillPoints,
+        position: currentRank,
+        adventurerProfiles: user.adventurerProfile
         ? {
             specialization: user.adventurerProfile.specialization || undefined,
             totalQuestsCompleted: user.adventurerProfile.totalQuestsCompleted,
@@ -192,7 +215,8 @@ export async function GET(request: NextRequest) {
             questCompletionRate: Number(user.adventurerProfile.questCompletionRate),
           }
         : undefined,
-    }));
+      };
+    });
 
     const total = await prisma.user.count({ where });
 


### PR DESCRIPTION
# Mismatched Rank Calculations Between Header and Leaderboard Table (#421)

**Closes #421**

## Changes Made

1. **Standard Competition Ranking Implementation:**
   - Updated the global leaderboard logic in `app/api/rankings/route.ts` to use Standard Competition Ranking (1, 1, 1, 4) instead of mapping raw array indices.
   - Introduced `currentRank` and `lastValue` tracking variables within the array mapping logic.
   - If consecutive users share the exact same score (xp, total spent, etc.), they are assigned the exact same rank position.
   - If scores differ, the rank position skips forward to match the user's absolute array index (`index + 1`).
2. **Unified Ranking Logic:**
   - Applied this standard ranking mathematical model to **both** Adventurer mode and Company mode leaderboards.
   - The rank assigned in the global table now perfectly matches the `betterUsersCount + 1` logic used in the individual user's top header (`app/api/rankings/user/route.ts`).

## Testing Notes
- **Tie-Breaking Verification:** Successfully tested using seeded tie-breaker accounts having exactly identical XP (15,000). The global table now displays identical rank numbers for all tied students, correctly matching the rank displayed in their personal dashboard header.
- **Score Differentials:** Verified that the rank number correctly skips increments for the subsequent user following a tie (e.g., jumping from Rank 1 to Rank 4).
