### PR TITLE
Fix #426: Enforce strict backend validations for quest rewards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,8 @@ SENTRY_PROJECT=adventurers-guild
 # Optional: Rate Limiting (Upstash Redis)
 UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-token-here
+
+# Quest Creation Limits
+MAX_QUEST_XP=50000
+MAX_QUEST_SP=500
+MAX_QUEST_MONETARY=500000

--- a/lib/services/quest-service.ts
+++ b/lib/services/quest-service.ts
@@ -160,8 +160,22 @@ export async function createQuest(body: CreateQuestBody, user: SessionUser): Pro
     parentQuestId, deadline, tasks,
   } = body;
 
-  if (!title || !description || !questType || !difficulty || !xpReward) {
+  if (!title || !description || !questType || !difficulty || xpReward === undefined || xpReward === null) {
     return { error: 'Missing required fields', data: null, status: 400 };
+  }
+
+  const MAX_XP = parseInt(process.env.MAX_QUEST_XP || '50000', 10);
+  const MAX_SP = parseInt(process.env.MAX_QUEST_SP || '500', 10);
+  const MAX_MONETARY = parseInt(process.env.MAX_QUEST_MONETARY || '500000', 10);
+
+  if (xpReward < 0 || xpReward > MAX_XP) {
+    return { error: `XP reward must be between 0 and ${MAX_XP}`, data: null, status: 400 };
+  }
+  if (skillPointsReward !== undefined && skillPointsReward !== null && (skillPointsReward < 0 || skillPointsReward > MAX_SP)) {
+    return { error: `Skill points reward must be between 0 and ${MAX_SP}`, data: null, status: 400 };
+  }
+  if (monetaryReward !== undefined && monetaryReward !== null && (monetaryReward < 0 || monetaryReward > MAX_MONETARY)) {
+    return { error: `Monetary reward must be between 0 and ${MAX_MONETARY}`, data: null, status: 400 };
   }
 
   if (deadline && new Date(deadline) < new Date()) {


### PR DESCRIPTION
# Skill Points Validation Missing (#426)

**Closes #426**

## Changes Made

1. **Strict Reward Boundaries:**
   - Updated the `createQuest` API function in `lib/services/quest-service.ts` to strictly enforce mathematical upper bounds on all quest rewards.
   - The API now reads the `MAX_QUEST_XP`, `MAX_QUEST_SP`, and `MAX_QUEST_MONETARY` variables directly from the `.env` configuration (with sensible fallbacks).
   - If a company submits a quest payload where any reward exceeds the maximum cap, the creation immediately aborts and returns a `400 Bad Request`.
2. **Environment Template Sync:**
   - Appended the default quest limits (`MAX_QUEST_XP`, `MAX_QUEST_SP`, `MAX_QUEST_MONETARY`) to the `.env.example` file to ensure the configuration is clearly documented for all future deployments.
3. **Edge-Case Safety:**
   - Improved the presence checks so that legitimate quests offering `0` XP or SP are no longer incorrectly flagged as "missing fields", while malicious negative integers (`< 0`) are strictly rejected.

## Testing Notes
- **Payload Validation:** Successfully tested submitting an oversized payload (e.g., 10M XP); the API returned the expected 400 error and the malicious quest was blocked before hitting the database.
- **Valid Quests:** Normal quests within the configured caps continue to be created without issue.
