### PR TITLE
fix: Xtream seed quest status must be available to show on landing page

### DIFF
--- a/prisma/seed-xtream.ts
+++ b/prisma/seed-xtream.ts
@@ -59,7 +59,7 @@ async function main() {
     monetaryReward: null,
     requiredSkills: ['Digital Marketing', 'WhatsApp Business API', 'SEO/AEO'],
     maxParticipants: 2,
-    track: 'INTERN' as const,
+    track: 'OPEN' as const, // getPublicQuests() defaults to track=OPEN when no track filter is passed — INTERN/BOOTCAMP quests never surface publicly
     source: 'CLIENT_PORTAL' as const,
     companyId: company.id,
     partnerOrgName: 'Xtream Car Treatment',

--- a/prisma/seed-xtream.ts
+++ b/prisma/seed-xtream.ts
@@ -63,7 +63,7 @@ async function main() {
     source: 'CLIENT_PORTAL' as const,
     companyId: company.id,
     partnerOrgName: 'Xtream Car Treatment',
-    status: 'in_progress' as const,
+    status: 'available' as const, // public quest feed (getPublicQuests) only returns 'available' quests
   };
 
   const existing = await prisma.quest.findFirst({ where: { title: questData.title, companyId: company.id } });


### PR DESCRIPTION
Fixes #443

Follow-up to #442. `getPublicQuests()` (`lib/services/public-quest-service.ts`) hardcodes `status: QuestStatus.available` as its only filter. The Xtream seed script created its quest with `in_progress` (matching the real engagement state), which meant it would never actually surface in the public feed or the landing page's trusted-companies marquee. Fixed to `available`, matching the existing `seed-bharatcode.ts` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)